### PR TITLE
Update reCAPTCHA version

### DIFF
--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -23,5 +23,5 @@ url = postgres:///weasyl
 # dsn = twisted+http://...
 
 [recaptcha-lo.weasyl.com]
-public_key = 6Le9U_0SAAAAAGXX5z9xg3LQC4tgGzWm_kC9-V_G
-private_key = 6Le9U_0SAAAAAKO9vYtaQJL01srJ-soG6l9vmTft
+public_key = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+private_key = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/templates/etc/signup.html
+++ b/templates/etc/signup.html
@@ -14,7 +14,7 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
     $if captcha_public_key:
       <label for="g-recaptcha-response">Captcha</label>
       <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-      <div class="g-recaptcha" data-sitekey="${captcha_public_key}"></div>
+      <div class="g-recaptcha" data-sitekey="${captcha_public_key}" data-theme="light"></div>
       <noscript>
         <div>
           <div style="width: 302px; height: 422px; position: relative;">
@@ -36,8 +36,6 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
           </div>
         </div>
       </noscript>
-
-      <p class="color-lighter" style="padding-top: 0.5em;"><i>This helps verify that you are a not a robot.</i></p>
 
     <div class="form-2up clear">
       <div class="form-2up-1">

--- a/templates/etc/signup.html
+++ b/templates/etc/signup.html
@@ -12,19 +12,31 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
     $ captcha_public_key = CAPTCHA()
 
     $if captcha_public_key:
+      <label for="g-recaptcha-response">Captcha</label>
+      <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+      <div class="g-recaptcha" data-sitekey="${captcha_public_key}"></div>
       <noscript>
-        <iframe src="https://www.google.com/recaptcha/api/noscript?k=${captcha_public_key}"
-                height="300" width="500" frameborder="0"></iframe><br>
+        <div>
+          <div style="width: 302px; height: 422px; position: relative;">
+            <div style="width: 302px; height: 422px; position: absolute;">
+              <iframe src="https://www.google.com/recaptcha/api/fallback?k=${captcha_public_key}"
+                      frameborder="0" scrolling="no"
+                      style="width: 302px; height:422px; border-style: none;">
+              </iframe>
+            </div>
+          </div>
+          <div style="width: 300px; height: 60px; border-style: none;
+                       bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
+                       background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
+            <textarea id="g-recaptcha-response" name="g-recaptcha-response"
+                      class="g-recaptcha-response"
+                      style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
+                              margin: 10px 25px; padding: 0px; resize: none;" >
+            </textarea>
+          </div>
+        </div>
       </noscript>
-      <label for="recaptcha_response_field">Captcha</label>
-      <script type="text/javascript"
-              src="https://www.google.com/recaptcha/api/challenge?k=${captcha_public_key}">
-      </script>
-      <noscript>
-        <textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
-        <input type="hidden" name="recaptcha_response_field"
-               value="manual_challenge">
-      </noscript>
+
       <p class="color-lighter" style="padding-top: 0.5em;"><i>This helps verify that you are a not a robot.</i></p>
 
     <div class="form-2up clear">

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -92,6 +92,7 @@ class signup_(controller_base):
                 "month": None,
                 "year": None,
                 "error": None,
+                "display_reCaptcha": True,
             },
         ])
 
@@ -99,7 +100,7 @@ class signup_(controller_base):
     def POST(self):
         form = web.input(
             username="", password="", passcheck="", email="", emailcheck="",
-            day="", month="", year="", recaptcha_challenge_field="", recaptcha_response_field="")
+            day="", month="", year="", recaptcha_challenge_field="", g_recaptcha_response=web.input("g-recaptcha-response"))
 
         if not define.captcha_verify(form):
             return define.errorpage(

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -105,7 +105,7 @@ class signup_(controller_base):
         if not define.captcha_verify(form):
             return define.errorpage(
                 self.user_id,
-                "There was an error verifying the data you entered; you should go back and try again.")
+                "There was an error validating the CAPTCHA response; you should go back and try again.")
 
         login.create(form)
         return define.errorpage(

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -105,7 +105,7 @@ class signup_(controller_base):
         if not define.captcha_verify(form):
             return define.errorpage(
                 self.user_id,
-                "The image verification you entered was not correct; you should go back and try again.")
+                "There was an error verifying the data you entered; you should go back and try again.")
 
         login.create(form)
         return define.errorpage(

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -92,7 +92,6 @@ class signup_(controller_base):
                 "month": None,
                 "year": None,
                 "error": None,
-                "display_reCaptcha": True,
             },
         ])
 
@@ -100,7 +99,8 @@ class signup_(controller_base):
     def POST(self):
         form = web.input(
             username="", password="", passcheck="", email="", emailcheck="",
-            day="", month="", year="", recaptcha_challenge_field="", g_recaptcha_response=web.input("g-recaptcha-response"))
+            day="", month="", year="", recaptcha_challenge_field="", 
+            g_recaptcha_response=web.input("g-recaptcha-response"))
 
         if not define.captcha_verify(form):
             return define.errorpage(

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -337,8 +337,8 @@ def captcha_verify(form):
         response=form.g_recaptcha_response['g-recaptcha-response'],
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
-    jsonResult = response.json()
-    return jsonResult['success']
+    captcha_validation_result = response.json()
+    return captcha_validation_result['success']
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -334,12 +334,11 @@ def captcha_verify(form):
 
     data = dict(
         secret=config_obj.get(_captcha_section(), 'private_key'),
-        remoteip=get_address(),
-        response=form.g_recaptcha_response)
-
+        response=form.g_recaptcha_response,
+        remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
-    result = response.text.splitlines()
-    return result[0] == 'true'
+    result = json.loads(response.read().decode('utf-8')) #Why does this error?!
+    return result['success']
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -334,12 +334,19 @@ def captcha_verify(form):
 
     data = dict(
         secret=config_obj.get(_captcha_section(), 'private_key'),
-        response=form.g_recaptcha_response,
+        response=form.g_recaptcha_response['g-recaptcha-response'],
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
     jsonResult = response.json()
     print jsonResult
-    return jsonResult['success'] == "true"
+    print jsonResult['success']
+    if jsonResult['success'] == 'True':
+        print 'Yay!'
+        return True
+    else:
+        print "Boo!"
+        return False
+    return (jsonResult['success'] is "True")
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -338,7 +338,7 @@ def captcha_verify(form):
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
     result = response.json()
-    return result['success']
+    return result['success'] == "true"
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -337,7 +337,7 @@ def captcha_verify(form):
         response=form.g_recaptcha_response,
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
-    result = json.loads(response.read().decode('utf-8')) #Why does this error?!
+    result = response.json()
     return result['success']
 
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -338,15 +338,7 @@ def captcha_verify(form):
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
     jsonResult = response.json()
-    print jsonResult
-    print jsonResult['success']
-    if jsonResult['success'] == 'True':
-        print 'Yay!'
-        return True
-    else:
-        print "Boo!"
-        return False
-    return (jsonResult['success'] is "True")
+    return jsonResult['success']
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -337,8 +337,8 @@ def captcha_verify(form):
         response=form.g_recaptcha_response,
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
-    result = response.json()
-    return result['success'] == "true"
+    jsonResult = response.json()
+    return jsonResult['success'][0] == "true"
 
 
 def get_userid(sessionid=None):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -329,16 +329,15 @@ def captcha_public():
 def captcha_verify(form):
     if config_read_bool("captcha_disable_verification", value=False):
         return True
-    if not form.recaptcha_response_field:
+    if not form.g_recaptcha_response:
         return False
 
     data = dict(
-        privatekey=config_obj.get(_captcha_section(), 'private_key'),
+        secret=config_obj.get(_captcha_section(), 'private_key'),
         remoteip=get_address(),
-        challenge=form.recaptcha_challenge_field.encode('utf-8'),
-        response=form.recaptcha_response_field.encode('utf-8'))
+        response=form.g_recaptcha_response)
 
-    response = http_post('https://www.google.com/recaptcha/api/verify', data=data)
+    response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
     result = response.text.splitlines()
     return result[0] == 'true'
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -338,7 +338,8 @@ def captcha_verify(form):
         remoteip=get_address())
     response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
     jsonResult = response.json()
-    return jsonResult['success'][0] == "true"
+    print jsonResult
+    return jsonResult['success'] == "true"
 
 
 def get_userid(sessionid=None):


### PR DESCRIPTION
Code updates to use the newer version of reCAPTCHA. Tests locally with production reCAPTCHA v2 keys work as expected, both with JavaScript and without scripting enabled. (The failure point during tests run on the Weasyl development VM in this situation is the inability to mail anything out. But that is well after any failure mode for the reCAPTCHA code.)