### PR TITLE
Update oauthlib to 1.1.2

### DIFF
--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -6,7 +6,7 @@ dogpile.cache==0.5.7
 dogpile.core==0.4.1
 lxml==3.6.0
 misaka==1.0.3+weasyl.6    # https://github.com/Weasyl/misaka
-oauthlib==1.1.1
+oauthlib==1.1.2
 psycopg2cffi==2.7.4
 pytz==2016.4
 pyyaml==3.11


### PR DESCRIPTION
Fixes <https://sentry.weasyldev.com/weasyl/weasyl/issues/1391/>; see <https://github.com/idan/oauthlib/pull/425>.