### PR TITLE
Resolve a number of issues introduced with #22

### DIFF
--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -227,7 +227,7 @@ def _select_character_and_check(userid, charid, rating=None, ignore=True, anyway
     elif ignore and blocktag.check(userid, charid=charid):
         raise WeasylError('TagBlocked')
 
-    query = dict(query.items())
+    query = dict(query)
 
     if increment_views and define.common_view_content(userid, charid, 'char'):
         query['page_views'] += 1

--- a/weasyl/comment.py
+++ b/weasyl/comment.py
@@ -284,7 +284,7 @@ def count(id, contenttype='submission'):
 
     if contenttype == 'submission':
         return d.engine.execute(
-            'SELECT COUNT(*) FROM comment cm WHERE cm.target_sub = %s',
+            'SELECT COUNT(*) FROM comments cm WHERE cm.target_sub = %s',
             [id]).scalar()
     elif contenttype == 'journal':
         tablename = 'journalcomment'

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -157,6 +157,7 @@ def select_view_api(userid, journalid, anyway=False, increment_views=False):
         'comments': comment.count(journalid, 'journal'),
         'favorited': favorite.check(userid, journalid=journalid),
         'friends_only': 'f' in journal.settings,
+        'posted_at': d.iso8601(journal.unixtime),
     }
 
 

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -22,6 +22,7 @@ from libweasyl import ratings
 from libweasyl import staff
 from libweasyl import text
 
+from weasyl import api
 from weasyl import media
 from weasyl import orm
 
@@ -102,8 +103,10 @@ def _select_journal_and_check(userid, journalid, rating=None, ignore=True, anywa
     elif ignore and blocktag.check(userid, journalid=journalid):
         raise WeasylError('TagBlocked')
 
+    query = dict(query.items())
+
     if increment_views and d.common_view_content(userid, journalid, 'journal'):
-        query.page_views += 1
+        query['page_views'] += 1
 
     return query
 
@@ -114,20 +117,20 @@ def select_view(userid, rating, journalid, ignore=True, anyway=None):
 
     return {
         'journalid': journalid,
-        'userid': journal.userid,
-        'username': journal.username,
-        'user_media': media.get_user_media(journal.userid),
-        'mine': userid == journal.userid,
-        'unixtime': journal.unixtime,
-        'title': journal.title,
+        'userid': journal['userid'],
+        'username': journal['username'],
+        'user_media': media.get_user_media(journal['userid']),
+        'mine': userid == journal['userid'],
+        'unixtime': journal['unixtime'],
+        'title': journal['title'],
         'content': files.read(files.make_resource(userid, journalid, 'journal/submit')),
-        'rating': journal.rating,
-        'settings': journal.settings,
-        'page_views': journal.page_views,
+        'rating': journal['rating'],
+        'settings': journal['settings'],
+        'page_views': journal['page_views'],
         'reported': report.check(journalid=journalid),
         'favorited': favorite.check(userid, journalid=journalid),
-        'friends_only': 'f' in journal.settings,
-        'hidden_submission': 'h' in journal.settings,
+        'friends_only': 'f' in journal['settings'],
+        'hidden_submission': 'h' in journal['settings'],
         'fave_count': favorite.count(journalid, 'journal'),
         'tags': searchtag.select(journalid=journalid),
         'comments': comment.select(userid, journalid=journalid),
@@ -144,20 +147,22 @@ def select_view_api(userid, journalid, anyway=False, increment_views=False):
 
     return {
         'journalid': journalid,
-        'title': journal.title,
-        'owner': journal.username,
-        'owner_login': d.get_sysname(journal.username),
+        'title': journal['title'],
+        'owner': journal['username'],
+        'owner_login': d.get_sysname(journal['username']),
+        'owner_media': api.tidy_all_media(
+            media.get_user_media(journal['userid'])),
         'content': text.markdown(content),
         'tags': searchtag.select(journalid=journalid),
-        'link': d.absolutify_url('/journal/%d/%s' % (journalid, text.slug_for(journal.title))),
+        'link': d.absolutify_url('/journal/%d/%s' % (journalid, text.slug_for(journal['title']))),
         'type': 'journal',
-        'rating': ratings.CODE_TO_NAME[journal.rating],
-        'views': journal.page_views,
+        'rating': ratings.CODE_TO_NAME[journal['rating']],
+        'views': journal['page_views'],
         'favorites': favorite.count(journalid, 'journal'),
         'comments': comment.count(journalid, 'journal'),
         'favorited': favorite.check(userid, journalid=journalid),
-        'friends_only': 'f' in journal.settings,
-        'posted_at': d.iso8601(journal.unixtime),
+        'friends_only': 'f' in journal['settings'],
+        'posted_at': d.iso8601(journal['unixtime']),
     }
 
 

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -103,7 +103,7 @@ def _select_journal_and_check(userid, journalid, rating=None, ignore=True, anywa
     elif ignore and blocktag.check(userid, journalid=journalid):
         raise WeasylError('TagBlocked')
 
-    query = dict(query.items())
+    query = dict(query)
 
     if increment_views and d.common_view_content(userid, journalid, 'journal'):
         query['page_views'] += 1


### PR DESCRIPTION
There were a number of issues with #22 that this should resolve. 

- [x] Missing `posted_at` and `owner_media` field for journal API responses
- [x] Misspelling of table name for comment counts for submissions
- [x] Broken page views for characters and journals
- [x] Missing media ID field (previous API docs say null fields are valid for when URL is unambiguous) 