### PR TITLE
Add ability to copy received note to staff notes

### DIFF
--- a/templates/note/message_view.html
+++ b/templates/note/message_view.html
@@ -34,7 +34,7 @@ $:{RENDER("common/stage_title.html", ["View Private Message", "Notes", "/notes?f
 
     $if myself['is_mod']:
       <form action="/modcontrol/copynotetostaffnotes" method="post" class="form clear">
-        <button class="button positive" style="float: right;">Copy Note to Staff Notes</button>
+        <button class="button" style="float: right;">Copy Note to Staff Notes</button>
         <input type="hidden" name="noteid" value="${query['noteid']}" />
         $:{CSRF()}
       </form>

--- a/templates/note/message_view.html
+++ b/templates/note/message_view.html
@@ -32,6 +32,17 @@ $:{RENDER("common/stage_title.html", ["View Private Message", "Notes", "/notes?f
 
     <div class="formatted-content">$:{MARKDOWN(query['content'])}</div>
 
+    $if myself['is_mod']:
+      <form name="copynotetostaffnotes" action="/modcontrol/copynotetostaffnotes" method="post" class="form clear">
+        <button type="submit" class="button positive" style="float: right;">Copy Note to Staff Notes</button>
+        <input type="hidden" name="notecontent" value="$:{MARKDOWN(query['content'])}" />
+        <input type="hidden" name="notesubject" value="${query['title']}" />
+        <input type="hidden" name="targetuserid" value="${query['senderid']}" />
+        <input type="hidden" name="targetusername" value="${LOGIN(query['sendername'])}" />
+        <input type="hidden" name="notedatetime" value="${(arrow.get(query['unixtime']).format('YYYY-MM-DD HH:mm:ss ZZ'))}" />
+        $:{CSRF()}
+      </form>
+
     $if not query['mine']:
       <form name="notescompose" action="/notes/compose" method="post" class="form clear">
         $:{CSRF()}

--- a/templates/note/message_view.html
+++ b/templates/note/message_view.html
@@ -33,13 +33,9 @@ $:{RENDER("common/stage_title.html", ["View Private Message", "Notes", "/notes?f
     <div class="formatted-content">$:{MARKDOWN(query['content'])}</div>
 
     $if myself['is_mod']:
-      <form name="copynotetostaffnotes" action="/modcontrol/copynotetostaffnotes" method="post" class="form clear">
-        <button type="submit" class="button positive" style="float: right;">Copy Note to Staff Notes</button>
-        <input type="hidden" name="notecontent" value="$:{MARKDOWN(query['content'])}" />
-        <input type="hidden" name="notesubject" value="${query['title']}" />
-        <input type="hidden" name="targetuserid" value="${query['senderid']}" />
-        <input type="hidden" name="targetusername" value="${LOGIN(query['sendername'])}" />
-        <input type="hidden" name="notedatetime" value="${(arrow.get(query['unixtime']).format('YYYY-MM-DD HH:mm:ss ZZ'))}" />
+      <form action="/modcontrol/copynotetostaffnotes" method="post" class="form clear">
+        <button class="button positive" style="float: right;">Copy Note to Staff Notes</button>
+        <input type="hidden" name="noteid" value="${query['noteid']}" />
         $:{CSRF()}
       </form>
 

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import absolute_import
 
 import anyjson as json
@@ -200,7 +202,7 @@ def modcontrol_copynotetostaffnotes_post_(request):
 
     notedata = note.select_view(request.userid, int(form.noteid))
 
-    staff_note_title = "Received note from {sender}, dated {date}, and the subject was: \"{subj}\".".format(
+    staff_note_title = u"Received note from {sender}, dated {date}, with subject: “{subj}”.".format(
         sender=notedata['sendername'],
         date=arrow.get(notedata['unixtime']).format('YYYY-MM-DD HH:mm:ss ZZ'),
         subj=notedata['title'],

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -190,3 +190,21 @@ def modcontrol_edituserconfig_(request):
 
     moderation.edituserconfig(form)
     raise HTTPSeeOther("/modcontrol")
+
+
+@moderator_only
+@token_checked
+def modcontrol_copynotetostaffnotes_post_(request):
+    form = request.web_input(targetuserid=None, targetusername=None, notecontent=None,
+                             notedatetime=None, notesubject=None)
+
+    staffnotetitle = ''.join(("Received note from ", form.targetusername, ", dated ", form.notedatetime,
+                              ', and the subject was: "', form.notesubject, '".'))
+
+    moderation.note_about(
+        userid=request.userid,
+        target_user=form.targetuserid,
+        title=staffnotetitle,
+        message=form.notecontent,
+    )
+    raise HTTPSeeOther(''.join(("/staffnotes/", form.targetusername)))

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -219,6 +219,7 @@ routes = (
     }),
     Route("/modcontrol/report", "modcontrol_report", moderation.modcontrol_report_),
     Route("/modcontrol/reports", "modcontrol_reports", moderation.modcontrol_reports_),
+    Route("/modcontrol/copynotetostaffnotes", "modcontrol_copynotetostaffnotes", {'POST': moderation.modcontrol_copynotetostaffnotes_post_}),
     Route("/modcontrol/closereport", "modcontrol_closereport", {'POST': moderation.modcontrol_closereport_}),
     Route("/modcontrol/contentbyuser", "modcontrol_contentbyuser", moderation.modcontrol_contentbyuser_),
     Route("/modcontrol/massaction", "modcontrol_massaction", {'POST': moderation.modcontrol_massaction_}),


### PR DESCRIPTION
For #134.

Adds a button to the note page of a received note, which permits moderators to directly copy the contents of the note to the Staff Notes of the user who sent the note.

I opted to put the controller and code in the ``moderation`` section since it is only for moderators, however if there is a desire for it, I can shift it under the ``interaction`` controller and ``note.py``; as it is currently written, though, no additional imports are needed.