### PR TITLE
Improve search performance a bit more

### DIFF
--- a/templates/etc/search.html
+++ b/templates/etc/search.html
@@ -1,4 +1,4 @@
-$def with (method, meta, results, next_count=0, back_count=0, subcats=None)
+$def with (method, meta, results, next_count=0, back_count=0, subcats=None, count_limit=None)
 $#:{TITLE("Weasyl Search")}
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 $code:
@@ -99,9 +99,9 @@ $code:
 
         <div style="padding-top: 1.4em;" class="pad-left pad-right">
           $if back_count:
-            <a class="button" href="/search?${QUERY_STRING(dict(meta, backid=results[0][id_fields[meta['find']]], nextid=None))}" rel="prev">Back (${back_count} more)</a>
+            <a class="button" href="/search?${QUERY_STRING(dict(meta, backid=results[0][id_fields[meta['find']]], nextid=None))}" rel="prev">Back (${back_count}$:{'+' if back_count == count_limit else ''} more)</a>
           $if next_count:
-            <a class="button" style="float:right;" href="/search?${QUERY_STRING(dict(meta, nextid=results[-1][id_fields[meta['find']]], backid=None))}" rel="next">Next (${next_count} more)</a>
+            <a class="button" style="float:right;" href="/search?${QUERY_STRING(dict(meta, nextid=results[-1][id_fields[meta['find']]], backid=None))}" rel="next">Next (${next_count}$:{'+' if next_count == count_limit else ''} more)</a>
         </div>
       $else:
         <p class="pad-left pad-right" style="padding-top: 2em;">There are no search results to display. You may want to <a class="color-a" href="/search">browse for content</a> or edit your search criteria.</p>

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -75,6 +75,7 @@ class search_(controller_base):
                 back_count,
                 # Submission subcategories
                 macro.MACRO_SUBCAT_LIST,
+                search.count_limit,
             ]))
         elif form.find:
             query = search.browse(self.user_id, rating, 66, form)

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -54,7 +54,7 @@ class search_(controller_base):
                 search_query.ratings.update(ratings.CHARACTER_MAP[rating_code].code for rating_code in meta["rated"])
 
                 query, next_count, back_count = search.select(
-                    self.user_id,
+                    userid=self.user_id,
                     rating=rating,
                     limit=63,
                     search=search_query,

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -189,12 +189,11 @@ def _find_without_media(userid, rating, limit,
             statement_from.append(
                 "INNER JOIN watchuser ON (watchuser.userid, watchuser.otherid) = (%(userid)s, content.userid)")
 
-    # Search within rating
-    if userid and search.ratings:
-        statement_where.append("AND content.rating = ANY (%(ratings)s)")
+        # Search within rating
+        if search.ratings:
+            statement_where.append("AND content.rating = ANY (%(ratings)s)")
 
-    # Blocked tags and ignored users
-    if userid:
+        # Blocked tags and ignored users
         statement_where.append("""
             AND NOT EXISTS (
                 SELECT 0 FROM ignoreuser

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -317,7 +317,7 @@ def select(userid, rating, limit,
         "required_include_count": len(search.required_includes),
     }
 
-    query = d.engine.execute(statement, **params)
+    query = d.engine.execute(statement, params)
 
     ret = [{
         "contype": type_code,
@@ -342,22 +342,22 @@ def select(userid, rating, limit,
 
     if backid:
         back_count = d.engine.execute(
-            make_statement("SELECT COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s) _"), **params).scalar() - len(ret)
+            make_statement("SELECT COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s) _"), params).scalar() - len(ret)
     elif nextid:
         back_count = (d.engine.execute(
             make_statement("SELECT COUNT(*) FROM (SELECT 1", "AND content.{select} >= %(nextid)s", " LIMIT %(count_limit)s) _"),
-            **params).scalar())
+            params).scalar())
     else:
         back_count = 0
 
     if backid:
         next_count = (d.engine.execute(
             make_statement("SELECT COUNT(*) FROM (SELECT 1", "AND content.{select} <= %(backid)s", " LIMIT %(count_limit)s) _"),
-            **params).scalar())
+            params).scalar())
         return list(reversed(ret)), next_count, back_count
     else:
         next_count = d.engine.execute(
-            make_statement("SELECT COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s) _"), **params).scalar() - len(ret)
+            make_statement("SELECT COUNT(*) FROM (SELECT 1", pagination_filter, " LIMIT %(count_limit)s + %(limit)s) _"), params).scalar() - len(ret)
         return ret, next_count, back_count
 
 

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import re
 import web
 

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -7,23 +7,23 @@ from weasyl import character, journal, media, searchtag, submission
 from weasyl import define as d
 
 
-_query_find_modifiers = {
+_QUERY_FIND_MODIFIERS = {
     "#submission": "submit",
     "#character": "char",
     "#journal": "journal",
     "#user": "user",
 }
 
-_query_rating_modifiers = {
+_QUERY_RATING_MODIFIERS = {
     "#general": GENERAL.code,
     "#moderate": MODERATE.code,
     "#mature": MATURE.code,
     "#explicit": EXPLICIT.code,
 }
 
-_query_delimiter = re.compile(r"[\s,;]+")
+_QUERY_DELIMITER = re.compile(r"[\s,;]+")
 
-_table_information = {
+_TABLE_INFORMATION = {
     "submit": (10, "s", "submission", "submitid", "subtype"),
     # The subtype values for characters and journals are fake
     # and set to permit us to reuse the same sql query.
@@ -31,7 +31,7 @@ _table_information = {
     "journal": (30, "j", "journal", "journalid", 3999),
 }
 
-count_limit = 10000
+COUNT_LIMIT = 10000
 
 
 class Query:
@@ -49,13 +49,13 @@ class Query:
             if item:
                 s.add(item)
 
-        find_modifier = _query_find_modifiers.get(criterion)
+        find_modifier = _QUERY_FIND_MODIFIERS.get(criterion)
 
         if find_modifier:
             self.find = find_modifier
             return
 
-        rating_modifier = _query_rating_modifiers.get(criterion)
+        rating_modifier = _QUERY_RATING_MODIFIERS.get(criterion)
 
         if rating_modifier:
             self.ratings.add(rating_modifier)
@@ -96,7 +96,7 @@ class Query:
         """
         query = Query()
 
-        for criterion in _query_delimiter.split(query_string.strip()):
+        for criterion in _QUERY_DELIMITER.split(query_string.strip()):
             if criterion:
                 query.add_criterion(criterion)
 
@@ -138,7 +138,7 @@ def select_users(q):
 
 def _find_without_media(userid, rating, limit,
                         search, within, cat, subcat, backid, nextid):
-    type_code, type_letter, table, select, subtype = _table_information[search.find]
+    type_code, type_letter, table, select, subtype = _TABLE_INFORMATION[search.find]
 
     # Begin statement
     statement_with = ""
@@ -310,7 +310,7 @@ def _find_without_media(userid, rating, limit,
         "category": cat,
         "subcategory": subcat,
         "limit": limit,
-        "count_limit": count_limit,
+        "count_limit": COUNT_LIMIT,
         "backid": backid,
         "nextid": nextid,
         "required_include_count": len(search.required_includes),

--- a/weasyl/test/test_search.py
+++ b/weasyl/test/test_search.py
@@ -120,7 +120,7 @@ def test_search_pagination(db):
 
     assert back_count == 0
     assert next_count == search.COUNT_LIMIT
-    assert [item['submitid'] for item in result] == submissions[:-_page_limit-1:-1]
+    assert [item['submitid'] for item in result] == submissions[:-_page_limit - 1:-1]
 
     result, next_count, back_count = search.select(
         search=search_query,
@@ -129,7 +129,7 @@ def test_search_pagination(db):
 
     assert back_count == _page_limit
     assert next_count == search.COUNT_LIMIT
-    assert [item['submitid'] for item in result] == submissions[-_page_limit-1:-2*_page_limit-1:-1]
+    assert [item['submitid'] for item in result] == submissions[-_page_limit - 1:-2 * _page_limit - 1:-1]
 
     result, next_count, back_count = search.select(
         search=search_query,
@@ -138,7 +138,7 @@ def test_search_pagination(db):
 
     assert back_count == search.COUNT_LIMIT
     assert next_count == _page_limit
-    assert [item['submitid'] for item in result] == submissions[2*_page_limit-1:_page_limit-1:-1]
+    assert [item['submitid'] for item in result] == submissions[2 * _page_limit - 1:_page_limit - 1:-1]
 
 
 @pytest.mark.parametrize(['term', 'n_results'], [

--- a/weasyl/test/test_search.py
+++ b/weasyl/test/test_search.py
@@ -103,7 +103,7 @@ def test_search_blocked_tags(db, rating, block_rating):
 _page_limit = 6
 
 
-@mock.patch.object(search, 'count_limit', 10)
+@mock.patch.object(search, 'COUNT_LIMIT', 10)
 def test_search_pagination(db):
     owner = db_utils.create_user()
     submissions = [db_utils.create_submission(owner, rating=ratings.GENERAL.code) for i in range(30)]
@@ -119,7 +119,7 @@ def test_search_pagination(db):
         cat=None, subcat=None, within='', backid=None, nextid=None)
 
     assert back_count == 0
-    assert next_count == search.count_limit
+    assert next_count == search.COUNT_LIMIT
     assert [item['submitid'] for item in result] == submissions[:-_page_limit-1:-1]
 
     result, next_count, back_count = search.select(
@@ -128,7 +128,7 @@ def test_search_pagination(db):
         cat=None, subcat=None, within='', backid=None, nextid=submissions[-_page_limit])
 
     assert back_count == _page_limit
-    assert next_count == search.count_limit
+    assert next_count == search.COUNT_LIMIT
     assert [item['submitid'] for item in result] == submissions[-_page_limit-1:-2*_page_limit-1:-1]
 
     result, next_count, back_count = search.select(
@@ -136,7 +136,7 @@ def test_search_pagination(db):
         userid=owner, rating=ratings.EXPLICIT.code, limit=_page_limit,
         cat=None, subcat=None, within='', backid=submissions[_page_limit - 1], nextid=None)
 
-    assert back_count == search.count_limit
+    assert back_count == search.COUNT_LIMIT
     assert next_count == _page_limit
     assert [item['submitid'] for item in result] == submissions[2*_page_limit-1:_page_limit-1:-1]
 


### PR DESCRIPTION
- Use an array-based blocktag check (dropped query time from 18s to 3s in one case)
- Stop counting search results after 10,000 (maybe we can stop measuring query time in seconds)