### PR TITLE
Speed up Recently Popular calculation

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/d0bffaa55b06_index_favorites_by_unixtime.py
+++ b/libweasyl/libweasyl/alembic/versions/d0bffaa55b06_index_favorites_by_unixtime.py
@@ -1,0 +1,22 @@
+"""Index favorites by unixtime
+
+Revision ID: d0bffaa55b06
+Revises: 9afc9a45510c
+Create Date: 2016-06-17 20:17:14.270674
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd0bffaa55b06'
+down_revision = '9afc9a45510c'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ind_favorite_unixtime', 'favorite', ['unixtime'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ind_favorite_unixtime', table_name='favorite')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -218,6 +218,7 @@ favorite = Table(
 
 Index('ind_favorite_userid', favorite.c.userid)
 Index('ind_favorite_type_targetid', favorite.c.type, favorite.c.targetid, unique=False)
+Index('ind_favorite_unixtime', favorite.c.unixtime)
 
 
 folder = Table(

--- a/weasyl/index.py
+++ b/weasyl/index.py
@@ -65,7 +65,7 @@ def filter_submissions(userid, submissions, incidence_limit=3):
     rating = ratings.GENERAL.code
     if userid:
         rating = d.get_rating(userid)
-        blocked_tags = blocktag.cached_select(userid)
+        blocked_tags = blocktag.select_ids(userid)
         ignored_users = set(ignoreuser.cached_list_ignoring(userid))
 
     submitter_incidence = collections.defaultdict(int)

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -62,11 +62,10 @@ def select_list(map_table, targetids):
         return {}
 
     mt = map_table
-    st = d.meta.tables['searchtag']
     q = (
         d.sa
-        .select([mt.c.targetid, d.sa.func.array_agg(st.c.title)])
-        .select_from(mt.join(st, mt.c.tagid == st.c.tagid))
+        .select([mt.c.targetid, d.sa.func.array_agg(mt.c.tagid)])
+        .select_from(mt)
         .where(mt.c.targetid.in_(targetids))
         .group_by(mt.c.targetid))
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1042,7 +1042,7 @@ def select_recently_popular():
 
     To calculate scores, this method performs the following evaluation:
 
-    item_score = log(item_fave_count) + log(item_view_counts) / 2 + submission_time / 180000
+    item_score = log(item_fave_count + 1) + log(item_view_counts) / 2 + submission_time / 180000
 
     180000 is roughly two days. So intuitively an item two days old needs an order of
     magnitude more favorites/views compared to a fresh one. Also the favorites are
@@ -1055,7 +1055,9 @@ def select_recently_popular():
 
     query = d.engine.execute("""
         SELECT
-            log(count(favorite.*) + 1) + log(submission.page_views + 1) / 2 + submission.unixtime / 180000 AS score,
+            log(count(favorite.*) + 1) +
+                log(submission.page_views + 1) / 2 +
+                submission.unixtime / 180000 AS score,
             submission.submitid,
             submission.title,
             submission.rating,

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1,6 +1,5 @@
 # submission.py
 
-import datetime
 import urlparse
 
 import arrow
@@ -27,7 +26,6 @@ import ignoreuser
 import collection
 
 from libweasyl.cache import region
-from libweasyl.models import content, meta, users
 from libweasyl import html, images, text, ratings, staff
 
 from weasyl import api, media, orm, twits
@@ -1053,41 +1051,32 @@ def select_recently_popular():
 
     :return: A list of submission dictionaries, in score-rank order.
     """
-    db = meta.Base.dbsession
-    subq = (
-        db.query(content.Favorite.targetid, sa.func.count().label('faves'))
-        .filter_by(type='s')
-        .group_by(content.Favorite.targetid)
-        .subquery())
-    score = (
-        sa.func.log(sa.func.greatest(sa.func.coalesce(subq.c.faves, 0), 1)) +
-        sa.func.log(sa.func.greatest(content.Submission.page_views, 1)) / 2 +
-        sa.cast(content.Submission.unixtime, sa.types.INTEGER) / 180000).label('score')
-    q = (
-        db.query(content.Submission, users.Profile, score)
-        .options(sa.orm.joinedload('tag_objects'))
-        .filter(~content.Submission.is_hidden, ~content.Submission.is_friends_only)
-        .outerjoin(subq, content.Submission.submitid == subq.c.targetid)
-        .join(users.Profile, content.Submission.userid == users.Profile.userid)
-        .order_by(score.desc()))
-
     max_days = int(d.config_read_setting("popular_max_age_days", "21"))
-    if max_days > 0:
-        q = q.filter(content.Submission.unixtime >
-                     sa.func.extract('EPOCH', sa.func.now() - datetime.timedelta(days=max_days)))
-    q = q.limit(128)
 
-    submissions = [{
-        'contype': 10,
-        'score': sc,
-        'submitid': s.submitid,
-        'title': s.title,
-        'rating': s.rating.code,
-        'subtype': s.subtype,
-        'unixtime': s.unixtime.timestamp,
-        'tags': list(s.tags),
-        'userid': s.userid,
-        'username': p.username,
-    } for s, p, sc in q.all()]
+    query = d.engine.execute("""
+        SELECT
+            log(count(favorite.*) + 1) + log(submission.page_views + 1) / 2 + submission.unixtime / 180000 AS score,
+            submission.submitid,
+            submission.title,
+            submission.rating,
+            submission.subtype,
+            submission.unixtime,
+            submission_tags.tags,
+            submission.userid,
+            profile.username
+        FROM submission
+            INNER JOIN submission_tags ON submission.submitid = submission_tags.submitid
+            INNER JOIN profile ON submission.userid = profile.userid
+            LEFT JOIN favorite ON favorite.type = 's' AND submission.submitid = favorite.targetid
+        WHERE
+            submission.unixtime > EXTRACT(EPOCH FROM now() - %(max_days)s * INTERVAL '1 day')::INTEGER AND
+            (favorite.unixtime IS NULL OR favorite.unixtime > EXTRACT(EPOCH FROM now() - %(max_days)s * INTERVAL '1 day')::INTEGER) AND
+            submission.settings !~ '[hf]'
+        GROUP BY submission.submitid, submission_tags.submitid, profile.userid
+        ORDER BY score DESC
+        LIMIT 128
+    """, max_days=max_days)
+
+    submissions = [dict(row, contype=10) for row in query]
     media.populate_with_submission_media(submissions)
     return submissions


### PR DESCRIPTION
Taking advantage of the fact that you can’t favorite something before it’s created, this reduces the number of favorite rows read from 5.5 million to a few thousand. (It’s possible to do the same thing without adding an index, but this makes the query neater.)