### PR TITLE
Add webkit transform prefix for ios and android browsers

### DIFF
--- a/static/public.css
+++ b/static/public.css
@@ -1427,6 +1427,7 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     position: absolute;
     left: 50%;
     top: 50%;
+    -webkit-transform: translate(-50%, -50%);
     transform: translate(-50%, -50%);
 }
 .thumbnail-grid .rating {


### PR DESCRIPTION
reported: https://forums.weasyl.com/vbulletin/showthread.php?8667-KitKat-browser-thumbnail-bug
https://twitter.com/DrKraest/status/739478234371379200

KitKat default browser and iOS <9.2 requires -webkit- prefix to css transform causing problems not remedied by #30 