### PR TITLE
Improve Recently Popular performance without index

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/48ab4dc5599f_do_not_index_favorites_by_unixtime.py
+++ b/libweasyl/libweasyl/alembic/versions/48ab4dc5599f_do_not_index_favorites_by_unixtime.py
@@ -1,0 +1,22 @@
+"""Do not index favorites by unixtime
+
+Revision ID: 48ab4dc5599f
+Revises: d0bffaa55b06
+Create Date: 2016-07-05 21:37:22.666480
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '48ab4dc5599f'
+down_revision = 'd0bffaa55b06'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_index('ind_favorite_unixtime', table_name='favorite')
+
+
+def downgrade():
+    op.create_index('ind_favorite_unixtime', 'favorite', ['unixtime'], unique=False)

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -218,7 +218,6 @@ favorite = Table(
 
 Index('ind_favorite_userid', favorite.c.userid)
 Index('ind_favorite_type_targetid', favorite.c.type, favorite.c.targetid, unique=False)
-Index('ind_favorite_unixtime', favorite.c.unixtime)
 
 
 folder = Table(


### PR DESCRIPTION
PostgreSQL insists on picking the new unixtime index for other favorites operations, making them run slowly. We could do a bunch of manual tuning, or do this instead, because it’s more efficient.