### PR TITLE
Add ability to edit site updates

### DIFF
--- a/templates/admincontrol/admincontrol.html
+++ b/templates/admincontrol/admincontrol.html
@@ -5,6 +5,10 @@ $:{TITLE("Administrator Control Panel")}
     <div style="font-size:1.3em;">
       <p><a href="/admincontrol/siteupdate">Submit Site Update</a></p><br />
     </div>
+
+    <div style="font-size:1.3em;">
+      <p><a href="/admincontrol/editsiteupdate">Edit Site Update</a></p><br />
+    </div>
     
     <div style="font-size:1.3em;">
       <p><a href="/admincontrol/finduser">Search Users</a></p><br />

--- a/templates/admincontrol/editsiteupdate.html
+++ b/templates/admincontrol/editsiteupdate.html
@@ -1,0 +1,19 @@
+$def with (su)
+$:{TITLE("Edit Site Update", "Administrator Control Panel", "/admincontrol")}
+
+<div class="content">
+  <form class="form wide" action="/admincontrol/editsiteupdate" method="post">
+    $:{CSRF()}
+    <input type="hidden" name="siteupdateid" value="$su[0]['updateid']">
+
+    <label for="editsiteupdatetitle">Title</label>
+    <input type="text" class="input" name="title" id="editsiteupdatetitle" value="$su[0]['title']" />
+
+    <label for="editsiteupdatecontent">Content</label>
+    <textarea class="markdown input expanding last-input" name="content" rows="9" id="editsiteupdatecontent">$su[0]['content']</textarea>
+    <br />
+
+    <button class="button highlighted" style="float: right;">Edit Site Update</button>
+    <a class="button" href="/admincontrol">Go Back</a>
+  </form>
+</div>

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -36,6 +36,23 @@ def admincontrol_siteupdate_post_(request):
     raise HTTPSeeOther(location="/admincontrol")
 
 
+@moderator_only
+def admincontrol_editsiteupdate_get_(request):
+    return Response(d.webpage(request.userid, "admincontrol/editsiteupdate.html", [
+        siteupdate.select(),
+    ]))
+
+
+@token_checked
+@moderator_only
+def admincontrol_editsiteupdate_post_(request):
+    form = request.web_input(title=None, content=None, siteupdateid=None)
+
+    siteupdate.edit(request.userid, form)
+
+    raise HTTPSeeOther(location="/admincontrol")
+
+
 @admin_only
 def admincontrol_manageuser_get_(request):
     form = request.web_input(name="")

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -244,6 +244,8 @@ routes = (
 
     # Admin control routes.
     Route("/admincontrol", "admincontrol", admin.admincontrol_),
+    Route("/admincontrol/editsiteupdate", "admin_editsiteupdate",
+          {'GET': admin.admincontrol_editsiteupdate_get_, 'POST': admin.admincontrol_editsiteupdate_post_}),
     Route("/admincontrol/siteupdate", "admin_siteupdate",
           {'GET': admin.admincontrol_siteupdate_get_, 'POST': admin.admincontrol_siteupdate_post_}),
     Route("/admincontrol/manageuser", "admin_manageuser",

--- a/weasyl/siteupdate.py
+++ b/weasyl/siteupdate.py
@@ -36,6 +36,26 @@ def create(userid, form):
     welcome.site_update_insert(updateid)
 
 
+def edit(userid, form):
+    form.title = form.title.strip()[:_TITLE]
+    form.content = form.content.strip()
+
+    if not form.title:
+        raise WeasylError("titleInvalid")
+    elif not form.content:
+        raise WeasylError("titleInvalid")
+    elif not form.siteupdateid:
+        raise WeasylError("titleInvalid")
+    elif userid not in staff.ADMINS:
+        raise WeasylError("InsufficientPermissions")
+
+    d.engine.execute("""
+        UPDATE siteupdate
+        SET title = %(title)s, content = %(content)s
+        WHERE updateid = %(updateid)s
+    """, title=form.title, content=form.content, updateid=form.siteupdateid)
+
+
 def select(limit=1):
     ret = [{
         "updateid": i[0],


### PR DESCRIPTION
For #132.

Adds a new admin-only page which allows editing site updates in the same manner as they were initially submitted (i.e., via a Markdown editor).