### PR TITLE
Update library requirements in requirements.txt

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,19 +1,19 @@
 # these are all pinned versions available from https://pypi.weasyldev.com
-libweasyl==0.11.1
+libweasyl==0.11.2
 
 zope.interface==4.1.3       # for twisted
-service_identity==14.0.0    # Newer Twisted wants this for cert verification
-Twisted==15.5.0
+service_identity==16.0.0    # Newer Twisted wants this for cert verification
+Twisted==16.2.0
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
-raven==5.9.2                # as above
-pyOpenSSL==0.15.1           # and again
-requests[security]==2.9.1
+raven==5.19.0               # as above
+pyOpenSSL==16.0.0           # and again
+requests[security]==2.10.0
 oauth2==1.9.0.post1
-python-memcached==1.57
+python-memcached==1.58
 txstatsd==1.0.0+weasyl.2    # https://github.com/Weasyl/txstatsd
-crochet==1.4.0
+crochet==1.5.0
 txyam2==0.5.1+weasyl.1      # https://github.com/Weasyl/txyam2
-mock==1.3.0
+mock==2.0.0
 Dozer==0.5                  # For WSGI memory profiling
-Pillow==3.0.0               # For WSGI memory profiling
+Pillow==3.2.0               # For WSGI memory profiling


### PR DESCRIPTION
Updates Weasyl Python library dependencies to current. Depends on libweasyl/#4 and its merge to master being tagged with 0.11.2.