### PR TITLE
Restore moderator ability to view hidden characters and journals

### DIFF
--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -232,7 +232,7 @@ def _select_character_and_check(userid, charid, rating=None, ignore=True, anyway
 
 def select_view(userid, charid, rating, ignore=True, anyway=None):
     query = _select_character_and_check(
-        userid, charid, rating=rating, ignore=ignore, anyway=anyway == 'anyway')
+        userid, charid, rating=rating, ignore=ignore, anyway=anyway == "true")
 
     login = define.get_sysname(query['username'])
 

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -109,7 +109,7 @@ def _select_journal_and_check(userid, journalid, rating=None, ignore=True, anywa
 
 def select_view(userid, rating, journalid, ignore=True, anyway=None):
     journal = _select_journal_and_check(
-        userid, journalid, rating=rating, ignore=ignore, anyway=anyway == 'anyway')
+        userid, journalid, rating=rating, ignore=ignore, anyway=anyway == "true")
 
     return {
         'journalid': journalid,


### PR DESCRIPTION
Fixes #146. Additionally resolves the same issue with character-type items.

Fixes the incorrect logic of determining if the 'anyway' URL parameter is set to the string 'true'; previous code was looking for the string 'anyway' (when the URL was passing in "true").