### PR TITLE
Sentry error-reporting improvements

### DIFF
--- a/weasyl/http.py
+++ b/weasyl/http.py
@@ -1,0 +1,8 @@
+def get_headers(wsgi_env):
+    """
+    Extracts HTTP_* variables from a WSGI environment as
+    title-cased header names.
+    """
+    return {
+        key[5:].replace('_', '-').title(): value
+        for key, value in wsgi_env.iteritems() if key.startswith('HTTP_')}

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -166,7 +166,7 @@ class SentryEnvironmentMiddleware(object):
         self.app = app
         self.client = raven.Client(
             dsn=dsn,
-            release=raven.fetch_git_sha(os.path.abspath(os.path.join(__file__, '../..'))),
+            release=d.CURRENT_SHA,
             processors=[
                 'raven.processors.SanitizePasswordsProcessor',
                 'weasyl.middleware.RemoveSessionCookieProcessor',

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -103,7 +103,7 @@ def weasyl_exception_processor():
         request_id = None
         if 'raven.captureException' in web.ctx.env:
             request_id = base64.b64encode(os.urandom(6), '+-')
-            event_id, = web.ctx.env['raven.captureException'](request_id=request_id)
+            event_id = web.ctx.env['raven.captureException'](request_id=request_id)
             request_id = '%s-%s' % (event_id, request_id)
         print 'unhandled error (request id %s) in %r' % (request_id, web.ctx.env)
         traceback.print_exc()

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -19,14 +19,9 @@ from libweasyl import security
 from libweasyl.cache import ThreadCacheProxy
 from weasyl import define as d
 from weasyl import errorcode
+from weasyl import http
 from weasyl import orm
 from weasyl.error import WeasylError
-
-
-def _get_headers(env):
-    return {
-        key[5:].replace('_', '-').title(): value
-        for key, value in env.iteritems() if key.startswith('HTTP_')}
 
 
 class ClientGoneAway(Exception):
@@ -188,7 +183,7 @@ class SentryEnvironmentMiddleware(object):
                 'method': web.ctx.env['REQUEST_METHOD'],
                 'data': web.webapi.rawinput(method='POST'),
                 'query_string': web.ctx.env['QUERY_STRING'],
-                'headers': _get_headers(web.ctx.env),
+                'headers': http.get_headers(web.ctx.env),
                 'env': web.ctx.env,
             },
         }

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -147,16 +147,8 @@ class RemoveSessionCookieProcessor(raven.processors.Processor):
         if 'headers' in data and 'Cookie' in data['headers']:
             data['headers']['Cookie'] = self._filter_header(data['headers']['Cookie'])
 
-    def filter_extra(self, data):
-        if 'env' not in data or 'HTTP_COOKIE' not in data['env']:
-            return data
-
-        env = data['env']
-        filtered_cookies = self._filter_header(env['HTTP_COOKIE'])
-
-        return dict(
-            data,
-            env=dict(env, HTTP_COOKIE=filtered_cookies))
+        if 'env' in data and 'HTTP_COOKIE' in data['env']:
+            data['env']['HTTP_COOKIE'] = self._filter_header(data['env']['HTTP_COOKIE'])
 
 
 class URLSchemeFixingMiddleware(object):

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -5,11 +5,11 @@ import web
 from libweasyl.oauth import get_consumers_for_user, revoke_consumers_for_user, server
 from weasyl.controllers.base import controller_base
 from weasyl import define as d
-from weasyl import errorcode, login, media, orm
+from weasyl import errorcode, http, login, media, orm
 
 
 def extract_params():
-    headers = {k[5:].replace('_', '-').title(): v for k, v in web.ctx.env.iteritems() if k.startswith('HTTP_')}
+    headers = http.get_headers(web.ctx.env)
     return web.ctx.path, web.ctx.method, web.input(), headers
 
 

--- a/weasyl/test/test_http.py
+++ b/weasyl/test/test_http.py
@@ -1,0 +1,16 @@
+import pytest
+
+from weasyl import http
+
+
+@pytest.mark.parametrize(('wsgi_env', 'expected'), [
+    ({}, {}),
+    ({'PATH_INFO': '/search', 'QUERY_STRING': 'q=example'}, {}),
+    ({'HTTP_ACCEPT': '*/*'}, {'Accept': '*/*'}),
+    (
+        {'CONTENT_LENGTH': '', 'HTTP_ACCEPT_ENCODING': 'gzip', 'HTTP_UPGRADE_INSECURE_REQUESTS': '1'},
+        {'Accept-Encoding': 'gzip', 'Upgrade-Insecure-Requests': '1'},
+    ),
+])
+def test_get_headers(wsgi_env, expected):
+    assert http.get_headers(wsgi_env) == expected


### PR DESCRIPTION
- Restores friendly error pages by fixing #78
- Strips session ids from events
- Uses built-in fields for event data when available so Sentry can add useful widgets

Tested using a local Sentry instance.