### PR TITLE
Display custom thumbnails alongside original in contentbyuser

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -3949,7 +3949,7 @@ img + #detail-art-text {
 }
 .content-by-user label {
     display: block;
-    width: 1250%;
+    width: 1650%;
     position: absolute;
     left: 0;
     top: 0;

--- a/templates/modcontrol/contentbyuser.html
+++ b/templates/modcontrol/contentbyuser.html
@@ -35,11 +35,26 @@ $code:
             </div>
           </td>
           <td class="thumb-cell">
-            $if 'sub_media' in i:
-              $ thumb = THUMB(i)
-              <img src="${thumb['display_url']}" alt="" class="thumb" />
+            $# custom thumb, if applicable
+            $if i['contype'] == 10 and 'thumbnail-custom' in i['sub_media']:
+              <img src="${i['sub_media']['thumbnail-custom'][0]['display_url']}" alt="" class="thumb" />
+            $elif i['contype'] == 20:
+              $# for characters, all thumbnails show as 'generated'.. even if they are custom..
+              <img src="${i['sub_media']['thumbnail-generated'][0]['display_url']}" alt="" class="thumb" />
             $else:
-              <span class="journal-thumb">&lt;journal&gt;</span>
+              <span class="journal-thumb">&lt;No Thumbnail&gt;</span>
+          </td>
+          <td class="thumb-cell">
+            $# the actual submission image, if applicable
+            $if i['contype'] == 10:
+              $if i['subtype'] >= 2000 and 'cover' in i['sub_media']:
+                <img src="${i['sub_media']['cover'][0]['display_url']}" alt="" class="thumb" />
+              $else:
+                <img src="${i['sub_media']['thumbnail-generated'][0]['display_url']}" alt="" class="thumb" />
+            $elif i['contype'] == 20:
+              <img src="${i['sub_media']['cover'][0]['display_url']}" alt="" class="thumb" />
+            $elif i['contype'] == 30:
+              <span class="journal-thumb">&lt;Journal&gt;</span>
           </td>
           <td class="title-cell">
             $if i['contype'] == 10:
@@ -73,4 +88,6 @@ $code:
       </div>
     </div>
   </form>
+
+
 </div>

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -409,24 +409,16 @@ def submissionsbyuser(userid, form):
     if userid not in staff.MODS:
         raise WeasylError("Unexpected")
 
-    query = d.execute("""
-        SELECT su.submitid, su.title, su.rating, su.unixtime, su.userid, pr.username, su.settings
+    query = d.engine.execute("""
+        SELECT su.submitid, su.title, su.rating, su.unixtime, su.userid,
+               pr.username, su.settings, su.subtype, 10 contype
         FROM submission su
             INNER JOIN profile pr USING (userid)
-        WHERE su.userid = (SELECT userid FROM login WHERE login_name = '%s')
+        WHERE su.userid = (SELECT userid FROM login WHERE login_name = %(login)s)
         ORDER BY su.submitid DESC
-    """, [d.get_sysname(form.name)])
+    """, login=d.get_sysname(form.name))
 
-    ret = [{
-        "contype": 10,
-        "submitid": i[0],
-        "title": i[1],
-        "rating": i[2],
-        "unixtime": i[3],
-        "userid": i[4],
-        "username": i[5],
-        "settings": i[6],
-    } for i in query]
+    ret = map(dict, query)
     media.populate_with_submission_media(ret)
     return ret
 


### PR DESCRIPTION
addresses #122 
Add a column to contentbyuser that shows either the cover image or generated thumbnail of a submission/character as appropriate. Generated thumbnails might cut some things off but they'll reduce the bandwidth of this page a lot and if something is getting cut off it's aspect ration is probably too crazy to see anything anyway.