### PR TITLE
Accessible oauth

### DIFF
--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -103,6 +103,9 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
       <label for="client-name">Application Name</label>
       <input id="client-name" type="text" name="client-name" class="input" required />
 
+      <label for="client-homepage">Application Homepage</label>
+      <input id="client-homepage" type="url" name="client-homepage" class="input" placeholder="optional" />
+
       <label for="redirect-uris">Redirect URIs</label>
       <input id="redirect-uris" type="url" name="redirect-uris" class="input" required
           placeholder="separate multiple URIs with a space"/>
@@ -125,7 +128,10 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         $for app in my_applications:
           <label class="input-checkbox">
             <input type="checkbox" name="clientid" value="${app.clientid}" />
-            <strong>${app.description}</strong>
+            $if app.homepage:
+              <a href="${app.homepage}"><strong>${app.description}</strong></a>
+            $else:
+              <strong>${app.description}</strong>
             <p>client ID: <tt>${app.clientid}</tt></p>
             <p>client secret: <tt>${app.client_secret}</tt></p>
             <p>scopes: <tt>${", ".join(app.scopes)}</tt></p>

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -21,7 +21,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         However, user agents accessing Weasyl with your API key also
         will <em>never</em> be able to see your password.
       </p>
-      <button name="add-api-key" value="y" class="button last-input positive" style="float: right;">
+      <button name="add-api-key" value="y" class="button positive" style="float: right;">
         New API Key
       </button>
     </form>
@@ -37,7 +37,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
           $for token, description in api_keys:
             <li>
               <label class="input-checkbox">
-                <input type="checkbox" name="delete-api-keys" value="${token}" /></th>
+                <input type="checkbox" name="delete-api-keys" value="${token}" />
 
                 <em>
                   $if description:
@@ -104,14 +104,26 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
       <input id="redirect-uris" type="text" name="redirect-uris" class="input" required />
 
       <button name="create-oauth2-client" value="y" style="float:right;margin-top:1em"
-              class="button last-input positive">Register Application</button>
+              class="button positive">Register Application</button>
     </form>
 
     <h3>Manage OAuth2 Applications</h3>
       $if my_applications:
-        <form>
+        <form action="" method="POST" class="clear">
+        $:{CSRF()}
         $for app in my_applications:
-          ${app.description}<br>
+          <label class="input-checkbox">
+            <input type="checkbox" name="clientid" value="${app.clientid}" />
+            <strong>${app.description}</strong>
+            <p>client ID: <tt>${app.clientid}</tt></p>
+            <p>client secret: <tt>${app.client_secret}</tt></p>
+            <p>scopes: <tt>${", ".join(app.scopes)}</tt></p>
+          </label>
+
+        <button name="remove-oauth2-client" value="y" style="float:right;margin-top:1em"
+                class="button negative">Delete Selected Applications</button>
+        <button name="reissue-client-secret" value="y" style="float:right;margin-top:1em"
+                class="button">Reissue Secrets</button>
         </form>
       $else:
         <p style="padding-top: 1em;">You have no registered applications!</p>

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -56,6 +56,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         <button class="button negative" style="float: right;">Delete Selected Keys</button>
       $else:
         <p style="padding-top: 1em;">You have no API keys!</p>
+
     </form>
 
 

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -1,4 +1,4 @@
-$def with (api_keys, consumers)
+$def with (api_keys, consumers, oauth_scopes, my_applications)
 $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
 
 <div id="apikeys-content" class="content form clear">
@@ -25,9 +25,8 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         New API Key
       </button>
     </form>
-  </div>
 
-  <div class="column">
+
     <h3>Manage API Keys</h3>
 
     <form name="manage-api-keys" action="" method="post" class="clear">
@@ -57,9 +56,11 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         <button class="button negative" style="float: right;">Delete Selected Keys</button>
       $else:
         <p style="padding-top: 1em;">You have no API keys!</p>
-
     </form>
 
+  </div>
+
+  <div class="column">
     <h3>Manage OAuth2 Consumers</h3>
 
     <form action="" method="post" class="clear">
@@ -78,9 +79,43 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         <button class="button negative" style="float: right;">Revoke Selected Consumers</button>
       $else:
         <p style="padding-top: 1em;">You have no OAuth2 consumers!</p>
-
-
     </form>
+
+    <h3>Register OAuth2 Application</h3>
+    <form action="" method="POST" class="clear">
+      $:{CSRF()}
+      <p style="padding-top: 1em;">
+        If you are a developer, you may register an application as an OAuth2 consumer.
+        You can then use your client id and client secret to request authorization tokens from
+        Weasyl. Your client secret MUST be stored securely and should not be accessible
+        by your application's users under any circumstance.
+      </p>
+      <label for="client-name">Application Name</label>
+      <input id="client-name" type="text" name="client-name" class="input" required />
+
+      <label>Scopes</label>
+      $for scope in oauth_scopes:
+        <label class="input-checkbox">
+          <input type="checkbox" name="client-scopes" value="${scope['name']}">
+          <strong>${scope['name']}</strong> - ${scope['description']}
+        </label>
+
+      <label for="redirect-uris">Redirect URIs</label>
+      <input id="redirect-uris" type="text" name="redirect-uris" class="input" required />
+
+      <button name="create-oauth2-client" value="y" style="float:right;margin-top:1em"
+              class="button last-input positive">Register Application</button>
+    </form>
+
+    <h3>Manage OAuth2 Applications</h3>
+      $if my_applications:
+        <form>
+        $for app in my_applications:
+          ${app.description}<br>
+        </form>
+      $else:
+        <p style="padding-top: 1em;">You have no registered applications!</p>
+
   </div>
 
   <h3>How to use API keys</h3>

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -58,6 +58,14 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         <p style="padding-top: 1em;">You have no API keys!</p>
     </form>
 
+
+    <h3>How to use API keys</h3>
+    <p>
+      To connect to Weasyl using an API key, set the value of
+      the <tt>X-Weasyl-API-Key</tt> HTTP header to the API key. This will
+      override any cookie-based authentication.
+    </p>
+
   </div>
 
   <div class="column">
@@ -88,10 +96,16 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         If you are a developer, you may register an application as an OAuth2 consumer.
         You can then use your client id and client secret to request authorization tokens from
         Weasyl. Your client secret MUST be stored securely and should not be accessible
-        by your application's users under any circumstance.
+        by your application's users under any circumstance. For more information see
+        <a href="https://projects.weasyl.com/weasylapi/#oauth2-endpoints">
+          https://projects.weasyl.com/weasylapi/#oauth2-endpoints</a>
       </p>
       <label for="client-name">Application Name</label>
       <input id="client-name" type="text" name="client-name" class="input" required />
+
+      <label for="redirect-uris">Redirect URIs</label>
+      <input id="redirect-uris" type="url" name="redirect-uris" class="input" required
+          placeholder="separate multiple URIs with a space"/>
 
       <label>Scopes</label>
       $for scope in oauth_scopes:
@@ -99,9 +113,6 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
           <input type="checkbox" name="client-scopes" value="${scope['name']}">
           <strong>${scope['name']}</strong> - ${scope['description']}
         </label>
-
-      <label for="redirect-uris">Redirect URIs</label>
-      <input id="redirect-uris" type="text" name="redirect-uris" class="input" required />
 
       <button name="create-oauth2-client" value="y" style="float:right;margin-top:1em"
               class="button positive">Register Application</button>
@@ -118,6 +129,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
             <p>client ID: <tt>${app.clientid}</tt></p>
             <p>client secret: <tt>${app.client_secret}</tt></p>
             <p>scopes: <tt>${", ".join(app.scopes)}</tt></p>
+            <p>redirects: ${" ".join(app.redirect_uris)}</p>
           </label>
 
         <button name="remove-oauth2-client" value="y" style="float:right;margin-top:1em"
@@ -129,12 +141,5 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         <p style="padding-top: 1em;">You have no registered applications!</p>
 
   </div>
-
-  <h3>How to use API keys</h3>
-  <p>
-    To connect to Weasyl using an API key, set the value of
-    the <tt>X-Weasyl-API-Key</tt> HTTP header to the API key. This will
-    override any cookie-based authentication.
-  </p>
 
 </div>

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -116,10 +116,10 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
 
       <label>Scopes</label>
       <p>You must select at least one of the following:</p>
-      $for scope in oauth_scopes:
+      $for scope, description in oauth_scopes.iteritems():
         <label class="input-checkbox">
-          <input type="checkbox" name="client-scopes" value="${scope['name']}">
-          <strong>${scope['name']}</strong> - ${scope['description']}
+          <input type="checkbox" name="client-scopes" value="${scope}">
+          <strong>${scope}</strong> - ${description}
         </label>
 
       <button name="create-oauth2-client" value="y" style="float:right;margin-top:1em"

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -112,6 +112,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
           placeholder="separate multiple URIs with a space"/>
 
       <label>Scopes</label>
+      <p>You must select at least one of the following:</p>
       $for scope in oauth_scopes:
         <label class="input-checkbox">
           <input type="checkbox" name="client-scopes" value="${scope['name']}">

--- a/templates/control/edit_apikeys.html
+++ b/templates/control/edit_apikeys.html
@@ -97,8 +97,11 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
         If you are a developer, you may register an application as an OAuth2 consumer.
         You can then use your client id and client secret to request authorization tokens from
         Weasyl. Your client secret MUST be stored securely and should not be accessible
-        by your application's users under any circumstance. For more information see
-        <a href="https://projects.weasyl.com/weasylapi/#oauth2-endpoints">
+        by your application's users under any circumstance. Anyone with your client secret
+        will be able to impersonate you and you will be held responsible for any actions
+        performed with it.
+        Do not share it or check it into source control, etc.<br />
+        For more information see <a href="https://projects.weasyl.com/weasylapi/#oauth2-endpoints">
           https://projects.weasyl.com/weasylapi/#oauth2-endpoints</a>
       </p>
       <label for="client-name">Application Name</label>
@@ -131,7 +134,7 @@ $:{RENDER("common/stage_title.html", ["API Keys", "Settings"])}
           <label class="input-checkbox">
             <input type="checkbox" name="clientid" value="${app.clientid}" />
             $if app.homepage:
-              <a href="${app.homepage}"><strong>${app.description}</strong></a>
+              <a href="${app.homepage}" target="_blank"><strong>${app.description}</strong></a>
             $else:
               <strong>${app.description}</strong>
             <p>client ID: <tt>${app.clientid}</tt></p>

--- a/templates/oauth2/authorize.html
+++ b/templates/oauth2/authorize.html
@@ -229,9 +229,7 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
     </table>
 
     <p>
-      Do not authorize this application if you do not trust it. However, this
-      application will <em>never</em> be able to see or change your
-      password.
+      Do not authorize this application if you do not trust it.
     </p>
 
     <input type="hidden" name="credentials" value="${INLINE_JSON(credentials)}">

--- a/templates/oauth2/authorize.html
+++ b/templates/oauth2/authorize.html
@@ -222,14 +222,11 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
       (by <a href="/~${LOGIN(client.owner.profile.username)}">${client.owner.profile.username}</a>)
       should be authorized to make requests on your behalf with the following permissions:</p>
 
-    $if scopes:
-      <table id="permissions">
-        <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
-        $for scope in scopes:
-          <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
-      </table>
-    $else:
-      <p>No elevated permissions requested</p>
+    <table id="permissions">
+      <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
+      $for scope in scopes:
+        <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
+    </table>
 
     <p>
       Do not authorize this application if you do not trust it. However, this

--- a/templates/oauth2/authorize.html
+++ b/templates/oauth2/authorize.html
@@ -166,6 +166,13 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
         text-align: center;
       }
     }
+    #permissions {
+      vertical-align: middle;
+      width: 100%;
+    }
+    #permissions td {
+      padding: 0px 8px;
+    }
   </style>
 
 </head>
@@ -213,13 +220,18 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
 
     <p>Please confirm that the application <strong>${client.description}</strong>
       (by <a href="/~${LOGIN(client.owner.profile.username)}">${client.owner.profile.username}</a>)
-      should be authorized to make requests on your behalf.</p>
+      should be authorized to make requests on your behalf with the following permissions:</p>
 
-    <p>Note that this means that <strong>${client.description}</strong> can
-      perform <em>almost any action</em> as if you were logged in. Do
-      not authorize this application if you do not trust it. However, this
+    <table id="permissions">
+      <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
+      $for scope in scopes:
+        <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
+    </table>
+    <p>
+      Do not authorize this application if you do not trust it. However, this
       application will <em>never</em> be able to see or change your
-      password.</p>
+      password.
+    </p>
 
     <input type="hidden" name="credentials" value="${INLINE_JSON(credentials)}">
     <div class="actions">

--- a/templates/oauth2/authorize.html
+++ b/templates/oauth2/authorize.html
@@ -222,11 +222,15 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
       (by <a href="/~${LOGIN(client.owner.profile.username)}">${client.owner.profile.username}</a>)
       should be authorized to make requests on your behalf with the following permissions:</p>
 
-    <table id="permissions">
-      <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
-      $for scope in scopes:
-        <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
-    </table>
+    $if scopes:
+      <table id="permissions">
+        <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
+        $for scope in scopes:
+          <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
+      </table>
+    $else:
+      <p>No elevated permissions requested</p>
+
     <p>
       Do not authorize this application if you do not trust it. However, this
       application will <em>never</em> be able to see or change your

--- a/templates/oauth2/authorize.html
+++ b/templates/oauth2/authorize.html
@@ -224,8 +224,8 @@ $def with (scopes, credentials, client, myself, my_media, mobile, error, usernam
 
     <table id="permissions">
       <tr><td><strong>PERMISSION</strong></td><td><strong>GRANTS</strong></td></tr>
-      $for scope in scopes:
-        <tr><td>${scope['name']}</td><td>${scope['description']}</td></tr>
+      $for scope, desc in scopes.iteritems():
+        <tr><td>${scope}</td><td>${desc}</td></tr>
     </table>
 
     <p>

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -90,7 +90,6 @@ class api_base(controller_base):
 
 
 class api_useravatar_(api_base):
-
     def GET(self):
         return self.POST()
 
@@ -138,7 +137,6 @@ class api_whoami_(api_base):
 
 
 class api_version_(api_base):
-
     @api_method
     def GET(self, format='.json'):
         if format == '.txt':
@@ -181,7 +179,6 @@ def tidy_submission(submission):
 
 
 class api_frontpage_(api_base):
-
     @api_method
     def GET(self):
         form = web.input(since=None, count=0)
@@ -210,7 +207,6 @@ class api_frontpage_(api_base):
 
 
 class api_submission_view_(api_base):
-
     @api_method
     def GET(self, submitid):
         form = web.input(anyway='', increment_views='')
@@ -221,7 +217,6 @@ class api_submission_view_(api_base):
 
 
 class api_user_view_(api_base):
-
     @api_method
     def GET(self, login):
         userid = self.user_id
@@ -377,7 +372,6 @@ class api_user_view_(api_base):
 
 
 class api_user_gallery_(api_base):
-
     @api_method
     def GET(self, login):
         userid = profile.resolve_by_login(login)

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -462,7 +462,7 @@ class api_messages_summary_(api_base):
 
 class api_favorite_(api_base):
     login_required = True
-    oauth_scopes = ['favourite']
+    oauth_scopes = ['favorite']
 
     @api_method
     def POST(self, content_type, content_id):
@@ -479,7 +479,7 @@ class api_favorite_(api_base):
 
 class api_unfavorite_(api_base):
     login_required = True
-    oauth_scopes = ['favourite']
+    oauth_scopes = ['favorite']
 
     @api_method
     def POST(self, content_type, content_id):

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -124,6 +124,7 @@ class api_searchtagsuggest_(api_base):
 
 class api_whoami_(api_base):
     login_required = True
+    oauth_scopes = ['identity']
 
     @api_method
     def GET(self):

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -70,6 +70,8 @@ _STANDARD_WWW_AUTHENTICATE = 'Bearer realm="Weasyl", Weasyl-API-Key realm="Weasy
 
 
 class api_base(controller_base):
+    oauth_scopes = []
+
     @api_method
     def status_check_fail(self, *args, **kwargs):
         web.ctx.status = '403 Forbidden'
@@ -88,6 +90,7 @@ class api_base(controller_base):
 
 
 class api_useravatar_(api_base):
+
     def GET(self):
         return self.POST()
 
@@ -135,6 +138,7 @@ class api_whoami_(api_base):
 
 
 class api_version_(api_base):
+
     @api_method
     def GET(self, format='.json'):
         if format == '.txt':
@@ -177,6 +181,7 @@ def tidy_submission(submission):
 
 
 class api_frontpage_(api_base):
+
     @api_method
     def GET(self):
         form = web.input(since=None, count=0)
@@ -205,6 +210,7 @@ class api_frontpage_(api_base):
 
 
 class api_submission_view_(api_base):
+
     @api_method
     def GET(self, submitid):
         form = web.input(anyway='', increment_views='')
@@ -215,6 +221,7 @@ class api_submission_view_(api_base):
 
 
 class api_user_view_(api_base):
+
     @api_method
     def GET(self, login):
         userid = self.user_id
@@ -370,6 +377,7 @@ class api_user_view_(api_base):
 
 
 class api_user_gallery_(api_base):
+
     @api_method
     def GET(self, login):
         userid = profile.resolve_by_login(login)
@@ -412,6 +420,7 @@ class api_user_gallery_(api_base):
 
 class api_messages_submissions_(api_base):
     login_required = True
+    oauth_scopes = ['notifications']
 
     @api_method
     def GET(self):
@@ -443,6 +452,7 @@ class api_messages_submissions_(api_base):
 
 class api_messages_summary_(api_base):
     login_required = True
+    oauth_scopes = ['notifications']
 
     @api_method
     def GET(self):
@@ -458,6 +468,7 @@ class api_messages_summary_(api_base):
 
 class api_favorite_(api_base):
     login_required = True
+    oauth_scopes = ['favourite']
 
     @api_method
     def POST(self, content_type, content_id):
@@ -474,6 +485,7 @@ class api_favorite_(api_base):
 
 class api_unfavorite_(api_base):
     login_required = True
+    oauth_scopes = ['favourite']
 
     @api_method
     def POST(self, content_type, content_id):

--- a/weasyl/controllers/base.py
+++ b/weasyl/controllers/base.py
@@ -12,6 +12,8 @@ class controller_base:
     moderator_only = False
     admin_only = False
     disallow_api = False
+    # passing None as a scope defaults to ['wholesite']
+    oauth_scopes = None
 
     def status_check_fail(self, *args, **kwargs):
         return define.common_status_page(self.user_id, self.status)
@@ -41,7 +43,7 @@ class controller_base:
         if (self.disallow_api or self.moderator_only or self.admin_only) and weasyl.api.is_api_user():
             raise web.forbidden()
 
-        self.user_id = define.get_userid()
+        self.user_id = define.get_userid(self.oauth_scopes)
         self.status = define.common_status_check(self.user_id)
 
         # Status check

--- a/weasyl/controllers/base.py
+++ b/weasyl/controllers/base.py
@@ -12,8 +12,8 @@ class controller_base:
     moderator_only = False
     admin_only = False
     disallow_api = False
-    # passing None as a scope defaults to ['wholesite']
-    oauth_scopes = None
+    # by default use the most restrictive permission for all controllers
+    oauth_scopes = ['wholesite']
 
     def status_check_fail(self, *args, **kwargs):
         return define.common_status_page(self.user_id, self.status)

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -423,9 +423,10 @@ class control_apikeys_(controller_base):
 
     @define.token_checked
     def POST(self):
-        form = web.input(**{'delete-api-keys': [], 'revoke-oauth2-consumers': [], 'client-scopes': []})
-
-        print(form)
+        form = web.input(**{'delete-api-keys': [],
+                            'revoke-oauth2-consumers': [],
+                            'client-scopes': [],
+                            'clientid': []})
 
         if form.get('add-api-key'):
             api.add_api_key(self.user_id, form.get('add-key-description'))
@@ -438,6 +439,10 @@ class control_apikeys_(controller_base):
                                    form['client-name'],
                                    form['client-scopes'],
                                    form['redirect-uris'])
+        elif form.get('remove-oauth2-client'):
+            oauth2.remove_clients(self.user_id, form['clientid'])
+        elif form.get('reissue-client-secret'):
+            oauth2.renew_client_secrets(self.user_id, form['clientid'])
 
         raise web.seeother("/control/apikeys")
 

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -438,9 +438,9 @@ class control_apikeys_(controller_base):
             name = form['client-name']
             scopes = form['client-scopes']
             if not name.strip():
-                raise WeasylError("applicationNameMissing")
+                raise WeasylError("ApplicationNameMissing")
             if not scopes:
-                raise WeasylError("applicationHasNoScope")
+                raise WeasylError("ApplicationHasNoScope")
             oauth.register_client(self.user_id,
                                   name,
                                   scopes,

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -439,7 +439,8 @@ class control_apikeys_(controller_base):
             oauth2.register_client(self.user_id,
                                    form['client-name'],
                                    form['client-scopes'],
-                                   self._separator.split(form['redirect-uris']))
+                                   self._separator.split(form['redirect-uris']),
+                                   form['client-homepage'])
         elif form.get('remove-oauth2-client'):
             oauth2.remove_clients(self.user_id, form['clientid'])
         elif form.get('reissue-client-secret'):

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -1,5 +1,5 @@
 import os
-
+import re
 import web
 
 import libweasyl.ratings as ratings
@@ -412,6 +412,7 @@ class control_streaming_(controller_base):
 class control_apikeys_(controller_base):
     login_required = True
     disallow_api = True
+    _separator = re.compile(r"\s+")
 
     def GET(self):
         return define.webpage(self.user_id, "control/edit_apikeys.html", [
@@ -438,7 +439,7 @@ class control_apikeys_(controller_base):
             oauth2.register_client(self.user_id,
                                    form['client-name'],
                                    form['client-scopes'],
-                                   form['redirect-uris'])
+                                   self._separator.split(form['redirect-uris']))
         elif form.get('remove-oauth2-client'):
             oauth2.remove_clients(self.user_id, form['clientid'])
         elif form.get('reissue-client-secret'):

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -417,18 +417,27 @@ class control_apikeys_(controller_base):
         return define.webpage(self.user_id, "control/edit_apikeys.html", [
             api.get_api_keys(self.user_id),
             oauth2.get_consumers_for_user(self.user_id),
+            oauth2.get_allowed_scopes(self.user_id),
+            oauth2.get_registered_applications(self.user_id),
         ])
 
     @define.token_checked
     def POST(self):
-        form = web.input(**{'delete-api-keys': [], 'revoke-oauth2-consumers': []})
+        form = web.input(**{'delete-api-keys': [], 'revoke-oauth2-consumers': [], 'client-scopes': []})
+
+        print(form)
 
         if form.get('add-api-key'):
             api.add_api_key(self.user_id, form.get('add-key-description'))
-        if form.get('delete-api-keys'):
+        elif form.get('delete-api-keys'):
             api.delete_api_keys(self.user_id, form['delete-api-keys'])
-        if form.get('revoke-oauth2-consumers'):
+        elif form.get('revoke-oauth2-consumers'):
             oauth2.revoke_consumers_for_user(self.user_id, form['revoke-oauth2-consumers'])
+        elif form.get('create-oauth2-client'):
+            oauth2.register_client(self.user_id,
+                                   form['client-name'],
+                                   form['client-scopes'],
+                                   form['redirect-uris'])
 
         raise web.seeother("/control/apikeys")
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -343,7 +343,7 @@ def captcha_verify(form):
     return result[0] == 'true'
 
 
-def get_userid(sessionid=None):
+def get_userid(scopes=None):
     """
     Returns the userid corresponding to the user's sessionid; if no such session
     exists, zero is returned.
@@ -359,7 +359,7 @@ def get_userid(sessionid=None):
 
     elif authorization:
         from weasyl.oauth2 import get_userid_from_authorization
-        userid = get_userid_from_authorization()
+        userid = get_userid_from_authorization(scopes)
         if not userid:
             web.header('WWW-Authenticate', 'Bearer realm="Weasyl" error="invalid_token"')
             raise web.webapi.Unauthorized()

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -42,6 +42,8 @@ offline_mode = (
 error_messages = {
     "addressInvalid": "Your IP address does not match the location from which this request was made.",
     "AdminLocked": "This content has been locked from any editing by an admin.",
+    "applicationHasNoScope": "Your OAuth2 application must have at least one access scope.",
+    "applicationNameMissing": "You did not supply a valid name for this application.",
     "ArtistTags": "You cannot remove tags that have been added by the artist.",
     "birthdayInsufficient": (
         "Your date of birth indicates that you are not allowed to set your content rating settings to the "
@@ -100,7 +102,6 @@ error_messages = {
         "name correctly and that the account you are trying to recover the password for actually exists."),
     "maxamountInvalid": "The maximum amount you entered is not valid.",
     "minamountInvalid": "The minimum amount you entered is not valid.",
-    "nameMissing": "You did not supply a valid name for this application.",
     "noCover": "No cover exists for that submission.",
     "noImageSource": "No image exists from which to create a thumbnail.",
     "not-utf8": "Text submissions must be encoded in UTF-8.",

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -42,8 +42,8 @@ offline_mode = (
 error_messages = {
     "addressInvalid": "Your IP address does not match the location from which this request was made.",
     "AdminLocked": "This content has been locked from any editing by an admin.",
-    "applicationHasNoScope": "Your OAuth2 application must have at least one access scope.",
-    "applicationNameMissing": "You did not supply a valid name for this application.",
+    "ApplicationHasNoScope": "Your OAuth2 application must have at least one access scope.",
+    "ApplicationNameMissing": "You did not supply a valid name for this application.",
     "ArtistTags": "You cannot remove tags that have been added by the artist.",
     "birthdayInsufficient": (
         "Your date of birth indicates that you are not allowed to set your content rating settings to the "

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -100,6 +100,7 @@ error_messages = {
         "name correctly and that the account you are trying to recover the password for actually exists."),
     "maxamountInvalid": "The maximum amount you entered is not valid.",
     "minamountInvalid": "The minimum amount you entered is not valid.",
+    "nameMissing": "You did not supply a valid name for this application",
     "noCover": "No cover exists for that submission.",
     "noImageSource": "No image exists from which to create a thumbnail.",
     "not-utf8": "Text submissions must be encoded in UTF-8.",

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -100,7 +100,7 @@ error_messages = {
         "name correctly and that the account you are trying to recover the password for actually exists."),
     "maxamountInvalid": "The maximum amount you entered is not valid.",
     "minamountInvalid": "The minimum amount you entered is not valid.",
-    "nameMissing": "You did not supply a valid name for this application",
+    "nameMissing": "You did not supply a valid name for this application.",
     "noCover": "No cover exists for that submission.",
     "noImageSource": "No image exists from which to create a thumbnail.",
     "not-utf8": "Text submissions must be encoded in UTF-8.",

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -9,9 +9,21 @@ from weasyl import errorcode, login, media, orm
 
 '''
 EXISTING BEARER SCOPES:
-    "identity" - required for /api/whoami
-    "wholesite" - total control
+    'identity' - required for /api/whoami and /api/avatar
+    'wholesite' - total control
 '''
+
+_SCOPES = [
+    {
+        'name': 'wholesite',
+        'description': 'FULL CONTROL - Note that this means the application can '
+                       'perform almost any action as if you were logged in!',
+    },
+    {
+        'name': 'identity',
+        'description': 'Permission to retrieve your weasyl username and account number'
+    },
+]
 
 def extract_params():
     headers = {k[5:].replace('_', '-').title(): v for k, v in web.ctx.env.iteritems() if k.startswith('HTTP_')}
@@ -31,8 +43,9 @@ class authorize_(controller_base):
         else:
             user = user_media = None
         credentials['scopes'] = scopes
+        detail_scopes = [scope for scope in _SCOPES if scope['name'] in scopes]
         return d.render('oauth2/authorize.html', [
-            scopes, credentials, client, user, user_media, mobile, error,
+            detail_scopes, credentials, client, user, user_media, mobile, error,
             username, password, remember_me, not_me,
         ])
 
@@ -61,7 +74,7 @@ class authorize_(controller_base):
             if error:
                 error = errorcode.login_errors.get(error, 'Unknown error.')
         elif not self.user_id:
-            error = "You must specify a username and password."
+            error = 'You must specify a username and password.'
         else:
             userid = self.user_id
         if error:

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -4,6 +4,7 @@ import web
 
 from libweasyl.oauth import server, SCOPES
 from weasyl.controllers.base import controller_base
+from weasyl.error import WeasylError
 from weasyl import define as d
 from weasyl import errorcode, login, media, orm
 
@@ -25,8 +26,11 @@ class authorize_(controller_base):
             user_media = media.get_user_media(self.user_id)
         else:
             user = user_media = None
-        credentials['scopes'] = scopes
-        detail_scopes = {scope: desc for scope, desc in SCOPES if scope in scopes}
+        credentials['scopes'] = set(scopes)
+        if credentials['scopes'] - set(SCOPES.keys()):
+            # credentials contains scopes that are not in the list of established scopes
+            raise WeasylError("Unexpected")
+        detail_scopes = {scope: desc for scope, desc in SCOPES.iteritems() if scope in scopes}
         return d.render('oauth2/authorize.html', [
             detail_scopes, credentials, client, user, user_media, mobile, error,
             username, password, remember_me, not_me,

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -26,7 +26,7 @@ class authorize_(controller_base):
         else:
             user = user_media = None
         credentials['scopes'] = scopes
-        detail_scopes = [scope for scope in SCOPES if scope['name'] in scopes]
+        detail_scopes = {scope: desc for scope, desc in SCOPES if scope in scopes}
         return d.render('oauth2/authorize.html', [
             detail_scopes, credentials, client, user, user_media, mobile, error,
             username, password, remember_me, not_me,

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -5,6 +5,7 @@ import web
 from libweasyl.oauth import get_consumers_for_user, revoke_consumers_for_user, server
 from libweasyl import staff, security
 from weasyl.controllers.base import controller_base
+from weasyl.error import WeasylError
 from weasyl import define as d
 from weasyl import errorcode, login, media, orm
 
@@ -140,6 +141,10 @@ def register_client(user_id, name, scopes, redirects, homepage):
     :param scopes: a list of the scopes registered for this application
     :param redirects: allowed redirect URIs for this application
     """
+
+    if not name.strip():
+        raise WeasylError("nameMissing")
+
     session = d.connect()
     new_consumer = orm.OAuthConsumer(
         clientid=security.generate_key(32),

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -7,6 +7,11 @@ from weasyl.controllers.base import controller_base
 from weasyl import define as d
 from weasyl import errorcode, login, media, orm
 
+'''
+EXISTING BEARER SCOPES:
+    "identity" - required for /api/whoami
+    "wholesite" - total control
+'''
 
 def extract_params():
     headers = {k[5:].replace('_', '-').title(): v for k, v in web.ctx.env.iteritems() if k.startswith('HTTP_')}
@@ -82,7 +87,9 @@ class token_(controller_base):
         return body
 
 
-def get_userid_from_authorization(scopes=['wholesite']):
+def get_userid_from_authorization(scopes=None):
+    if not scopes:
+        scopes = ['wholesite']
     valid, request = server.verify_request(*(extract_params() + (scopes,)))
     if not valid:
         return None

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -23,6 +23,15 @@ _SCOPES = [
         'name': 'identity',
         'description': 'Permission to retrieve your weasyl username and account number'
     },
+    {
+        'name': 'notifications',
+        'description': 'Access to view your submission inbox, as well as notification counts '
+                       'for comments, favs, messages, etc.',
+    },
+    {
+        'name': 'favourite',
+        'description': 'The ability to favourite and unfavourite submissions'
+    },
 ]
 
 def extract_params():

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -17,7 +17,7 @@ _SCOPES = [
     },
     {
         'name': 'identity',
-        'description': 'Permission to retrieve your weasyl username and account number'
+        'description': 'Permission to retrieve your weasyl username and account number',
     },
     {
         'name': 'notifications',
@@ -25,8 +25,8 @@ _SCOPES = [
                        'for comments, favs, messages, etc.',
     },
     {
-        'name': 'favourite',
-        'description': 'The ability to favourite and unfavourite submissions'
+        'name': 'favorite',
+        'description': 'The ability to favorite and unfavorite submissions',
     },
 ]
 
@@ -80,7 +80,7 @@ class authorize_(controller_base):
             if error:
                 error = errorcode.login_errors.get(error, 'Unknown error.')
         elif not self.user_id:
-            error = 'You must specify a username and password.'
+            error = "You must specify a username and password."
         else:
             userid = self.user_id
         if error:
@@ -126,9 +126,9 @@ def get_allowed_scopes(user_id):
     :param user_id: the userid of the application owner
     :return: a list of scopes
     """
-    allowed = list(_SCOPES)
+    allowed = _SCOPES
     # only trusted individuals should be allowed to use the "wholesite" oauth grant
-    if user_id not in list(staff.ADMINS | staff.MODS | staff.DEVELOPERS):
+    if user_id not in staff.ADMINS | staff.MODS | staff.DEVELOPERS:
         allowed = [scope for scope in allowed if scope['name'] != 'wholesite']
     return allowed
 
@@ -141,7 +141,6 @@ def register_client(user_id, name, scopes, redirects, homepage):
     :param scopes: a list of the scopes registered for this application
     :param redirects: allowed redirect URIs for this application
     """
-
     if not name.strip():
         raise WeasylError("nameMissing")
 
@@ -162,8 +161,6 @@ def register_client(user_id, name, scopes, redirects, homepage):
     session.add(new_consumer)
     session.commit()
 
-    return
-
 
 def get_registered_applications(user_id):
     """
@@ -181,7 +178,6 @@ def remove_clients(user_id, clients):
          .filter_by(ownerid=user_id)
          .filter(orm.OAuthConsumer.clientid.in_(clients)))
     q.delete(synchronize_session=False)
-    return
 
 
 def renew_client_secrets(user_id, clients):
@@ -191,4 +187,3 @@ def renew_client_secrets(user_id, clients):
              .filter_by(clientid=cid))
         q.update({orm.OAuthConsumer.client_secret: security.generate_key(64)},
                  synchronize_session=False)
-    return

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -142,7 +142,9 @@ def register_client(user_id, name, scopes, redirects, homepage):
     :param redirects: allowed redirect URIs for this application
     """
     if not name.strip():
-        raise WeasylError("nameMissing")
+        raise WeasylError("applicationNameMissing")
+    if not scopes:
+        raise WeasylError("applicationHasNoScope")
 
     session = d.connect()
     new_consumer = orm.OAuthConsumer(

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -156,7 +156,7 @@ def register_client(user_id, name, scopes, redirects, ):
     session.add(new_consumer)
     session.commit()
 
-    return None
+    return
 
 
 def get_registered_applications(user_id):
@@ -174,5 +174,15 @@ def remove_clients(user_id, clients):
     q = (orm.OAuthConsumer.query
          .filter_by(ownerid=user_id)
          .filter(orm.OAuthConsumer.clientid.in_(clients)))
-    q.delete(synchronize_session='fetch')
+    q.delete(synchronize_session=False)
+    return
+
+
+def renew_client_secrets(user_id, clients):
+    for cid in clients:
+        q = (orm.OAuthConsumer.query
+             .filter_by(ownerid=user_id)
+             .filter_by(clientid=cid))
+        q.update({orm.OAuthConsumer.client_secret: security.generate_key(64)},
+                 synchronize_session=False)
     return

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -132,7 +132,7 @@ def get_allowed_scopes(user_id):
     return allowed
 
 
-def register_client(user_id, name, scopes, redirects, ):
+def register_client(user_id, name, scopes, redirects, homepage):
     """
     Register an application as an OAuth2 consumer
     :param user_id: the user registering this application
@@ -149,7 +149,8 @@ def register_client(user_id, name, scopes, redirects, ):
         response_type="code",
         scopes=scopes,
         redirect_uris=redirects,
-        client_secret=security.generate_key(64)
+        client_secret=security.generate_key(64),
+        homepage=homepage,
     )
     # this doesnt seem right
     session.begin()


### PR DESCRIPTION
Changes to allow Weasyl users to generate their own OAuth2 client ID's and client secrets  (with limited scopes). Relies on Weasyl/libweasyl#3
Also modifies  the OAuth clickthrough page to display more information about the various scopes the application is requesting.

The registration and management UI is a bit (read: a lot) brutish so feel free to tear it apart but it should be at least basically functional. it's a developer thing anyway so getting it _beautiful_ is not my highest priority.
