### PR TITLE
Update library requirements in requirements files to newest non-betas

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,7 +1,7 @@
 # these are all pinned versions available from https://pypi.weasyldev.com
 zope.interface==4.3.2       # for twisted
 service_identity==16.0.0    # Newer Twisted wants this for cert verification
-Twisted==16.4.1
+Twisted==16.3.2             # Twisted 16.4+ will need additional code work
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
 raven==5.27.0               # as above

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,10 +1,10 @@
 # these are all pinned versions available from https://pypi.weasyldev.com
 zope.interface==4.3.2       # for twisted
 service_identity==16.0.0    # Newer Twisted wants this for cert verification
-Twisted==16.4.0
+Twisted==16.4.1
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
-raven==5.26.0               # as above
+raven==5.27.0               # as above
 pyOpenSSL==16.1.0           # and again
 requests[security]==2.11.1
 oauth2==1.9.0.post1

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,12 +1,12 @@
 # these are all pinned versions available from https://pypi.weasyldev.com
-zope.interface==4.1.3       # for twisted
+zope.interface==4.3.2       # for twisted
 service_identity==16.0.0    # Newer Twisted wants this for cert verification
-Twisted==16.2.0
+Twisted==16.4.0
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
-raven==5.21.0               # as above
-pyOpenSSL==16.0.0           # and again
-requests[security]==2.10.0
+raven==5.26.0               # as above
+pyOpenSSL==16.1.0           # and again
+requests[security]==2.11.1
 oauth2==1.9.0.post1
 python-memcached==1.58
 txstatsd==1.0.0+weasyl.2    # https://github.com/Weasyl/txstatsd
@@ -14,5 +14,5 @@ crochet==1.5.0
 txyam2==0.5.1+weasyl.1      # https://github.com/Weasyl/txyam2
 mock==2.0.0
 Dozer==0.5                  # For WSGI memory profiling
-Pillow==3.2.0               # For WSGI memory profiling
-pyramid==1.7.0
+Pillow==3.3.1               # For WSGI memory profiling
+pyramid==1.7.3

--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,6 +1,6 @@
 alembic==0.8.8
 anyjson==0.3.3
-arrow==0.8.0
+arrow==0.7.0
 bcrypt==3.1.0
 dogpile.cache==0.6.2
 dogpile.core==0.4.1

--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,4 +1,4 @@
-alembic==0.8.7
+alembic==0.8.8
 anyjson==0.3.3
 arrow==0.8.0
 bcrypt==3.1.0

--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,15 +1,15 @@
-alembic==0.8.6
+alembic==0.8.7
 anyjson==0.3.3
-arrow==0.7.0
+arrow==0.8.0
 bcrypt==3.1.0
-dogpile.cache==0.5.7
+dogpile.cache==0.6.2
 dogpile.core==0.4.1
-lxml==3.6.0
+lxml==3.6.4
 misaka==1.0.3+weasyl.6    # https://github.com/Weasyl/misaka
-oauthlib==1.1.2
+oauthlib==2.0.0
 psycopg2cffi==2.7.4
-pytz==2016.4
-pyyaml==3.11
+pytz==2016.6.1
+pyyaml==3.12
 sanpera==0.1.1+weasyl.6   # https://github.com/Weasyl/sanpera
-sqlalchemy==1.0.13
+sqlalchemy==1.0.15
 translationstring==1.3


### PR DESCRIPTION
We haven't done this very recently and it's likely due. Also probably good to rule out any underlying library memory issues given what we're troubleshooting on the front end.