### PR TITLE
Shout notifications should link to /shouts/username#cid

### DIFF
--- a/templates/message/notifications.html
+++ b/templates/message/notifications.html
@@ -157,7 +157,7 @@ $:{RENDER("common/stage_title.html", ["Notifications", "Messages", 0])}
               <a href="/site-updates/${i['updateid']}">${i['title']}</a>
             $elif i['type'] == 4010:
               $# shout
-              $:{item_user} left a <a href="/shouts#cid${i['commentid']}">comment</a> on your shout page.
+              $:{item_user} left a <a href="/shouts/${i['ownername']}#cid${i['commentid']}">comment</a> on your shout page.
             $elif i['type'] == 4015:
               $# shout reply
               $:{item_user} left a $:{shout_reply('shouts')} to $:{your_comment('shouts')} on $:{item_ownername}</a>'s shout page.

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -363,12 +363,14 @@ def select_comments(userid):
     queries = []
 
     # Shout comments
+    current_username = d.get_sysname(d.get_display_name(userid))
     queries.append({
         "type": 4010,
         "id": i.welcomeid,
         "unixtime": i.unixtime,
         "userid": i.otherid,
         "username": i.username,
+        "ownername": current_username,
         "commentid": i.targetid,
     } for i in d.engine.execute("""
         SELECT we.welcomeid, we.unixtime, we.otherid, we.targetid, pr.username


### PR DESCRIPTION
Addresses #212.

Linking to /shouts#cid only works if the link is visited while logged in, as the target user to whom the shout was sent. Adding the user to whom the shout was sent permits a more permanent link, and works if the link is copied and visited while logged or or sent to a different user if copied.

Effectively, this change makes this (in the ``/messages/notifications#comments`` section):
```
<a href="/~ikani" class="username">Ikani</a> left a <a href="/shouts#cid2610533">comment</a> on your shout page.
```
Into this:
```
<a href="/~ikani" class="username">Ikani</a> left a <a href="/shouts/kyra#cid2610533">comment</a> on your shout page.
```