### PR TITLE
Update raven library version to 5.21.0

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -4,7 +4,7 @@ service_identity==16.0.0    # Newer Twisted wants this for cert verification
 Twisted==16.2.0
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
-raven==5.19.0               # as above
+raven==5.21.0               # as above
 pyOpenSSL==16.0.0           # and again
 requests[security]==2.10.0
 oauth2==1.9.0.post1


### PR DESCRIPTION
Fixes a bug at submit time to sentry in certain circumstances, where exceptions cause 'ValueError: too many values to unpack'.