### PR TITLE
Make 'make-test' work when pytest or flake8 not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ guest-run: .vagrant
 # Phony target to run tests
 .PHONY: test
 test: setup
+	$(VE)/bin/pip install $(USE_WHEEL) pytest flake8
 	WEASYL_ROOT=$(shell pwd) $(VE)/bin/py.test weasyl/test
 
 # Phony target for an interactive shell

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ $(VE): etc/requirements.txt
 	test -e $@ || { virtualenv $@; cp etc/pip.conf $@ ; \
                $@/bin/pip install -U pip setuptools -i https://pypi.python.org/simple ; }
 	$@/bin/pip install $(USE_WHEEL) -r etc/requirements.txt
+	$@/bin/pip install $(USE_WHEEL) pytest flake8
 	touch $@
 
 .PHONY: install-libweasyl
@@ -108,7 +109,6 @@ guest-run: .vagrant
 # Phony target to run tests
 .PHONY: test
 test: setup
-	$(VE)/bin/pip install $(USE_WHEEL) pytest flake8
 	WEASYL_ROOT=$(shell pwd) $(VE)/bin/py.test weasyl/test
 
 # Phony target for an interactive shell


### PR DESCRIPTION
Installs both the python libraries pytest and flake8 when 'make test' is run and neither of these libraries are installed in weasyl-env.