### PR TITLE
Add last_active column to profile

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/83e6b2a46191_track_most_recent_submission_time.py
+++ b/libweasyl/libweasyl/alembic/versions/83e6b2a46191_track_most_recent_submission_time.py
@@ -1,0 +1,34 @@
+"""Track most recent submission time on profile
+
+Used to prevent scans on submission for determining when
+a user most recently posted something, for ordering
+marketplace search results
+
+Revision ID: 83e6b2a46191
+Revises: a49795aa2584
+Create Date: 2017-01-07 03:21:10.114125
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '83e6b2a46191'
+down_revision = 'a49795aa2584'
+
+from alembic import op
+import sqlalchemy as sa
+import libweasyl
+
+
+def upgrade():
+    op.add_column('profile', sa.Column('last_active', libweasyl.models.helpers.WeasylTimestampColumn(),
+                                       nullable=False, server_default='0'))
+    op.execute("""
+        UPDATE profile p SET last_active = (
+            SELECT COALESCE(MAX(s.unixtime), 0) AS latest FROM submission s WHERE s.userid = p.userid
+        )
+    """)
+
+
+def downgrade():
+    op.drop_column('profile', 'last_active')
+    pass

--- a/libweasyl/libweasyl/alembic/versions/83e6b2a46191_track_most_recent_submission_time.py
+++ b/libweasyl/libweasyl/alembic/versions/83e6b2a46191_track_most_recent_submission_time.py
@@ -20,15 +20,15 @@ import libweasyl
 
 
 def upgrade():
-    op.add_column('profile', sa.Column('last_active', libweasyl.models.helpers.WeasylTimestampColumn(),
+    op.add_column('profile', sa.Column('latest_submission_time', libweasyl.models.helpers.WeasylTimestampColumn(),
                                        nullable=False, server_default='0'))
     op.execute("""
-        UPDATE profile p SET last_active = (
+        UPDATE profile p SET latest_submission_time = (
             SELECT COALESCE(MAX(s.unixtime), 0) AS latest FROM submission s WHERE s.userid = p.userid
         )
     """)
 
 
 def downgrade():
-    op.drop_column('profile', 'last_active')
+    op.drop_column('profile', 'latest_submission_time')
     pass

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -524,7 +524,7 @@ profile = Table(
     Column('catchphrase', String(length=200), nullable=False, server_default=''),
     Column('artist_type', String(length=100), nullable=False, server_default=''),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('last_active', WeasylTimestampColumn(), nullable=False, server_default='0'),
+    Column('latest_submission_time', WeasylTimestampColumn(), nullable=False, server_default='0'),
     Column('profile_text', Text(), nullable=False, server_default=''),
     Column('settings', String(length=20), nullable=False, server_default='ccci'),
     Column('stream_url', String(length=500), nullable=False, server_default=''),

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -524,6 +524,7 @@ profile = Table(
     Column('catchphrase', String(length=200), nullable=False, server_default=''),
     Column('artist_type', String(length=100), nullable=False, server_default=''),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
+    Column('last_active', WeasylTimestampColumn(), nullable=False, server_default='0'),
     Column('profile_text', Text(), nullable=False, server_default=''),
     Column('settings', String(length=20), nullable=False, server_default='ccci'),
     Column('stream_url', String(length=500), nullable=False, server_default=''),

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -126,10 +126,14 @@ def _create_submission(expected_type):
 
             profile.check_user_rating_allowed(userid, submission.rating)
 
-            return create_specific(
+            newid = create_specific(
                 userid=userid,
                 submission=submission,
                 **kwargs)
+            if newid:
+                p = d.meta.tables['profile']
+                d.connect().execute(p.update().where(p.c.userid == userid).values(last_active=arrow.utcnow()))
+            return newid
 
         return create_generic
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -132,7 +132,7 @@ def _create_submission(expected_type):
                 **kwargs)
             if newid:
                 p = d.meta.tables['profile']
-                d.connect().execute(p.update().where(p.c.userid == userid).values(last_active=arrow.utcnow()))
+                d.connect().execute(p.update().where(p.c.userid == userid).values(latest_submission_time=arrow.utcnow()))
             return newid
 
         return create_generic

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -23,10 +23,10 @@ def add_entity(entity):
     return entity
 
 
-def update_last_active(userid):
+def update_last_submission_time(userid, unixtime):
     profile = d.meta.tables['profile']
     db = d.connect()
-    db.execute(profile.update().where(profile.c.userid == userid).values(last_active=arrow.utcnow()))
+    db.execute(profile.update().where(profile.c.userid == userid).values(latest_submission_time=unixtime))
     db.flush()
 
 
@@ -86,7 +86,7 @@ def create_submission(userid, title="", rating=ratings.GENERAL.code, unixtime=ar
     submission = add_entity(content.Submission(
         userid=userid, rating=rating, title=title, unixtime=unixtime, content=description,
         folderid=folderid, subtype=subtype, sorttime=arrow.get(0), settings=settings))
-    update_last_active(userid)
+    update_last_submission_time(userid, unixtime)
     return submission.submitid
 
 
@@ -136,7 +136,7 @@ def create_shout(userid, targetid, parentid=None, body="",
 def create_journal(userid, title='', rating=ratings.GENERAL.code, unixtime=arrow.get(1), settings=None):
     journal = add_entity(content.Journal(
         userid=userid, title=title, rating=rating, unixtime=unixtime, settings=settings))
-    update_last_active(userid)
+    update_last_submission_time(userid, unixtime)
     return journal.journalid
 
 
@@ -152,7 +152,7 @@ def create_character(userid, name='', age='', gender='', height='', weight='', s
     character = add_entity(content.Character(
         userid=userid, char_name=name, age=age, gender=gender, height=height, weight=weight,
         species=species, content=description, rating=rating, unixtime=unixtime, settings=settings))
-    update_last_active(userid)
+    update_last_submission_time(userid, unixtime)
     return character.charid
 
 

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -23,6 +23,13 @@ def add_entity(entity):
     return entity
 
 
+def update_last_active(userid):
+    profile = d.meta.tables['profile']
+    db = d.connect()
+    db.execute(profile.update().where(profile.c.userid == userid).values(last_active=arrow.utcnow()))
+    db.flush()
+
+
 def create_api_key(userid, token, description=""):
     add_entity(orm.APIToken(userid=userid, token=token, description=description))
 
@@ -79,6 +86,7 @@ def create_submission(userid, title="", rating=ratings.GENERAL.code, unixtime=ar
     submission = add_entity(content.Submission(
         userid=userid, rating=rating, title=title, unixtime=unixtime, content=description,
         folderid=folderid, subtype=subtype, sorttime=arrow.get(0), settings=settings))
+    update_last_active(userid)
     return submission.submitid
 
 
@@ -128,6 +136,7 @@ def create_shout(userid, targetid, parentid=None, body="",
 def create_journal(userid, title='', rating=ratings.GENERAL.code, unixtime=arrow.get(1), settings=None):
     journal = add_entity(content.Journal(
         userid=userid, title=title, rating=rating, unixtime=unixtime, settings=settings))
+    update_last_active(userid)
     return journal.journalid
 
 
@@ -143,6 +152,7 @@ def create_character(userid, name='', age='', gender='', height='', weight='', s
     character = add_entity(content.Character(
         userid=userid, char_name=name, age=age, gender=gender, height=height, weight=weight,
         species=species, content=description, rating=rating, unixtime=unixtime, settings=settings))
+    update_last_active(userid)
     return character.charid
 
 


### PR DESCRIPTION
Done in preparation of #192, this establishes a column on `profile` called `last_active` that stores the unixtime of when the user most recently created a submission, character or journal. This is done to improve performance of the Marketplace search query.