### PR TITLE
Invalidate all other sessions when a user's password is changed.

### DIFF
--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -565,7 +565,7 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
         sess = d.get_weasyl_session()
         d.engine.execute("""
             DELETE FROM sessions
-            WHERE userid = (%(userid)s)
+            WHERE userid = %(userid)s
               AND sessionid != (%(currentsession)s)
         """, userid=userid, currentsession=sess.sessionid)
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -561,6 +561,14 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
     if newpassword:
         d.execute("UPDATE authbcrypt SET hashsum = '%s' WHERE userid = %i", [login.passhash(newpassword), userid])
 
+        # Invalidate all sessions for `userid` except for the current one
+        sess = d.get_weasyl_session()
+        d.engine.execute("""
+            DELETE FROM sessions
+            WHERE userid = (%(userid)s)
+              AND sessionid != (%(currentsession)s)
+        """, userid=userid, currentsession=sess.sessionid)
+
 
 def edit_preferences(userid, timezone=None,
                      preferences=None, jsonb_settings=None):

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -566,7 +566,7 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
         d.engine.execute("""
             DELETE FROM sessions
             WHERE userid = %(userid)s
-              AND sessionid != (%(currentsession)s)
+              AND sessionid != %(currentsession)s
         """, userid=userid, currentsession=sess.sessionid)
 
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1061,7 +1061,7 @@ def select_recently_popular():
         SELECT
             log(count(favorite.*) + 1) +
                 log(submission.page_views + 1) / 2 +
-                submission.unixtime / 180000 AS score,
+                submission.unixtime / 180000.0 AS score,
             submission.submitid,
             submission.title,
             submission.rating,


### PR DESCRIPTION
Addresses #221.

Obtains the current session via ``d.get_weasyl_session()``, then deletes all records from the ``session`` table where records match the ``userid`` for whom we just updated their password, and where the ``sessionid`` in the candidate record does not equal the ``sessionid`` in the session object.