### PR TITLE
Return tags with /api/messages/submissions call

### DIFF
--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -3,7 +3,6 @@ from itertools import chain
 from weasyl import character
 from weasyl import define as d
 from weasyl import media
-from weasyl import searchtag
 
 
 notification_clusters = {

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -117,7 +117,7 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 INNER JOIN character ch ON we.targetid = ch.charid
                 INNER JOIN profile pr ON ch.userid = pr.userid
                 LEFT JOIN LATERAL (
-                    SELECT c.charid AS id, string_agg(tags.title, ',') AS tags
+                    SELECT c.charid AS id, array_agg(tags.title) AS tags
                     FROM character as c
                     LEFT JOIN searchmapchar AS cmap ON c.charid = cmap.targetid
                     JOIN searchtag AS tags ON cmap.tagid = tags.tagid
@@ -143,7 +143,7 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON we.otherid = pr.userid
                 LEFT JOIN LATERAL (
-                    SELECT s.submitid AS id, string_agg(tags.title, ',') AS tags
+                    SELECT s.submitid AS id, array_agg(tags.title) AS tags
                     FROM submission AS s
                     LEFT JOIN searchmapsubmit AS smap ON s.submitid = smap.targetid
                     JOIN searchtag AS tags ON smap.tagid = tags.tagid
@@ -169,7 +169,7 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON su.userid = pr.userid
                 LEFT JOIN LATERAL (
-                    SELECT s.submitid AS id, string_agg(tags.title, ',') AS tags
+                    SELECT s.submitid AS id, array_agg(tags.title) AS tags
                     FROM submission AS s
                     LEFT JOIN searchmapsubmit AS smap ON s.submitid = smap.targetid
                     JOIN searchtag AS tags ON smap.tagid = tags.tagid
@@ -206,7 +206,7 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
         "userid": i.userid,
         "username": i.username,
         "subtype": i.subtype,
-        "tags": (i.tags).split(','),
+        "tags": i.tags,
         "sub_media": _fake_media_items(i),
     } for i in query]
 

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -3,6 +3,7 @@ from itertools import chain
 from weasyl import character
 from weasyl import define as d
 from weasyl import media
+from weasyl import searchtag as st
 
 
 notification_clusters = {
@@ -168,18 +169,25 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
         limit=limit,
     )
 
-    results = [{
-        "contype": i.contype,
-        "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,
-        "welcomeid": i.welcomeid,
-        "title": i.title,
-        "rating": i.rating,
-        "unixtime": i.unixtime,
-        "userid": i.userid,
-        "username": i.username,
-        "subtype": i.subtype,
-        "sub_media": _fake_media_items(i),
-    } for i in query]
+    results = []
+    for i in query:
+        if i.contype != _CONTYPE_CHAR:
+            tags = st.select(submitid=i.id)
+        else:
+            tags = st.select(charid=i.id)
+        results.append({
+            "contype": i.contype,
+            "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,
+            "welcomeid": i.welcomeid,
+            "title": i.title,
+            "rating": i.rating,
+            "unixtime": i.unixtime,
+            "userid": i.userid,
+            "username": i.username,
+            "subtype": i.subtype,
+            "tags": tags,
+            "sub_media": _fake_media_items(i),
+        })
 
     media.populate_with_submission_media(
         [i for i in results if i["contype"] != _CONTYPE_CHAR])

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -112,21 +112,19 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 ch.settings,
                 we.welcomeid,
                 0 AS subtype,
-                agg.tags
+                array_agg(tags.title) as tags
             FROM welcome we
                 INNER JOIN character ch ON we.targetid = ch.charid
                 INNER JOIN profile pr ON ch.userid = pr.userid
-                LEFT JOIN LATERAL (
-                    SELECT c.charid AS id, array_agg(tags.title) AS tags
-                    FROM character as c
-                    LEFT JOIN searchmapchar AS cmap ON c.charid = cmap.targetid
-                    JOIN searchtag AS tags ON cmap.tagid = tags.tagid
-                    WHERE cmap.targetid = ch.charid
-                    GROUP BY c.charid
-                ) agg ON agg.id = we.targetid
+                LEFT JOIN searchmapchar AS smc ON ch.charid = smc.targetid
+                JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2050 AND
                 we.userid = %(userid)s
+            GROUP BY
+                ch.charid,
+                pr.username,
+                we.welcomeid
             UNION SELECT
                 40 AS contype,
                 su.submitid AS id,
@@ -138,21 +136,19 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 su.settings,
                 we.welcomeid,
                 su.subtype,
-                agg.tags
+                array_agg(tags.title) as tags
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON we.otherid = pr.userid
-                LEFT JOIN LATERAL (
-                    SELECT s.submitid AS id, array_agg(tags.title) AS tags
-                    FROM submission AS s
-                    LEFT JOIN searchmapsubmit AS smap ON s.submitid = smap.targetid
-                    JOIN searchtag AS tags ON smap.tagid = tags.tagid
-                    WHERE smap.targetid = su.submitid
-                    GROUP BY s.submitid
-                ) agg ON agg.id = we.targetid
+                LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
+                JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2030 AND
                 we.userid = %(userid)s
+            GROUP BY
+                su.submitid,
+                pr.username,
+                we.welcomeid
             UNION SELECT
                 10 AS contype,
                 su.submitid AS id,
@@ -164,21 +160,19 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 su.settings,
                 we.welcomeid,
                 su.subtype,
-                agg.tags
+                array_agg(tags.title) as tags
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON su.userid = pr.userid
-                LEFT JOIN LATERAL (
-                    SELECT s.submitid AS id, array_agg(tags.title) AS tags
-                    FROM submission AS s
-                    LEFT JOIN searchmapsubmit AS smap ON s.submitid = smap.targetid
-                    JOIN searchtag AS tags ON smap.tagid = tags.tagid
-                    WHERE smap.targetid = su.submitid
-                    GROUP BY s.submitid
-                ) agg ON agg.id = we.targetid
+                LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
+                JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2010 AND
                 we.userid = %(userid)s
+            GROUP BY
+                su.submitid,
+                pr.username,
+                we.welcomeid
         ) results
         WHERE
             rating <= %(rating)s

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -3,7 +3,7 @@ from itertools import chain
 from weasyl import character
 from weasyl import define as d
 from weasyl import media
-from weasyl import searchtag as st
+from weasyl import searchtag
 
 
 notification_clusters = {
@@ -172,9 +172,9 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
     results = []
     for i in query:
         if i.contype != _CONTYPE_CHAR:
-            tags = st.select(submitid=i.id)
+            tags = searchtag.select(submitid=i.id)
         else:
-            tags = st.select(charid=i.id)
+            tags = searchtag.select(charid=i.id)
         results.append({
             "contype": i.contype,
             "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -112,12 +112,12 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 ch.settings,
                 we.welcomeid,
                 0 AS subtype,
-                array_agg(tags.title) as tags
+                array_agg(tags.title) AS tags
             FROM welcome we
                 INNER JOIN character ch ON we.targetid = ch.charid
                 INNER JOIN profile pr ON ch.userid = pr.userid
                 LEFT JOIN searchmapchar AS smc ON ch.charid = smc.targetid
-                JOIN searchtag AS tags USING (tagid)
+                LEFT JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2050 AND
                 we.userid = %(userid)s
@@ -136,12 +136,12 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 su.settings,
                 we.welcomeid,
                 su.subtype,
-                array_agg(tags.title) as tags
+                array_agg(tags.title) AS tags
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON we.otherid = pr.userid
                 LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
-                JOIN searchtag AS tags USING (tagid)
+                LEFT JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2030 AND
                 we.userid = %(userid)s
@@ -160,12 +160,12 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 su.settings,
                 we.welcomeid,
                 su.subtype,
-                array_agg(tags.title) as tags
+                array_agg(tags.title) AS tags
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON su.userid = pr.userid
                 LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
-                JOIN searchtag AS tags USING (tagid)
+                LEFT JOIN searchtag AS tags USING (tagid)
             WHERE
                 we.type = 2010 AND
                 we.userid = %(userid)s


### PR DESCRIPTION
The API says tags should already be returned for the ``/api/messages/submissions`` endpoint; so return them. Proposed fix for #86.

Example output, using three submissions, one character. https://paste.weasyldev.com/show/Bl4xWt1qQ9egqlFJkPYO/