### PR TITLE
Add virtualization extension requirement to help section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,9 @@ the project's `gitter room <https://gitter.im/Weasyl/weasyl>`_.
 
 The above instructions have been tested on Linux and OS X. It should be possible
 to run weasyl in a virtual environment under Windows, but it hasn't been thoroughly
-tested.
+tested. Ensure that either Intel VT-x/EPT or AMD-V/RVI are exposed to the virtual 
+machine or Vagrant/Virtualbox may hang attempting to SSH to the VM during the 
+``vagrant up`` command.
 
 
 .. _Weasyl: https://www.weasyl.com

--- a/README.rst
+++ b/README.rst
@@ -68,9 +68,13 @@ the project's `gitter room <https://gitter.im/Weasyl/weasyl>`_.
 
 The above instructions have been tested on Linux and OS X. It should be possible
 to run weasyl in a virtual environment under Windows, but it hasn't been thoroughly
-tested. Ensure that either Intel VT-x/EPT or AMD-V/RVI are exposed to the virtual 
-machine or Vagrant/Virtualbox may hang attempting to SSH to the VM during the 
-``vagrant up`` command.
+tested. 
+
+When developing under Windows hosts with a Linux guest, ensure that either Intel VT-x/EPT 
+or AMD-V/RVI are exposed to the virtual machine (e.g., the ``Virtualize Intel VT-x/EPT or 
+AMD-V/RVI`` setting under the Processors device settings for the guest VM). If this setting 
+is not selected, the configuration of the Weasyl VM via ``make setup-vagrant`` may hang 
+when Vagrant attempts to SSH to the VM to perform configuration of the guest. 
 
 
 .. _Weasyl: https://www.weasyl.com

--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,10 @@ to run weasyl in a virtual environment under Windows, but it hasn't been thoroug
 tested. 
 
 When developing under Windows hosts with a Linux guest, ensure that either Intel VT-x/EPT 
-or AMD-V/RVI are exposed to the virtual machine (e.g., the ``Virtualize Intel VT-x/EPT or 
-AMD-V/RVI`` setting under the Processors device settings for the guest VM). If this setting 
-is not selected, the configuration of the Weasyl VM via ``make setup-vagrant`` may hang 
-when Vagrant attempts to SSH to the VM to perform configuration of the guest. 
+or AMD-V/RVI are exposed to the virtual machine (e.g., the "Virtualize Intel VT-x/EPT or 
+AMD-V/RVI" setting under the Processors device settings for the guest VM in VMware). If 
+this setting is not selected, the configuration of the Weasyl VM via ``make setup-vagrant`` 
+may hang when Vagrant attempts to SSH to the VM to perform configuration of the guest. 
 
 
 .. _Weasyl: https://www.weasyl.com


### PR DESCRIPTION
When virtualizing under a Windows host, Intel VT-x/EPT or AMD-V/RVI must be passed through to the guest OS, or Virtualbox will fail to properly bring up the Weasyl VM during the ``vagrant up`` command. No descriptive error is given by Vagrant in this instance, potentially leading to confusion.