### PR TITLE
Convert currencies correctly for min/max price filtering

### DIFF
--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -253,14 +253,14 @@ def select_commissionable(userid, q, commishclass, min_price, max_price, currenc
     """]
     if min_price:
         for c in CURRENCY_CHARMAP:
-            ratio = currency_ratio(c, currency)
-            if ratio:
-                stmt.append("AND NOT (cp.settings ~ '^%s' AND cp.amount_min < %f)\n" % (c, ratio * min_price))
+            local_min = convert_currency(min_price, currency, c)
+            if local_min:
+                stmt.append("AND NOT (cp.settings ~ '^%s' AND cp.amount_min < %f)\n" % (c, local_min))
     if max_price:
         for c in CURRENCY_CHARMAP:
-            ratio = currency_ratio(c, currency)
-            if ratio:
-                stmt.append("AND NOT (cp.settings ~ '^%s' AND cp.amount_min > %f)\n" % (c, ratio * max_price))
+            local_max = convert_currency(max_price, currency, c)
+            if local_max:
+                stmt.append("AND NOT (cp.settings ~ '^%s' AND cp.amount_min > %f)\n" % (c, local_max))
     tags = q.lower().split()
     if userid:
         stmt.append(m.MACRO_IGNOREUSER % (userid, "p"))


### PR DESCRIPTION
Having the currency conversion ratio effectively inverted causes unexpected results in marketplace searches.