### PR TITLE
Use array-based tag table to improve search performance

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/9afc9a45510c_add_submission_tags_for_fast_searching.py
+++ b/libweasyl/libweasyl/alembic/versions/9afc9a45510c_add_submission_tags_for_fast_searching.py
@@ -1,0 +1,32 @@
+"""Add submission_tags for fast searching
+
+Revision ID: 9afc9a45510c
+Revises: abac1922735d
+Create Date: 2016-06-13 14:40:01.782784
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9afc9a45510c'
+down_revision = 'abac1922735d'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.create_table('submission_tags',
+    sa.Column('submitid', sa.Integer(), nullable=False),
+    sa.Column('tags', postgresql.ARRAY(sa.Integer()), nullable=False),
+    sa.ForeignKeyConstraint(['submitid'], ['submission.submitid'], name='submission_tags_submitid_fkey', onupdate='CASCADE', ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('submitid')
+    )
+    op.execute(
+        'INSERT INTO submission_tags (submitid, tags) '
+        'SELECT targetid, array_agg(tagid) FROM searchmapsubmit GROUP BY targetid')
+    op.create_index('ind_submission_tags_tags', 'submission_tags', ['tags'], unique=False, postgresql_using='gin')
+
+
+def downgrade():
+    op.drop_index('ind_submission_tags_tags', table_name='submission_tags')
+    op.drop_table('submission_tags')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -740,6 +740,16 @@ Index('ind_submission_media_links_submitid', submission_media_links.c.submitid)
 Index('ind_submission_media_links_mediaid', submission_media_links.c.mediaid, unique=False)
 
 
+submission_tags = Table(
+    'submission_tags', metadata,
+    Column('submitid', Integer(), primary_key=True, nullable=False),
+    Column('tags', ARRAY(Integer()), nullable=False),
+    default_fkey(['submitid'], ['submission.submitid'], name='submission_tags_submitid_fkey'),
+)
+
+Index('ind_submission_tags_tags', submission_tags.c.tags, postgresql_using='gin')
+
+
 suspension = Table(
     'suspension', metadata,
     Column('userid', Integer(), primary_key=True, nullable=False),

--- a/libweasyl/libweasyl/ratings.py
+++ b/libweasyl/libweasyl/ratings.py
@@ -5,11 +5,12 @@ from translationstring import TranslationString as _
 
 @functools.total_ordering
 class Rating(object):
-    def __init__(self, code, name, nice_name, minimum_age, block_text,
+    def __init__(self, code, character, name, nice_name, minimum_age, block_text,
                  additional_description=None):
 
         # public properties
         self.code = code
+        self.character = character
         self.name = name
         self.minimum_age = minimum_age
         self.additional_description = additional_description
@@ -58,15 +59,16 @@ class Rating(object):
         return self.code
 
 
-GENERAL = Rating(10, "general", "General", 0, "Block general and higher")
-MODERATE = Rating(20, "moderate", "Moderate", 13, "Block moderate and higher")
-MATURE = Rating(30, "mature", "Mature", 18, "Block mature and higher", "non-sexual")
-EXPLICIT = Rating(40, "explicit", "Explicit", 18, "Block explicit only", "sexual")
+GENERAL = Rating(10, "g", "general", "General", 0, "Block general and higher")
+MODERATE = Rating(20, "m", "moderate", "Moderate", 13, "Block moderate and higher")
+MATURE = Rating(30, "a", "mature", "Mature", 18, "Block mature and higher", "non-sexual")
+EXPLICIT = Rating(40, "p", "explicit", "Explicit", 18, "Block explicit only", "sexual")
 ALL_RATINGS = [GENERAL, MODERATE, MATURE, EXPLICIT]
 
 
 CODE_MAP = {rating.code: rating for rating in ALL_RATINGS}
 NAME_MAP = {rating.name: rating for rating in ALL_RATINGS}
+CHARACTER_MAP = {rating.character: rating for rating in ALL_RATINGS}
 CODE_TO_NAME = {rating.code: rating.name for rating in ALL_RATINGS}
 
 

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -59,7 +59,6 @@ class search_(controller_base):
                     limit=63,
                     search=search_query,
                     within=meta["within"],
-                    rated=meta["rated"],
                     cat=meta["cat"],
                     subcat=meta["subcat"],
                     backid=meta["backid"],

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -3,6 +3,8 @@ import time
 
 import web
 
+from libweasyl import ratings
+
 from weasyl import define, index, macro, search, template, profile, siteupdate, submission
 from weasyl.controllers.base import controller_base
 
@@ -43,7 +45,25 @@ class search_(controller_base):
                 "nextid": int(form.nextid) if form.nextid else None,
             }
 
-            query, next_count, back_count = search.select(self.user_id, rating, limit=63, **meta)
+            search_query = search.Query.parse(meta["q"], find)
+
+            if search_query.find == "user":
+                query = search.select_users(meta["q"])
+                next_count = back_count = 0
+            else:
+                search_query.ratings.update(ratings.CHARACTER_MAP[rating_code].code for rating_code in meta["rated"])
+
+                query, next_count, back_count = search.select(
+                    self.user_id,
+                    rating=rating,
+                    limit=63,
+                    search=search_query,
+                    within=meta["within"],
+                    rated=meta["rated"],
+                    cat=meta["cat"],
+                    subcat=meta["subcat"],
+                    backid=meta["backid"],
+                    nextid=meta["nextid"])
 
             page.append(define.render("etc/search.html", [
                 # Search method

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -90,7 +90,7 @@ class Query:
             tag = d.get_search_tag(criterion)
             add_nonempty(self.required_includes, tag)
 
-    def __bool__(self):
+    def __nonzero__(self):
         return bool(
             self.possible_includes or
             self.required_includes or

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -135,7 +135,7 @@ def select_users(q):
 
 
 def select(userid, rating, limit,
-           search, within, rated, cat, subcat, backid, nextid):
+           search, within, cat, subcat, backid, nextid):
     type_code, type_letter, table, select, subtype = _table_information[search.find]
 
     # Begin statement

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -73,6 +73,14 @@ def select_list(map_table, targetids):
     return dict(list(db.execute(q)))
 
 
+def get_ids(names):
+    result = d.engine.execute(
+        "SELECT tagid, title FROM searchtag WHERE title = ANY (%(names)s)",
+        names=list(names))
+
+    return {row.title: row.tagid for row in result}
+
+
 def suggest(userid, target):
     if not target:
         return []

--- a/weasyl/test/test_search.py
+++ b/weasyl/test/test_search.py
@@ -6,28 +6,35 @@ from weasyl.test import db_utils
 from weasyl import search
 
 
-def do_search(query, find):
-    terms = {
-        'cat': None, 'subcat': None, 'within': '', 'rated': [],
-        'q': query, 'find': find, 'backid': None, 'nextid': None
-    }
-    return search.select(None, ratings.GENERAL.code, 100, **terms)
+def test_query_parsing():
+    assert not search.Query.parse('', 'submit')
+    assert not search.Query.parse('#character', 'submit')
+    assert search.Query.parse('tag_that_does_not_exist', 'submit')
+
+    query = search.Query.parse('one, two +three & -four |five |six user:a +user:b -user:c #general #moderate #submission', 'journal')
+
+    assert query.possible_includes == {'five', 'six'}
+    assert query.required_includes == {'one', 'two', 'three'}
+    assert query.required_excludes == {'four'}
+    assert query.required_user_includes == {'a', 'b'}
+    assert query.required_user_excludes == {'c'}
+    assert query.ratings == {ratings.GENERAL.code, ratings.MODERATE.code}
+    assert query.find == 'submit'
 
 
-@pytest.mark.parametrize(['term', 'category', 'n_results'], [
-    (u"shouldmatchnothing", "submit", 0),
-    (u"shouldmatchnothing\\k", "user", 0),
-    (u"nobodyatall", "user", 0),
-    (u"JasonAG", "user", 1),
-    (u"Jason", "user", 1),
-    (u"rob", "user", 1),
-    (u"twisted", "user", 2),
-    (u"sam", "user", 2),
-    (u"jason otherkin", "user", 2),
-    (u"ryan wildlife calvin", "user", 3),
-    (u"Marth", "user", 1),
+@pytest.mark.parametrize(['term', 'n_results'], [
+    (u"shouldmatchnothing\\k", 0),
+    (u"nobodyatall", 0),
+    (u"JasonAG", 1),
+    (u"Jason", 1),
+    (u"rob", 1),
+    (u"twisted", 2),
+    (u"sam", 2),
+    (u"jason otherkin", 2),
+    (u"ryan wildlife calvin", 3),
+    (u"Marth", 1),
 ])
-def test_user_search(db, term, category, n_results):
+def test_user_search(db, term, n_results):
     config = CharSettings({'use-only-tag-blacklist'}, {}, {})
     db_utils.create_user("Sam Peacock", username="sammy", config=config)
     db_utils.create_user("LionCub", username="spammer2800", config=config)
@@ -39,7 +46,7 @@ def test_user_search(db, term, category, n_results):
     db_utils.create_user("Twisted Mindset", username="twistedm", config=config)
     db_utils.create_user("Martha", config=config)
 
-    results, _, _ = do_search(term, category)
+    results = search.select_users(term)
     assert len(results) == n_results
 
 
@@ -50,5 +57,5 @@ def test_user_search_ordering(db):
     db_utils.create_user("user_Ab", username="userab", config=config)
     db_utils.create_user("user_Bb", username="userbb", config=config)
 
-    results, _, _ = do_search(u"user", "user")
+    results = search.select_users(u"user")
     assert [user["title"] for user in results] == ["user_aa", "user_Ab", "user_ba", "user_Bb"]


### PR DESCRIPTION
This might make searches take less than 20 seconds. If it does, we should be able to use it for tag blacklists, too.