### PR TITLE
Use TIMESTAMP column for latest submission time

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/eff79a07a88d_use_timestamp_column_for_latest_.py
+++ b/libweasyl/libweasyl/alembic/versions/eff79a07a88d_use_timestamp_column_for_latest_.py
@@ -1,0 +1,48 @@
+"""Use TIMESTAMP column for latest submission
+
+Revision ID: eff79a07a88d
+Revises: 7ff3906eccf5
+Create Date: 2017-01-08 22:20:43.814375
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'eff79a07a88d'
+down_revision = '83e6b2a46191'
+
+from alembic import op
+import sqlalchemy as sa
+
+import libweasyl
+from libweasyl.legacy import UNIXTIME_OFFSET
+
+
+def upgrade():
+    op.alter_column(
+        'profile',
+        'latest_submission_time',
+        new_column_name='latest_submission_time_old',
+    )
+    op.add_column(
+        'profile',
+        sa.Column('latest_submission_time', libweasyl.models.helpers.ArrowColumn(), nullable=False, server_default='epoch'),
+    )
+    op.execute(
+        "UPDATE profile SET latest_submission_time = TIMESTAMP WITHOUT TIME ZONE 'epoch' + "
+        "(latest_submission_time_old - %d) * INTERVAL '1 second'" % (UNIXTIME_OFFSET,))
+    op.drop_column('profile', 'latest_submission_time_old')
+
+
+def downgrade():
+    op.alter_column(
+        'profile',
+        'latest_submission_time',
+        new_column_name='latest_submission_time_new',
+    )
+    op.add_column(
+        'profile',
+        sa.Column('latest_submission_time', libweasyl.models.helpers.WeasylTimestampColumn(), nullable=False, server_default='0'),
+    )
+    op.execute(
+        "UPDATE profile SET latest_submission_time = extract(epoch from latest_submission_time_new) + %d" % (UNIXTIME_OFFSET,))
+    op.drop_column('profile', 'latest_submission_time_new')

--- a/libweasyl/libweasyl/alembic/versions/eff79a07a88d_use_timestamp_column_for_latest_.py
+++ b/libweasyl/libweasyl/alembic/versions/eff79a07a88d_use_timestamp_column_for_latest_.py
@@ -1,7 +1,7 @@
 """Use TIMESTAMP column for latest submission
 
 Revision ID: eff79a07a88d
-Revises: 7ff3906eccf5
+Revises: 83e6b2a46191
 Create Date: 2017-01-08 22:20:43.814375
 
 """

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -524,7 +524,7 @@ profile = Table(
     Column('catchphrase', String(length=200), nullable=False, server_default=''),
     Column('artist_type', String(length=100), nullable=False, server_default=''),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('latest_submission_time', WeasylTimestampColumn(), nullable=False, server_default='0'),
+    Column('latest_submission_time', ArrowColumn(), nullable=False, server_default='epoch'),
     Column('profile_text', Text(), nullable=False, server_default=''),
     Column('settings', String(length=20), nullable=False, server_default='ccci'),
     Column('stream_url', String(length=500), nullable=False, server_default=''),


### PR DESCRIPTION
`WeasylTimestampColumn` is for compatibility with very old code; it shouldn’t be used with new columns.