### PR TITLE
Escape </script> in inline JSON regardless of casing

### DIFF
--- a/libweasyl/libweasyl/html.py
+++ b/libweasyl/libweasyl/html.py
@@ -57,4 +57,4 @@ def inline_json(obj):
     Returns:
         An escaped :term:`native string` of JSON.
     """
-    return json.dumps(obj).replace("</script", r"<\/script").replace("<!--", r"<\!--")
+    return json.dumps(obj).replace("</", r"<\/").replace("<!--", r"<\!--")

--- a/libweasyl/libweasyl/test/test_html.py
+++ b/libweasyl/libweasyl/test/test_html.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+from libweasyl import html
+
+
+def test_inline_json(monkeypatch):
+    monkeypatch.setattr(html, 'json', json)
+    assert html.inline_json('</script>') == r'"<\/script>"'
+    assert html.inline_json('</SCRIPT>') == r'"<\/SCRIPT>"'
+    assert html.inline_json('<!--<script>') == r'"<\!--<script>"'


### PR DESCRIPTION
Not a live vulnerability:

* anyjson already does this escaping (not the `<!--`)
* we don’t use `inline_json` on any user input

but it’s still fragile, stupid and my fault.