### PR TITLE
Miscellaneous fixes for the Login Email Blacklist

### DIFF
--- a/templates/directorcontrol/emailblacklist.html
+++ b/templates/directorcontrol/emailblacklist.html
@@ -16,10 +16,10 @@ $:{RENDER("common/stage_title.html", ["Blacklist Email Address", "Director Contr
       <tbody>
         $for item in entries:
           <tr>
-            <td><input class="checkbox" type="checkbox" name="remove_selection" value="$item['id']"></td>
-            <td>$item['domain_name']</td>
-            <td>$item['reason']</td>
-            <td>$item['name']</td>
+            <td style="text-align: center;"><input class="checkbox" type="checkbox" name="remove_selection" value="$item['id']"></td>
+            <td style="text-align: center;">$item['domain_name']</td>
+            <td style="text-align: center;">$item['reason']</td>
+            <td style="text-align: center;">$item['name']</td>
           </tr>
       </tbody>
     </table>
@@ -31,7 +31,7 @@ $:{RENDER("common/stage_title.html", ["Blacklist Email Address", "Director Contr
 <div class="content">
   <form method="POST" action="/directorcontrol/emailblacklist" class="form skinny clear">
     <label for="domain_name">Domain Name to Blacklist</label>
-    <input type="text" class="input" maxlength="252" name="domain_name" id="domain_name">
+    <input type="text" class="input" maxlength="252" name="domain_name" id="domain_name" required>
 
     <label for="reason">Reason Why Blacklisted</label>
     <textarea rows="4" cols="60" class="input" name="reason" id="reason"></textarea>

--- a/templates/directorcontrol/emailblacklist.html
+++ b/templates/directorcontrol/emailblacklist.html
@@ -27,7 +27,7 @@ $:{RENDER("common/stage_title.html", ["Edit Account Creation Email Blacklist", "
       <button class="button positive" name="action" value="remove">Unblacklist Selected Domains</button>
     </form>
   $else:
-    <span class="label" style="text-align: center;">No email domains are currently blacklisted from creating an account.</span>
+    <p style="text-align: center;">No email domains are currently blacklisted from creating an account.</p>
 </div>
 
 

--- a/templates/directorcontrol/emailblacklist.html
+++ b/templates/directorcontrol/emailblacklist.html
@@ -1,30 +1,33 @@
 $def with (entries)
-$:{RENDER("common/stage_title.html", ["Blacklist Email Address", "Director Control Panel", "/directorcontrol"])}
+$:{RENDER("common/stage_title.html", ["Edit Account Creation Email Blacklist", "Director Control Panel", "/directorcontrol"])}
 
 <div class="content blacklisted-emails">
-  <form method="POST" action="/directorcontrol/emailblacklist">
-    $:{CSRF()}
-    <table>
-      <thead>
-        <tr>
-          <th width="10%">Remove</th>
-          <th width="40%">Domain Name</th>
-          <th width="40%">Reason Blacklisted</th>
-          <th width="10%">Added by</th>
-        </tr>
-      </thead>
-      <tbody>
-        $for item in entries:
+  $if entries:
+    <form method="POST" action="/directorcontrol/emailblacklist">
+      $:{CSRF()}
+      <table>
+        <thead>
           <tr>
-            <td style="text-align: center;"><input class="checkbox" type="checkbox" name="remove_selection" value="$item['id']"></td>
-            <td style="text-align: center;">$item['domain_name']</td>
-            <td style="text-align: center;">$item['reason']</td>
-            <td style="text-align: center;">$item['name']</td>
+            <th width="10%" style="text-align: left;">Remove</th>
+            <th width="40%" style="text-align: left;">Domain Name</th>
+            <th width="40%" style="text-align: left;">Reason Blacklisted</th>
+            <th width="10%" style="text-align: left;">Added by</th>
           </tr>
-      </tbody>
-    </table>
-    <button class="button positive" name="action" value="remove">Unblacklist Selected Domains</button>
-  </form>
+        </thead>
+        <tbody>
+          $for item in entries:
+            <tr>
+              <td><input class="checkbox" type="checkbox" name="remove_selection" value="$item['id']"></td>
+              <td>$item['domain_name']</td>
+              <td>$item['reason']</td>
+              <td>$item['name']</td>
+            </tr>
+        </tbody>
+      </table>
+      <button class="button positive" name="action" value="remove">Unblacklist Selected Domains</button>
+    </form>
+  $else:
+    <span class="label" style="text-align: center;">No email domains are currently blacklisted from creating an account.</span>
 </div>
 
 
@@ -37,6 +40,8 @@ $:{RENDER("common/stage_title.html", ["Blacklist Email Address", "Director Contr
     <textarea rows="4" cols="60" class="input" name="reason" id="reason"></textarea>
 
     $:{CSRF()}
-    <button class="button negative" name="action" value="add">Blacklist Domain</button>
+    <div style="padding-top: 1em;">
+      <button class="button negative" name="action" value="add">Blacklist Domain</button>
+    </div>
   </form>
 </div>

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -35,13 +35,12 @@ def directorcontrol_emailblacklist_post_(request):
         d.engine.execute("DELETE FROM emailblacklist WHERE id = ANY (%(selected_ids)s)",
                          selected_ids=map(int, form.remove_selection))
 
-    # Add entry to blacklist
+    # Add entry to blacklist, if there is an entry in form.domain_name
     elif form.action == "add" and form.domain_name:
-        if len(form.domain_name) <= 252:
-            d.engine.execute("""
-                INSERT INTO emailblacklist (domain_name, reason, added_by)
-                    VALUES (%(domain_name)s, %(reason)s, %(added_by)s)
-                    ON CONFLICT (domain_name) DO NOTHING
-            """, domain_name=form.domain_name.lower(), reason=form.reason, added_by=request.userid)
+        d.engine.execute("""
+            INSERT INTO emailblacklist (domain_name, reason, added_by)
+                VALUES (%(domain_name)s, %(reason)s, %(added_by)s)
+                ON CONFLICT (domain_name) DO NOTHING
+        """, domain_name=form.domain_name.lower(), reason=form.reason, added_by=request.userid)
 
     raise HTTPSeeOther(location="/directorcontrol/emailblacklist")

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -36,11 +36,12 @@ def directorcontrol_emailblacklist_post_(request):
                          selected_ids=map(int, form.remove_selection))
 
     # Add entry to blacklist
-    elif form.action == "add":
-        d.engine.execute(d.meta.tables["emailblacklist"].insert(), {
-            "domain_name": form.domain_name.lower(),
-            "reason": form.reason,
-            "added_by": request.userid,
-        })
+    elif form.action == "add" and form.domain_name:
+        if len(form.domain_name) <= 252:
+            d.engine.execute("""
+                INSERT INTO emailblacklist (domain_name, reason, added_by)
+                    VALUES (%(domain_name)s, %(reason)s, %(added_by)s)
+                    ON CONFLICT (domain_name) DO NOTHING
+            """, domain_name=form.domain_name.lower(), reason=form.reason, added_by=request.userid)
 
     raise HTTPSeeOther(location="/directorcontrol/emailblacklist")


### PR DESCRIPTION
- Fixes alignment of text in the columns to be centered to match the centered column headings.
- Eschews the ``d.meta.tables`` method of adding a row, opting for raw SQL to leverage ``ON CONFLICT (domain_name) DO NOTHING`` to prevent errors in the event that a domain name is attempted to be added twice.
- Enforces the 252 character limit on the Python back-end (it was only relying on HTML length limits before).
- ~~Forces domain name to lowercase (because capitalization doesn't really matter)~~ This was already done in the ``d.meta.tables`` method of adding SQL, and was carried over in these changes.