### PR TITLE
Capitalization and style fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ The easiest way to get Weasyl running is within a virtual environment using
 
 After libweasyl is cloned, Vagrant will fetch the base box and then provision
 the VM. Expect this step to take a while as it downloads a virtual machine
-image, installs all of weasyl's dependencies, and populates a small database.
+image, installs all of Weasyl's dependencies, and populates a small database.
 
 To start the server inside the VM, run::
 
@@ -32,20 +32,20 @@ warnings about the self-signed certificate.
 Next Steps
 ----------
 
-At this point weasyl is running within a virtual machine. Your weasyl repo
+At this point Weasyl is running within a virtual machine. Your Weasyl repo
 is mounted as ``/home/vagrant/weasyl`` inside the guest so edits made locally
-will be reflected inside the VM. To make changes, stop the `make guest-run`
-process, edit the code, and rerun `make guest-run`.
+will be reflected inside the VM. To make changes, stop the ``make guest-run``
+process, edit the code, and rerun ``make guest-run``.
 
 If you need to examine the virtual machine (e.g. to look at the database
-directly), run `vagrant ssh`.
+directly), run ``vagrant ssh``.
 
 
 The Sample Database
 -------------------
 
 The downloaded database contains sample content pulled and scrubbed from
-weasyl staff accounts. No content should be included from non-staff users
+Weasyl staff accounts. No content should be included from non-staff users
 or those who haven't otherwise explicitly given permission to use their
 account.
 
@@ -63,11 +63,11 @@ Troubleshooting and Getting Help
 If the ``make setup-vagrant`` step fails halfway through, you can resume it with the
 standard vagrant commands ``vagrant up`` followed by ``vagrant provision``.
 
-If you have questions or get stuck, you can trying talking to weasyl project members in
+If you have questions or get stuck, you can trying talking to Weasyl project members in
 the project's `gitter room <https://gitter.im/Weasyl/weasyl>`_.
 
 The above instructions have been tested on Linux and OS X. It should be possible
-to run weasyl in a virtual environment under Windows, but it hasn't been thoroughly
+to run Weasyl in a virtual environment under Windows, but it hasn't been thoroughly
 tested. 
 
 When developing under Windows hosts with a Linux guest, ensure that either Intel VT-x/EPT 


### PR DESCRIPTION
Fixed a few instances of "Weasyl" not being capitalized outside of places where one would expect lowercase usage (such as path names); fixed a few instances of commands not being properly enclosed in double backticks.