### PR TITLE
Automatically update year in footer

### DIFF
--- a/templates/common/page_end.html
+++ b/templates/common/page_end.html
@@ -1,4 +1,4 @@
-$def with (options=None, active_users_string='')
+$def with (options=None, active_users_string='', current_year='')
   <footer><div id="footer">
 
     <nav role="navigation"><div id="footer-nav" class="clear">

--- a/templates/common/page_end.html
+++ b/templates/common/page_end.html
@@ -1,4 +1,4 @@
-$def with (options=None, active_users_string='', current_year='')
+$def with (options=None, active_users_string='')
   <footer><div id="footer">
 
     <nav role="navigation"><div id="footer-nav" class="clear">
@@ -65,7 +65,7 @@ $def with (options=None, active_users_string='', current_year='')
       $if active_users_string:
         ${active_users_string}.
         <br>
-      ${SHA} &middot; Copyright &copy; 2012–${current_year} Weasyl LLC
+      ${SHA} &middot; Copyright &copy; 2012–${arrow.now().year} Weasyl LLC
     </p>
 
   </div><!-- /footer --></footer>

--- a/templates/common/page_end.html
+++ b/templates/common/page_end.html
@@ -65,7 +65,7 @@ $def with (options=None, active_users_string='')
       $if active_users_string:
         ${active_users_string}.
         <br>
-      ${SHA} &middot; Copyright &copy; 2012–2016 Weasyl LLC
+      ${SHA} &middot; Copyright &copy; 2012–${current_year} Weasyl LLC
     </p>
 
   </div><!-- /footer --></footer>

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -872,8 +872,7 @@ def active_users():
 def common_page_end(userid, page, rating=None, config=None,
                     now=None, options=None):
     active_users_string = active_users()
-    current_year = datetime.datetime.now().year
-    data = render("common/page_end.html", [options, active_users_string, current_year])
+    data = render("common/page_end.html", [options, active_users_string])
     page.append(data)
     return "".join(page)
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -872,6 +872,7 @@ def active_users():
 def common_page_end(userid, page, rating=None, config=None,
                     now=None, options=None):
     active_users_string = active_users()
+    current_year = datetime.datetime.now().year
     data = render("common/page_end.html", [options, active_users_string])
     page.append(data)
     return "".join(page)

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -873,7 +873,7 @@ def common_page_end(userid, page, rating=None, config=None,
                     now=None, options=None):
     active_users_string = active_users()
     current_year = datetime.datetime.now().year
-    data = render("common/page_end.html", [options, active_users_string])
+    data = render("common/page_end.html", [options, active_users_string, current_year])
     page.append(data)
     return "".join(page)
 


### PR DESCRIPTION
The logical progression from my previous commit which fixed the current year statically; uses datetime to get the year from the system, and passes it to page_end.html. Properly resolves issue #7.