### PR TITLE
Remove unused `files.read` parameters; let errors propagate

### DIFF
--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -286,9 +286,6 @@ def _markdown_fragment(target, image):
 
 
 def markdown(target, image=False):
-    if target is None:
-        return ""
-
     fragment = _markdown_fragment(target, image)
     return html.tostring(fragment, encoding=unicode)[5:-6]  # <div>...</div>
 

--- a/weasyl/files.py
+++ b/weasyl/files.py
@@ -24,20 +24,9 @@ PATH_CONFIG = "config/"
 PATH_SEARCH = "search/"
 
 
-def read(filename, encoding="utf-8", errors="replace", encode=None):
-    """
-    Returns file data. If the filename is invalid, None is returned.
-    """
-    try:
-        data = codecs.open(filename, "r", encoding, errors).read()
-    except IOError:
-        d.log_exc()
-        return None
-
-    if encode:
-        return data.encode(encode)
-    else:
-        return data
+def read(filename):
+    with codecs.open(filename, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
 
 
 def ensure_file_directory(filename):


### PR DESCRIPTION
“Missing submission/journal file” shouldn’t be ignored, and the Markdown renderer shouldn’t be the one to handle it.