### PR TITLE
Fix searchtag test failures by using more sets

### DIFF
--- a/templates/control/edit_tagrestrictions.html
+++ b/templates/control/edit_tagrestrictions.html
@@ -16,7 +16,7 @@ $:{RENDER("common/stage_title.html", ["Edit Community Tagging Restrictions", "Se
       You can still add these tags to your own submissions.
     </p>
     <span class="label">Add or Remove Tags:</span><br />
-    <textarea id="tags-textarea" name="tags">${" ".join(tags)}</textarea>
+    <textarea id="tags-textarea" name="tags">${" ".join(sorted(tags))}</textarea>
     <div style="padding-top: 1em;">
       <button class="button positive" style="float: right;">Save Tags</button>
     </div>

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -439,8 +439,7 @@ def get_user_tag_restrictions(userid):
         WHERE userid = %(userid)s
         ORDER BY st.title
     """, userid=userid).fetchall()
-    tags = [tag.title for tag in query]
-    return tags
+    return {tag.title for tag in query}
 
 
 def get_global_tag_restrictions(userid):

--- a/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
@@ -9,9 +9,9 @@ from weasyl.error import WeasylError
 from weasyl.test import db_utils
 
 # Test lists of tags
-valid_tags = ['test', '*test', 'te*st', 'test*', 'test_too']
-invalid_tags = ['*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}']
-combined_tags = valid_tags + invalid_tags
+valid_tags = {'test', '*test', 'te*st', 'test*', 'test_too'}
+invalid_tags = {'*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}'}
+combined_tags = valid_tags | invalid_tags
 
 
 @pytest.mark.usefixtures('db')
@@ -22,7 +22,7 @@ def test_edit_global_tag_restrictions_fully_clear_entries_after_adding_items(mon
     searchtag.edit_global_tag_restrictions(director_user_id, tags)
     tags = set()
     searchtag.edit_global_tag_restrictions(director_user_id, tags)
-    assert searchtag.get_global_tag_restrictions(director_user_id) == []
+    assert not searchtag.get_global_tag_restrictions(director_user_id)
 
 
 @pytest.mark.usefixtures('db')
@@ -63,7 +63,7 @@ def test_edit_global_tag_restrictions(monkeypatch):
     tags = searchtag.parse_restricted_tags(", ".join(combined_tags))
     searchtag.edit_global_tag_restrictions(director_user_id, tags)
     resultant_tags = searchtag.get_global_tag_restrictions(director_user_id)
-    resultant_tags_titles = [x.title for x in resultant_tags]
+    resultant_tags_titles = {x.title for x in resultant_tags}
     assert resultant_tags_titles == valid_tags
     for user in resultant_tags:
         assert user.login_name == "testdirector"

--- a/weasyl/test/searchtag/test_edit_user_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_edit_user_tag_restrictions.py
@@ -6,9 +6,9 @@ from weasyl import searchtag
 from weasyl.test import db_utils
 
 # Test lists of tags
-valid_tags = ['test', '*test', 'te*st', 'test*', 'test_too']
-invalid_tags = ['*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}']
-combined_tags = valid_tags + invalid_tags
+valid_tags = {'test', '*test', 'te*st', 'test*', 'test_too'}
+invalid_tags = {'*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}'}
+combined_tags = valid_tags | invalid_tags
 
 
 @pytest.mark.usefixtures('db')
@@ -30,7 +30,7 @@ def test_edit_user_tag_restrictions_with_prior_entries_test_removal_of_entry():
     user_id = db_utils.create_user()
     tags = searchtag.parse_restricted_tags(", ".join(combined_tags))
     searchtag.edit_user_tag_restrictions(user_id, tags)
-    tags_to_keep = ['test', 'te*st', 'test_too']
+    tags_to_keep = {'test', 'te*st', 'test_too'}
 
     # Set the new tags; AKA, remove the two defined tags
     tags = searchtag.parse_restricted_tags(", ".join(tags_to_keep))
@@ -46,4 +46,4 @@ def test_edit_user_tag_restrictions_fully_clear_entries_after_adding_items():
     searchtag.edit_user_tag_restrictions(user_id, tags)
     tags = set()
     searchtag.edit_user_tag_restrictions(user_id, tags)
-    assert searchtag.get_user_tag_restrictions(user_id) == []
+    assert not searchtag.get_user_tag_restrictions(user_id)

--- a/weasyl/test/searchtag/test_get_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_get_tag_restrictions.py
@@ -9,9 +9,9 @@ from weasyl.error import WeasylError
 from weasyl.test import db_utils
 
 # Test lists of tags
-valid_tags = ['test', '*test', 'te*st', 'test*', 'test_too']
-invalid_tags = ['*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}']
-combined_tags = valid_tags + invalid_tags
+valid_tags = {'test', '*test', 'te*st', 'test*', 'test_too'}
+invalid_tags = {'*', 'a*', '*a', 'a*a*', '*a*a', '*aa*', 'a**a', '}'}
+combined_tags = valid_tags | invalid_tags
 
 
 @pytest.mark.usefixtures('db')
@@ -30,7 +30,7 @@ def test_get_global_searchtag_restrictions(monkeypatch):
     tags = searchtag.parse_restricted_tags(", ".join(combined_tags))
     searchtag.edit_global_tag_restrictions(director_user_id, tags)
     resultant_tags = searchtag.get_global_tag_restrictions(director_user_id)
-    resultant_tags_titles = [x.title for x in resultant_tags]
+    resultant_tags_titles = {x.title for x in resultant_tags}
     assert resultant_tags_titles == valid_tags
     for user in resultant_tags:
         assert user.login_name == "testdirector"


### PR DESCRIPTION
>The tests were failing because the order was being compared, when it wasn't actually important.