### PR TITLE
Remove 'cached=true' from templates

### DIFF
--- a/templates/detail/character.html
+++ b/templates/detail/character.html
@@ -145,10 +145,10 @@ $def with (myself, query, violations)
   <div id="detail-comments">
     $if query['comments']:
       <h3>Comments</h3>
-      $:{RENDER("common/comment_thread.html", ["detail_comments", query['comments'], "char", myself, query['charid'], query['userid']], cached = True)}
+      $:{RENDER("common/comment_thread.html", ["detail_comments", query['comments'], "char", myself, query['charid'], query['userid']])}
     $if myself:
       <h3>Leave a Comment</h3>
-      $:{RENDER("common/comment_form.html", [myself, query['charid'], "char"], cached = True)}
+      $:{RENDER("common/comment_form.html", [myself, query['charid'], "char"])}
   </div><!-- /detail-comments -->
 
 </div><!-- /detail-content -->

--- a/templates/detail/journal.html
+++ b/templates/detail/journal.html
@@ -125,10 +125,10 @@ $def with (myself, query, violations)
   <div id="detail-comments">
     $if query['comments']:
       <h3>Comments</h3>
-      $:{RENDER("common/comment_thread.html", ["detail_comments", query['comments'], "journal", myself, query['journalid'], query['userid']], cached = True)}
+      $:{RENDER("common/comment_thread.html", ["detail_comments", query['comments'], "journal", myself, query['journalid'], query['userid']])}
     $if myself:
       <h3>Leave a Comment</h3>
-      $:{RENDER("common/comment_form.html", [myself, query['journalid'], "journal"], cached = True)}
+      $:{RENDER("common/comment_form.html", [myself, query['journalid'], "journal"])}
   </div><!-- /detail-comments -->
 
 </div><!-- /detail_content -->

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -155,7 +155,7 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
     $if(shouts):
       $:{RENDER("common/comment_thread.html", ["user_comments", shouts, "userid", myself, None, profile['userid']])}
     $if(myself):
-      $:{RENDER("common/comment_form.html", [myself, profile['userid'], "shouts"], cached = True)}
+      $:{RENDER("common/comment_form.html", [myself, profile['userid'], "shouts"])}
   </div><!-- /user-shouts -->
 
 </div><!-- /user-content -->

--- a/templates/user/shouts.html
+++ b/templates/user/shouts.html
@@ -26,5 +26,5 @@ $def with (profile, userinfo, relationship, myself, shouts, feature)
   $else:
     There are no ${'staff notes' if feature == "staffnotes" else 'comments'} to display.
   $if(myself):
-    $:{RENDER("common/comment_form.html", [myself, profile['userid'], feature], cached = True)}
+    $:{RENDER("common/comment_form.html", [myself, profile['userid'], feature])}
 </div><!-- /shouts-content -->


### PR DESCRIPTION
Finish removing cached parameters from templates; leaving the 'cached=true' in broke the template when attempting to view the template in question.

No further instances of ``cached = true`` exist in templates per ``git grep cached``.