### PR TITLE
Restore Python 3 compatibility in libweasyl password authentication

### DIFF
--- a/libweasyl/libweasyl/models/users.py
+++ b/libweasyl/libweasyl/models/users.py
@@ -131,16 +131,17 @@ class AuthBCrypt(Base):
 
     def does_authenticate(self, password):
         """
-        If the given password, matches the hashed password in the database,
-        return True. Otherwise, returns False.
+        If the given password matches the hashed password in the database,
+        returns True. Otherwise, returns False.
 
-        If the hashed password isn't stored as utf-8, it will update it to the
+        If the hashed password isn't stored as utf-8, it will be updated to the
         newer utf-8 format while the plaintext password is available.
         """
+        expected_hash = self.hashsum.encode('ascii')
 
-        if bcrypt.hashpw(password.encode('utf-8'), self.hashsum) == self.hashsum:
+        if bcrypt.checkpw(password.encode('utf-8'), expected_hash):
             return True
-        elif bcrypt.hashpw(plaintext(password).encode('utf-8'), self.hashsum) == self.hashsum:
+        elif bcrypt.checkpw(plaintext(password).encode('utf-8'), expected_hash):
             log.debug('updated old non-ASCII password for userid %d', self.userid)
             self.set_password(password)
             return True

--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,7 +1,7 @@
 alembic==0.8.8
 anyjson==0.3.3
 arrow==0.7.0
-bcrypt==3.1.0
+bcrypt==3.1.1
 dogpile.cache==0.6.2
 dogpile.core==0.4.1
 lxml==3.6.4


### PR DESCRIPTION
Text fields are returned from the database as strings, but bcrypt expects bytes.