### PR TITLE
Implements pyca/bcrypt

### DIFF
--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,15 +1,15 @@
 alembic==0.8.6
 anyjson==0.3.3
 arrow==0.7.0
+bcrypt==3.1.0
 dogpile.cache==0.5.7
 dogpile.core==0.4.1
 lxml==3.6.0
 misaka==1.0.3+weasyl.6    # https://github.com/Weasyl/misaka
 oauthlib==1.1.1
 psycopg2==2.6.1
-py-bcrypt==0.4
 pytz==2016.4
+pyyaml==3.11
 sanpera==0.1.1+weasyl.6   # https://github.com/Weasyl/sanpera
 sqlalchemy==1.0.13
 translationstring==1.3
-pyyaml==3.11


### PR DESCRIPTION
Changes out py-bcrypt for pyca/bcrypt==3.1.0. This version landed on PyPI a short while ago, and now includes the checkpw() function. Unicode still needed to be encoded to utf-8.

Fixes Issue #52.