### PR TITLE
Exclude weasyl-apidocs from flake8; add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@
 ;   E711: comparison to None should be ‘if cond is None:’
 ignore = E501,E711
 
-exclude = node_modules,weasyl-env,.git,static,libweasyl/libweasyl/alembic,libweasyl/docs
+exclude = node_modules,weasyl-env,.git,static,libweasyl/libweasyl/alembic,libweasyl/docs,weasyl-apidocs
 
 [pytest]
 addopts = -ra


### PR DESCRIPTION
Maybe the combination will help prevent all this trailing whitespace.