### PR TITLE
Add 'required' attribute where possible in submission pages

### DIFF
--- a/templates/submit/character.html
+++ b/templates/submit/character.html
@@ -10,7 +10,7 @@ $:{RENDER("common/stage_title.html", ["Character Profile", "Submit", "/submit"])
         <h3>Files</h3>
 
         <label>Picture</label>
-        <input type="file" name="submitfile" id="submitfile" class="styled-input" accept="image/*" />
+        <input type="file" name="submitfile" id="submitfile" class="styled-input" accept="image/*" required />
         <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (JPG): 10 MB</i></p>
         <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (PNG): 10 MB</i></p>
         <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (GIF): 10 MB</i></p>
@@ -23,7 +23,7 @@ $:{RENDER("common/stage_title.html", ["Character Profile", "Submit", "/submit"])
         <h3>Character Bio</h3>
 
         <label for="charactertitle">Name</label>
-        <input type="text" class="input" name="title" id="charactertitle" maxlength="100" />
+        <input type="text" class="input" name="title" id="charactertitle" maxlength="100" required />
 
         <label for="characterage">Age</label>
         <input type="text" class="input" name="age" id="characterage" maxlength="100" />
@@ -41,7 +41,7 @@ $:{RENDER("common/stage_title.html", ["Character Profile", "Submit", "/submit"])
         <input type="text" class="input" name="species" id="characterspecies" maxlength="100" />
 
         <label for="characterrating">Rating</label>
-        <select name="rating" class="input" id="characterrating">
+        <select name="rating" class="input" id="characterrating" required>
           <option value="" selected="selected">&nbsp;</option>
           $for rating in ratings:
             <option value="${rating.code}">${rating.name_with_age}</option>

--- a/templates/submit/journal.html
+++ b/templates/submit/journal.html
@@ -9,10 +9,10 @@ $:{RENDER("common/stage_title.html", ["Journal Entry", "Submit", "/submit"])}
       <h3>Information</h3>
 
       <label for="journaltitle">Title</label>
-      <input type="text" class="input" name="title" id="journaltitle" />
+      <input type="text" class="input" name="title" id="journaltitle" required />
 
       <label for="journalrating">Rating</label>
-      <select name="rating" class="input" id="journalrating">
+      <select name="rating" class="input" id="journalrating" required>
         <option value="" selected="selected">&nbsp;</option>
         $for rating in ratings:
           <option value="${rating.code}">${rating.name_with_age}</option>
@@ -22,7 +22,7 @@ $:{RENDER("common/stage_title.html", ["Journal Entry", "Submit", "/submit"])}
     <div class="column description">
       <h3>Content</h3>
       <label for="journaldesc">Content</label>
-      <textarea name="content" class="markdown input expanding" rows="9" id="journaldesc"></textarea>
+      <textarea name="content" class="markdown input expanding" rows="9" id="journaldesc" required></textarea>
     </div><!-- /description -->
 
     <div class="column tagging">

--- a/templates/submit/literary.html
+++ b/templates/submit/literary.html
@@ -45,7 +45,7 @@ $:{TITLE("Literary Artwork", "Submit", "/submit")}
       <h3>Information</h3>
 
       <label for="submissiontitle">Title</label>
-      <input type="text" class="input" name="title" id="submissiontitle" maxlength="200" />
+      <input type="text" class="input" name="title" id="submissiontitle" maxlength="200" required />
 
       <label for="submissioncat">Subcategory</label>
       <select name="subtype" class="input" id="submissioncat">
@@ -62,7 +62,7 @@ $:{TITLE("Literary Artwork", "Submit", "/submit")}
       </select>
 
       <label for="submissionrating">Rating</label>
-      <select name="rating" class="input" id="submissionrating">
+      <select name="rating" class="input" id="submissionrating" required>
         <option value="" selected="selected">&nbsp;</option>
         $for rating in ratings:
           <option value="${rating.code}">${rating.name_with_age}</option>

--- a/templates/submit/multimedia.html
+++ b/templates/submit/multimedia.html
@@ -36,7 +36,7 @@ $:{TITLE("Multimedia Artwork", "Submit", "/submit")}
       <h3>Information</h3>
 
       <label for="submissiontitle">Title</label>
-      <input type="text" class="input" name="title" id="submissiontitle" maxlength="200" />
+      <input type="text" class="input" name="title" id="submissiontitle" maxlength="200" required />
 
       <label for="submissioncat">Subcategory</label>
       <select name="subtype" class="input" id="submissioncat">
@@ -53,7 +53,7 @@ $:{TITLE("Multimedia Artwork", "Submit", "/submit")}
       </select>
 
       <label for="submissionrating">Rating</label>
-      <select name="rating" class="input" id="submissionrating">
+      <select name="rating" class="input" id="submissionrating" required>
         <option value="" selected="selected">&nbsp;</option>
         $for rating in ratings:
           <option value="${rating.code}">${rating.name_with_age}</option>

--- a/templates/submit/visual.html
+++ b/templates/submit/visual.html
@@ -16,7 +16,7 @@ $:{TITLE("Visual Artwork", "Submit", "/submit")}
         </div>
         <input type="hidden" name="imageURL" value="${form.imageURL}" />
       $else:
-        <input type="file" name="submitfile" id="submitfile" class="styled-input" accept="image/*" />
+        <input type="file" name="submitfile" id="submitfile" class="styled-input" accept="image/*" required />
       <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (JPG): 10 MB</i></p>
       <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (PNG): 10 MB</i></p>
       <p class="color-lighter" style="padding-top: 0.5em;"><i>Limit (GIF): 10 MB</i></p>
@@ -31,7 +31,7 @@ $:{TITLE("Visual Artwork", "Submit", "/submit")}
       <h3>Information</h3>
 
       <label for="submissiontitle">Title</label>
-      <input type="text" class="input" name="title" value="${form.title}" id="submissiontitle" maxlength="200" />
+      <input type="text" class="input" name="title" value="${form.title}" id="submissiontitle" maxlength="200" required />
 
       <label for="submissioncat">Subcategory</label>
       <select name="subtype" class="input" id="submissioncat">
@@ -48,7 +48,7 @@ $:{TITLE("Visual Artwork", "Submit", "/submit")}
       </select>
 
       <label for="submissionrating">Rating</label>
-      <select name="rating" class="input" id="submissionrating">
+      <select name="rating" class="input" id="submissionrating" required>
         <option value="" selected="selected">&nbsp;</option>
         $for rating in ratings:
           <option value="${rating.code}">${rating.name_with_age}</option>


### PR DESCRIPTION
For #173.

Adds the HTML5 'required' attribute when possible to catch some input validation errors client-side, which would otherwise be caught server-side.

Does not address the search tag issue, unfortunately. I inspected the source of the tag, and however the JavaScript that's operating on the space/comma action adds a new ``<ul>`` item (or something along those lines), and as such it doesn't modify either the ``textarea`` or the ``input`` tags (though even the ``input`` tag isn't actually in the source templates; added by JS, maybe?). Here's the example on the live site of this behavior: https://i.sli.mg/hj3Ar7.png