### PR TITLE
Index media by sha256

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/c8c088918278_index_media_by_sha256.py
+++ b/libweasyl/libweasyl/alembic/versions/c8c088918278_index_media_by_sha256.py
@@ -1,0 +1,22 @@
+"""Index media by sha256
+
+Revision ID: c8c088918278
+Revises: 48ab4dc5599f
+Create Date: 2016-07-06 11:47:57.436197
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c8c088918278'
+down_revision = '48ab4dc5599f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ind_media_sha256', 'media', ['sha256'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ind_media_sha256', table_name='media')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -424,6 +424,8 @@ media = Table(
     Column('sha256', String(length=64)),
 )
 
+Index('ind_media_sha256', media.c.sha256)
+
 
 media_media_links = Table(
     'media_media_links', metadata,


### PR DESCRIPTION
Stops `MediaItem.fetch_or_create()` from scanning the entirety of the media table, a process that currently slows every upload down by about a second.