### PR TITLE
Unbreak the Awesome People page (SCSS/CSS Styles)

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -4078,13 +4078,6 @@ img + #detail-art-text {
     width: 47%;
     padding: 0 2% 0.5em 0;
     vertical-align: top;
-    word-wrap: break-word;
-}
-
-@media (min-width: 30em) {
-    .donator-list > li {
-        width: 30%;
-    }
 }
 
 @media (min-width: 45em) {


### PR DESCRIPTION
Resolves Issue #72. Removes two SCSS rules that applied to the /thanks page's donator-list class. The rules removed were the same ones identified in the issue.