### PR TITLE
Recenter the position of thumbs

### DIFF
--- a/static/public.css
+++ b/static/public.css
@@ -1424,16 +1424,10 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     display: block;
     max-width: 100%;
     max-height: 100%;
-}
-.enhanced-thumbnails.csstransforms .thumbnail-grid .thumb-bounds img {
     position: absolute;
     left: 50%;
     top: 50%;
-    -webkit-transform: translate(-50%, -50%);
-       -moz-transform: translate(-50%, -50%);
-        -ms-transform: translate(-50%, -50%);
-         -o-transform: translate(-50%, -50%);
-            transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 .thumbnail-grid .rating {
     width: 60px;


### PR DESCRIPTION
This looks like it was a side-effect of mordernizr being removed and
.csstransform rules no longer being applied.

There's still one more .csstranform rule in the CSS file that I'm
not really sure what to do about.