### PR TITLE
Page footer (page_end.html): Update copyright date

### DIFF
--- a/templates/common/page_end.html
+++ b/templates/common/page_end.html
@@ -65,7 +65,7 @@ $def with (options=None, active_users_string='')
       $if active_users_string:
         ${active_users_string}.
         <br>
-      ${SHA} &middot; Copyright &copy; 2012–2015 Weasyl LLC
+      ${SHA} &middot; Copyright &copy; 2012–2016 Weasyl LLC
     </p>
 
   </div><!-- /footer --></footer>


### PR DESCRIPTION
Changes the year in the copyright line to the current year; previously, the line had 2015 as the end-year.