### PR TITLE
Add a CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,81 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+Sexual imagery, language, or examples related to site behavior (such as
+explicit visual submissions that exhibit a bug) are permitted so long as:
+
+* They are relevant to the topic of discussion and presented in a
+  respectful manner
+* They are labeled with appropriate warnings and linked in a manner such
+  that one can choose not to view them
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at conduct@weasyl.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -31,7 +31,7 @@ Examples of unacceptable behavior by participants include:
   professional setting
 
 Sexual imagery, language, or examples related to site behavior (such as
-explicit visual submissions that exhibit a bug) are permitted so long as:
+explicit visual submissions that exhibit a bug) are permitted only if:
 
 * They are relevant to the topic of discussion and presented in a
   respectful manner

--- a/README.rst
+++ b/README.rst
@@ -68,15 +68,22 @@ the project's `gitter room <https://gitter.im/Weasyl/weasyl>`_.
 
 The above instructions have been tested on Linux and OS X. It should be possible
 to run Weasyl in a virtual environment under Windows, but it hasn't been thoroughly
-tested. 
+tested.
 
-When developing under Windows hosts with a Linux guest, ensure that either Intel VT-x/EPT 
-or AMD-V/RVI are exposed to the virtual machine (e.g., the "Virtualize Intel VT-x/EPT or 
-AMD-V/RVI" setting under the Processors device settings for the guest VM in VMware). If 
-this setting is not selected, the configuration of the Weasyl VM via ``make setup-vagrant`` 
-may hang when Vagrant attempts to SSH to the VM to perform configuration of the guest. 
+When developing under Windows hosts with a Linux guest, ensure that either Intel VT-x/EPT
+or AMD-V/RVI are exposed to the virtual machine (e.g., the "Virtualize Intel VT-x/EPT or
+AMD-V/RVI" setting under the Processors device settings for the guest VM in VMware). If
+this setting is not selected, the configuration of the Weasyl VM via ``make setup-vagrant``
+may hang when Vagrant attempts to SSH to the VM to perform configuration of the guest.
 
+
+Code of Conduct
+---------------
+
+Please note that this project is released with a `Contributor Code of Conduct`_. By
+participating in this project you agree to abide by its terms.
 
 .. _Weasyl: https://www.weasyl.com
 .. _Vagrant: https://www.vagrantup.com
 .. _VirtualBox: https://www.virtualbox.org
+.. _Contributor Code of Conduct: CODE_OF_CONDUCT.md


### PR DESCRIPTION
The code of conduct is adapted from http://contributor-covenant.org/.
It has been altered slightly to account for the often explicit
content hosted by this project.