### PR TITLE
Input Hardening & Validation of Input

### DIFF
--- a/templates/control/edit_profile.html
+++ b/templates/control/edit_profile.html
@@ -28,7 +28,7 @@ $code:
       <input type="text" id="editprofile-gender" class="input" name="gender" value="${userinfo['gender']}" maxlength="100" />
 
       <label for="editprofile-country">Location</label>
-      <input type="text" id="editprofile-country" class="input" name="country" value="${userinfo['country']}" maxlength="100" />
+      <input type="text" id="editprofile-country" class="input" name="country" value="${userinfo['country']}" maxlength="50" />
 
       <label for="editprofile-catchphrase">Catchphrase</label>
       <input type="text" id="editprofile-catchphrase" class="input" name="catchphrase" value="${profile['catchphrase']}" maxlength="200" />
@@ -110,11 +110,11 @@ $code:
       $for site, values in userinfo['sorted_user_links']:
         $for value in values:
           <div class="group">
-            <input type="text" class="input site-name" name="site_names" value="${site}" placeholder="Site">
+            <input type="text" class="input site-name" name="site_names" value="${site}" placeholder="Site Name" maxlength="64">
             <input type="text" class="input" name="site_values" value="${value}" placeholder="Username or URL">
           </div>
       <div class="group">
-        <input type="text" class="input site-name" name="site_names" placeholder="Site">
+        <input type="text" class="input site-name" name="site_names" placeholder="Site Name" maxlength="64">
         <input type="text" class="input" name="site_values" placeholder="Username or URL">
       </div>
       <div class="group">

--- a/templates/submit/journal.html
+++ b/templates/submit/journal.html
@@ -9,7 +9,7 @@ $:{RENDER("common/stage_title.html", ["Journal Entry", "Submit", "/submit"])}
       <h3>Information</h3>
 
       <label for="journaltitle">Title</label>
-      <input type="text" class="input" name="title" id="journaltitle" required />
+      <input type="text" class="input" name="title" id="journaltitle" maxlength="200" required />
 
       <label for="journalrating">Rating</label>
       <select name="rating" class="input" id="journalrating" required>

--- a/weasyl/avatar.py
+++ b/weasyl/avatar.py
@@ -34,7 +34,7 @@ def upload(userid, filedata):
 
 # TODO: Make this function respect new geometry.
 def create(userid, x1, y1, x2, y2, auto=False, config=None):
-    x1, y1, x2, y2 = d.get_int(x1), d.get_int(y1), d.get_int(x2), d.get_int(y2)
+    x1, y1, x2, y2 = d.get_int_DEPRECIATED(x1), d.get_int_DEPRECIATED(y1), d.get_int_DEPRECIATED(x2), d.get_int_DEPRECIATED(y2)
     db = d.connect()
     im = db.query(orm.MediaItem).get(avatar_source(userid)['mediaid']).as_image()
     file_type = image.image_file_type(im)

--- a/weasyl/comment.py
+++ b/weasyl/comment.py
@@ -192,7 +192,7 @@ def insert(userid, submitid=None, charid=None, journalid=None, parentid=None, co
 
 # NOTE: This method is UNUSED.
 def edit(userid, form):
-    commentid = d.get_int(form.commentid)
+    commentid = d.get_int_DEPRECIATED(form.commentid)
 
     if form.feature not in ["submit", "char", "journal"]:
         raise WeasylError("Unexpected")

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -417,14 +417,14 @@ def edit_content(userid, content):
 
 def remove_class(userid, classid):
     if not d.execute("SELECT EXISTS (SELECT 0 FROM commishclass WHERE (classid, userid) = (%i, %i))",
-                     [d.get_int(classid), userid], ["bool"]):
+                     [d.get_int_DEPRECIATED(classid), userid], ["bool"]):
         raise WeasylError("classidInvalid")
-    d.execute("DELETE FROM commishclass WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
-    d.execute("DELETE FROM commishprice WHERE (classid, userid) = (%i, %i)", [d.get_int(classid), userid])
+    d.execute("DELETE FROM commishclass WHERE (classid, userid) = (%i, %i)", [d.get_int_DEPRECIATED(classid), userid])
+    d.execute("DELETE FROM commishprice WHERE (classid, userid) = (%i, %i)", [d.get_int_DEPRECIATED(classid), userid])
 
 
 def remove_price(userid, priceid):
     if not d.execute("SELECT EXISTS (SELECT 0 FROM commishprice WHERE (priceid, userid) = (%i, %i))",
-                     [d.get_int(priceid), userid], ["bool"]):
+                     [d.get_int_DEPRECIATED(priceid), userid], ["bool"]):
         raise WeasylError("priceidInvalid")
-    d.execute("DELETE FROM commishprice WHERE (priceid, userid) = (%i, %i)", [d.get_int(priceid), userid])
+    d.execute("DELETE FROM commishprice WHERE (priceid, userid) = (%i, %i)", [d.get_int_DEPRECIATED(priceid), userid])

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -50,7 +50,7 @@ def submit_visual_post_(request):
     if not define.config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
@@ -58,8 +58,8 @@ def submit_visual_post_(request):
     s.title = form.title
     s.rating = rating
     s.content = form.content
-    s.folderid = define.get_int(form.folderid) or None
-    s.subtype = define.get_int(form.subtype)
+    s.folderid = define.get_int_DEPRECIATED(form.folderid) or None
+    s.subtype = define.get_int_DEPRECIATED(form.subtype)
 
     submitid = submission.create_visual(
         request.userid, s, friends_only=form.friends, tags=tags,
@@ -95,7 +95,7 @@ def submit_literary_post_(request):
     if not define.config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
@@ -103,8 +103,8 @@ def submit_literary_post_(request):
     s.title = form.title
     s.rating = rating
     s.content = form.content
-    s.folderid = define.get_int(form.folderid) or None
-    s.subtype = define.get_int(form.subtype)
+    s.folderid = define.get_int_DEPRECIATED(form.folderid) or None
+    s.subtype = define.get_int_DEPRECIATED(form.subtype)
 
     submitid, thumb = submission.create_literary(
         request.userid, s, embedlink=form.embedlink, friends_only=form.friends, tags=tags,
@@ -139,7 +139,7 @@ def submit_multimedia_post_(request):
     if not define.config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
@@ -147,8 +147,8 @@ def submit_multimedia_post_(request):
     s.title = form.title
     s.rating = rating
     s.content = form.content
-    s.folderid = define.get_int(form.folderid) or None
-    s.subtype = define.get_int(form.subtype)
+    s.folderid = define.get_int_DEPRECIATED(form.folderid) or None
+    s.subtype = define.get_int_DEPRECIATED(form.subtype)
 
     autothumb = ('noautothumb' not in form)
 
@@ -182,7 +182,7 @@ def submit_character_post_(request):
     if not define.config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
@@ -217,7 +217,7 @@ def submit_journal_post_(request):
     if not define.config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
@@ -240,8 +240,8 @@ def submit_shout_(request):
         raise WeasylError("InsufficientPermissions")
 
     c = orm.Comment()
-    c.parentid = define.get_int(form.parentid)
-    c.userid = define.get_int(form.userid or form.staffnotes)
+    c.parentid = define.get_int_DEPRECIATED(form.parentid)
+    c.userid = define.get_int_DEPRECIATED(form.userid or form.staffnotes)
     c.content = form.content
 
     commentid = shout.insert(request.userid, c, staffnotes=form.staffnotes)
@@ -250,9 +250,9 @@ def submit_shout_(request):
         return {"id": commentid}
 
     if form.staffnotes:
-        raise HTTPSeeOther(location='/staffnotes?userid=%i#cid%i' % (define.get_int(form.staffnotes), commentid))
+        raise HTTPSeeOther(location='/staffnotes?userid=%i#cid%i' % (define.get_int_DEPRECIATED(form.staffnotes), commentid))
     else:
-        raise HTTPSeeOther(location="/shouts?userid=%i#cid%i" % (define.get_int(form.userid), commentid))
+        raise HTTPSeeOther(location="/shouts?userid=%i#cid%i" % (define.get_int_DEPRECIATED(form.userid), commentid))
 
 
 @login_required
@@ -261,21 +261,21 @@ def submit_shout_(request):
 def submit_comment_(request):
     form = request.web_input(submitid="", charid="", journalid="", parentid="", content="", format="")
 
-    commentid = comment.insert(request.userid, charid=define.get_int(form.charid),
-                               parentid=define.get_int(form.parentid),
-                               submitid=define.get_int(form.submitid),
-                               journalid=define.get_int(form.journalid),
+    commentid = comment.insert(request.userid, charid=define.get_int_DEPRECIATED(form.charid),
+                               parentid=define.get_int_DEPRECIATED(form.parentid),
+                               submitid=define.get_int_DEPRECIATED(form.submitid),
+                               journalid=define.get_int_DEPRECIATED(form.journalid),
                                content=form.content)
 
     if form.format == "json":
         return {"id": commentid}
 
-    if define.get_int(form.submitid):
-        raise HTTPSeeOther(location="/submission/%i#cid%i" % (define.get_int(form.submitid), commentid))
-    elif define.get_int(form.charid):
-        raise HTTPSeeOther(location="/character/%i#cid%i" % (define.get_int(form.charid), commentid))
+    if define.get_int_DEPRECIATED(form.submitid):
+        raise HTTPSeeOther(location="/submission/%i#cid%i" % (define.get_int_DEPRECIATED(form.submitid), commentid))
+    elif define.get_int_DEPRECIATED(form.charid):
+        raise HTTPSeeOther(location="/character/%i#cid%i" % (define.get_int_DEPRECIATED(form.charid), commentid))
     else:
-        raise HTTPSeeOther(location="/journal/%i#cid%i" % (define.get_int(form.journalid), commentid))
+        raise HTTPSeeOther(location="/journal/%i#cid%i" % (define.get_int_DEPRECIATED(form.journalid), commentid))
 
 
 @login_required
@@ -286,12 +286,12 @@ def submit_report_(request):
     report.create(request.userid, form)
     if form.reportid:
         raise HTTPSeeOther(location="/modcontrol/report?reportid=%s" % (form.reportid,))
-    elif define.get_int(form.submitid):
-        raise HTTPSeeOther(location="/submission/%i" % (define.get_int(form.submitid),))
-    elif define.get_int(form.charid):
-        raise HTTPSeeOther(location="/character/%i" % (define.get_int(form.charid),))
+    elif define.get_int_DEPRECIATED(form.submitid):
+        raise HTTPSeeOther(location="/submission/%i" % (define.get_int_DEPRECIATED(form.submitid),))
+    elif define.get_int_DEPRECIATED(form.charid):
+        raise HTTPSeeOther(location="/character/%i" % (define.get_int_DEPRECIATED(form.charid),))
     else:
-        raise HTTPSeeOther(location="/journal/%i" % (define.get_int(form.journalid),))
+        raise HTTPSeeOther(location="/journal/%i" % (define.get_int_DEPRECIATED(form.journalid),))
 
 
 @login_required
@@ -301,11 +301,11 @@ def submit_tags_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    submitid = define.get_int(form.submitid)
-    charid = define.get_int(form.charid)
-    journalid = define.get_int(form.journalid)
-    preferred_tags_userid = define.get_int(form.preferred_tags_userid)
-    optout_tags_userid = define.get_int(form.optout_tags_userid)
+    submitid = define.get_int_DEPRECIATED(form.submitid)
+    charid = define.get_int_DEPRECIATED(form.charid)
+    journalid = define.get_int_DEPRECIATED(form.journalid)
+    preferred_tags_userid = define.get_int_DEPRECIATED(form.preferred_tags_userid)
+    optout_tags_userid = define.get_int_DEPRECIATED(form.optout_tags_userid)
 
     result = searchtag.associate(request.userid, tags, submitid, charid, journalid, preferred_tags_userid, optout_tags_userid)
     if result:
@@ -343,7 +343,7 @@ def submit_tags_(request):
 @login_required
 def reupload_submission_get_(request):
     form = request.web_input(submitid="")
-    form.submitid = define.get_int(form.submitid)
+    form.submitid = define.get_int_DEPRECIATED(form.submitid)
 
     if request.userid != define.get_ownerid(submitid=form.submitid):
         return Response(define.errorpage(request.userid, errorcode.permission))
@@ -359,7 +359,7 @@ def reupload_submission_get_(request):
 @token_checked
 def reupload_submission_post_(request):
     form = request.web_input(targetid="", submitfile="")
-    form.targetid = define.get_int(form.targetid)
+    form.targetid = define.get_int_DEPRECIATED(form.targetid)
 
     if request.userid != define.get_ownerid(submitid=form.targetid):
         return Response(define.errorpage(request.userid, errorcode.permission))
@@ -371,7 +371,7 @@ def reupload_submission_post_(request):
 @login_required
 def reupload_character_get_(request):
     form = request.web_input(charid="")
-    form.charid = define.get_int(form.charid)
+    form.charid = define.get_int_DEPRECIATED(form.charid)
 
     if request.userid != define.get_ownerid(charid=form.charid):
         return Response(define.errorpage(request.userid, errorcode.permission))
@@ -387,7 +387,7 @@ def reupload_character_get_(request):
 @token_checked
 def reupload_character_post_(request):
     form = request.web_input(targetid="", submitfile="")
-    form.targetid = define.get_int(form.targetid)
+    form.targetid = define.get_int_DEPRECIATED(form.targetid)
 
     if request.userid != define.get_ownerid(charid=form.targetid):
         return Response(define.errorpage(request.userid, errorcode.permission))
@@ -399,7 +399,7 @@ def reupload_character_post_(request):
 @login_required
 def reupload_cover_get_(request):
     form = request.web_input(submitid="")
-    form.submitid = define.get_int(form.submitid)
+    form.submitid = define.get_int_DEPRECIATED(form.submitid)
 
     if request.userid != define.get_ownerid(submitid=form.submitid):
         return Response(define.errorpage(request.userid, errorcode.permission))
@@ -411,7 +411,7 @@ def reupload_cover_get_(request):
 @token_checked
 def reupload_cover_post_(request):
     form = request.web_input(submitid="", coverfile="")
-    form.submitid = define.get_int(form.submitid)
+    form.submitid = define.get_int_DEPRECIATED(form.submitid)
 
     submission.reupload_cover(request.userid, form.submitid, form.coverfile)
     raise HTTPSeeOther(location="/submission/%i" % (form.submitid,))
@@ -421,7 +421,7 @@ def reupload_cover_post_(request):
 @login_required
 def edit_submission_get_(request):
     form = request.web_input(submitid="", anyway="")
-    form.submitid = define.get_int(form.submitid)
+    form.submitid = define.get_int_DEPRECIATED(form.submitid)
 
     detail = submission.select_view(request.userid, form.submitid, ratings.EXPLICIT.code, False, anyway=form.anyway)
 
@@ -448,22 +448,22 @@ def edit_submission_post_(request):
     form = request.web_input(submitid="", title="", folderid="", subtype="", rating="",
                              content="", friends="", critique="", embedlink="")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
     s = orm.Submission()
-    s.submitid = define.get_int(form.submitid)
+    s.submitid = define.get_int_DEPRECIATED(form.submitid)
     s.title = form.title
     s.rating = rating
     s.content = form.content
-    s.folderid = define.get_int(form.folderid) or None
-    s.subtype = define.get_int(form.subtype)
+    s.folderid = define.get_int_DEPRECIATED(form.folderid) or None
+    s.subtype = define.get_int_DEPRECIATED(form.subtype)
 
     submission.edit(request.userid, s, embedlink=form.embedlink,
                     friends_only=form.friends, critique=form.critique)
     raise HTTPSeeOther(location="/submission/%i/%s%s" % (
-        define.get_int(form.submitid),
+        define.get_int_DEPRECIATED(form.submitid),
         slug_for(form.title),
         "?anyway=true" if request.userid in staff.MODS else ''
     ))
@@ -472,7 +472,7 @@ def edit_submission_post_(request):
 @login_required
 def edit_character_get_(request):
     form = request.web_input(charid="", anyway="")
-    form.charid = define.get_int(form.charid)
+    form.charid = define.get_int_DEPRECIATED(form.charid)
 
     detail = character.select_view(request.userid, form.charid, ratings.EXPLICIT.code, False, anyway=form.anyway)
 
@@ -492,12 +492,12 @@ def edit_character_post_(request):
     form = request.web_input(charid="", title="", age="", gender="", height="",
                              weight="", species="", rating="", content="", friends="")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
     c = orm.Character()
-    c.charid = define.get_int(form.charid)
+    c.charid = define.get_int_DEPRECIATED(form.charid)
     c.age = form.age
     c.gender = form.gender
     c.height = form.height
@@ -509,7 +509,7 @@ def edit_character_post_(request):
 
     character.edit(request.userid, c, friends_only=form.friends)
     raise HTTPSeeOther(location="/character/%i/%s%s" % (
-        define.get_int(form.charid),
+        define.get_int_DEPRECIATED(form.charid),
         slug_for(form.title),
         ("?anyway=true" if request.userid in staff.MODS else '')
     ))
@@ -518,7 +518,7 @@ def edit_character_post_(request):
 @login_required
 def edit_journal_get_(request):
     form = request.web_input(journalid="", anyway="")
-    form.journalid = define.get_int(form.journalid)
+    form.journalid = define.get_int_DEPRECIATED(form.journalid)
 
     detail = journal.select_view(request.userid, ratings.EXPLICIT.code, form.journalid, False, anyway=form.anyway)
 
@@ -535,18 +535,18 @@ def edit_journal_get_(request):
 def edit_journal_post_(request):
     form = request.web_input(journalid="", title="", rating="", friends="", content="")
 
-    rating = ratings.CODE_MAP.get(define.get_int(form.rating))
+    rating = ratings.CODE_MAP.get(define.get_int_DEPRECIATED(form.rating))
     if not rating:
         raise WeasylError("ratingInvalid")
 
     j = orm.Journal()
-    j.journalid = define.get_int(form.journalid)
+    j.journalid = define.get_int_DEPRECIATED(form.journalid)
     j.title = form.title
     j.rating = rating
     j.content = form.content
     journal.edit(request.userid, j, friends_only=form.friends)
     raise HTTPSeeOther(location="/journal/%i/%s%s" % (
-        define.get_int(form.journalid),
+        define.get_int_DEPRECIATED(form.journalid),
         slug_for(form.title),
         ("?anyway=true" if request.userid in staff.MODS else '')
     ))
@@ -558,7 +558,7 @@ def edit_journal_post_(request):
 def remove_submission_(request):
     form = request.web_input(submitid="")
 
-    ownerid = submission.remove(request.userid, define.get_int(form.submitid))
+    ownerid = submission.remove(request.userid, define.get_int_DEPRECIATED(form.submitid))
     if request.userid == ownerid:
         raise HTTPSeeOther(location="/control")  # todo
     else:
@@ -570,7 +570,7 @@ def remove_submission_(request):
 def remove_character_(request):
     form = request.web_input(charid="")
 
-    ownerid = character.remove(request.userid, define.get_int(form.charid))
+    ownerid = character.remove(request.userid, define.get_int_DEPRECIATED(form.charid))
     if request.userid == ownerid:
         raise HTTPSeeOther(location="/control")  # todo
     else:
@@ -582,7 +582,7 @@ def remove_character_(request):
 def remove_journal_(request):
     form = request.web_input(journalid="")
 
-    ownerid = journal.remove(request.userid, define.get_int(form.journalid))
+    ownerid = journal.remove(request.userid, define.get_int_DEPRECIATED(form.journalid))
     if request.userid == ownerid:
         raise HTTPSeeOther(location="/control")  # todo
     else:
@@ -594,7 +594,7 @@ def remove_journal_(request):
 @supports_json
 def remove_comment_(request):
     form = request.web_input(commentid="", feature="", format="")
-    commentid = define.get_int(form.commentid)
+    commentid = define.get_int_DEPRECIATED(form.commentid)
 
     if form.feature == "userid":
         targetid = shout.remove(request.userid, commentid=commentid)

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -18,7 +18,7 @@ def submission_(request):
     form = request.web_input(submitid="", ignore="", anyway="")
 
     rating = define.get_rating(request.userid)
-    submitid = define.get_int(submitid) if submitid else define.get_int(form.submitid)
+    submitid = define.get_int_DEPRECIATED(submitid) if submitid else define.get_int_DEPRECIATED(form.submitid)
 
     extras = {
         "pdf": True,
@@ -106,7 +106,7 @@ def character_(request):
     form = request.web_input(charid="", ignore="", anyway="")
 
     rating = define.get_rating(request.userid)
-    charid = define.get_int(request.matchdict.get('charid', form.charid))
+    charid = define.get_int_DEPRECIATED(request.matchdict.get('charid', form.charid))
 
     try:
         item = character.select_view(
@@ -140,7 +140,7 @@ def journal_(request):
     form = request.web_input(journalid="", ignore="", anyway="")
 
     rating = define.get_rating(request.userid)
-    journalid = define.get_int(request.matchdict.get('journalid', form.journalid))
+    journalid = define.get_int_DEPRECIATED(request.matchdict.get('journalid', form.journalid))
 
     try:
         item = journal.select_view(

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -27,11 +27,12 @@ def search_(request):
 
     page = define.common_page_start(request.userid, title="Browse and search")
 
+    # Input hardening/validation; form.find can only be certain values
+    if form.q or form.find and form.find not in ("submit", "char", "journal", "user"):
+        form.find = "submit"
+
     if form.q:
         find = form.find
-
-        if find not in ("submit", "char", "journal", "user"):
-            find = "submit"
 
         q = form.q.strip()
         search_query = search.Query.parse(q, find)
@@ -41,10 +42,10 @@ def search_(request):
             "find": search_query.find,
             "within": form.within,
             "rated": set('gmap') & set(form.rated),
-            "cat": int(form.cat) if form.cat else None,
-            "subcat": int(form.subcat) if form.subcat else None,
-            "backid": int(form.backid) if form.backid else None,
-            "nextid": int(form.nextid) if form.nextid else None,
+            "cat": define.get_int(form.cat) if form.cat else None,
+            "subcat": define.get_int(form.subcat) if form.subcat else None,
+            "backid": define.get_int(form.backid) if form.backid else None,
+            "nextid": define.get_int(form.nextid) if form.nextid else None,
         }
 
         if search_query.find == "user":
@@ -82,7 +83,7 @@ def search_(request):
 
         meta = {
             "find": form.find,
-            "cat": int(form.cat) if form.cat else None,
+            "cat": define.get_int(form.cat) if form.cat else None,
         }
 
         page.append(define.render("etc/search.html", [

--- a/weasyl/controllers/interaction.py
+++ b/weasyl/controllers/interaction.py
@@ -14,7 +14,7 @@ from weasyl import (
 @token_checked
 def followuser_(request):
     form = request.web_input(userid="")
-    otherid = define.get_int(form.userid)
+    otherid = define.get_int_DEPRECIATED(form.userid)
 
     if request.userid == otherid:
         return Response(define.errorpage(request.userid, "You cannot follow yourself."))
@@ -32,7 +32,7 @@ def followuser_(request):
 @token_checked
 def unfollowuser_(request):
     form = request.web_input(userid="")
-    form.otherid = define.get_int(form.userid)
+    form.otherid = define.get_int_DEPRECIATED(form.userid)
 
     followuser.remove(request.userid, form.otherid)
 
@@ -45,7 +45,7 @@ def unfollowuser_(request):
 @token_checked
 def frienduser_(request):
     form = request.web_input(userid="")
-    otherid = define.get_int(form.userid)
+    otherid = define.get_int_DEPRECIATED(form.userid)
 
     if request.userid == otherid:
         return Response(define.errorpage(request.userid, "You cannot friend yourself."))
@@ -69,7 +69,7 @@ def frienduser_(request):
 @token_checked
 def unfrienduser_(request):
     form = request.web_input(userid="", feature="")
-    otherid = define.get_int(form.userid)
+    otherid = define.get_int_DEPRECIATED(form.userid)
 
     if request.userid == otherid:
         return Response(define.errorpage(request.userid, "You cannot friend yourself."))
@@ -83,7 +83,7 @@ def unfrienduser_(request):
 @token_checked
 def ignoreuser_(request):
     form = request.web_input(userid="")
-    otherid = define.get_int(form.userid)
+    otherid = define.get_int_DEPRECIATED(form.userid)
 
     if form.action == "ignore":
         if not ignoreuser.check(request.userid, otherid):
@@ -180,9 +180,9 @@ def notes_remove_(request):
 @token_checked
 def favorite_(request):
     form = request.web_input(submitid="", charid="", journalid="")
-    form.charid = define.get_int(form.charid)
-    form.submitid = define.get_int(form.submitid)
-    form.journalid = define.get_int(form.journalid)
+    form.charid = define.get_int_DEPRECIATED(form.charid)
+    form.submitid = define.get_int_DEPRECIATED(form.submitid)
+    form.journalid = define.get_int_DEPRECIATED(form.journalid)
 
     if form.action == "favorite":
         favorite.insert(request.userid, form.submitid, form.charid, form.journalid)

--- a/weasyl/controllers/messages.py
+++ b/weasyl/controllers/messages.py
@@ -20,7 +20,7 @@ def messages_remove_(request):
     if remove_all_before:
         message.remove_all_before(request.userid, int(remove_all_before))
     elif form.get('remove-all-submissions'):
-        message.remove_all_submissions(request.userid, define.get_int(form['remove-all-submissions']))
+        message.remove_all_submissions(request.userid, define.get_int_DEPRECIATED(form['remove-all-submissions']))
     else:
         message.remove(request.userid, map(int, form.remove))
 
@@ -72,5 +72,5 @@ def messages_submissions_(request):
         form.feature,
         # Submissions
         message.select_submissions(request.userid, 66,
-                                   backtime=define.get_int(form.backtime), nexttime=define.get_int(form.nexttime)),
+                                   backtime=define.get_int_DEPRECIATED(form.backtime), nexttime=define.get_int_DEPRECIATED(form.nexttime)),
     ]))

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -155,7 +155,7 @@ def modcontrol_manageuser_(request):
 def modcontrol_removeavatar_(request):
     form = request.web_input(userid="")
 
-    moderation.removeavatar(request.userid, define.get_int(form.userid))
+    moderation.removeavatar(request.userid, define.get_int_DEPRECIATED(form.userid))
     raise HTTPSeeOther(location="/modcontrol")
 
 
@@ -164,7 +164,7 @@ def modcontrol_removeavatar_(request):
 def modcontrol_removebanner_(request):
     form = request.web_input(userid="")
 
-    moderation.removebanner(request.userid, define.get_int(form.userid))
+    moderation.removebanner(request.userid, define.get_int_DEPRECIATED(form.userid))
     raise HTTPSeeOther(location="/modcontrol")
 
 
@@ -173,7 +173,7 @@ def modcontrol_removebanner_(request):
 def modcontrol_editprofiletext_(request):
     form = request.web_input(userid="", content="")
 
-    moderation.editprofiletext(request.userid, define.get_int(form.userid), form.content)
+    moderation.editprofiletext(request.userid, define.get_int_DEPRECIATED(form.userid), form.content)
     raise HTTPSeeOther(location="/modcontrol")
 
 
@@ -182,7 +182,7 @@ def modcontrol_editprofiletext_(request):
 def modcontrol_editcatchphrase_(request):
     form = request.web_input(userid="", content="")
 
-    moderation.editcatchphrase(request.userid, define.get_int(form.userid), form.content)
+    moderation.editcatchphrase(request.userid, define.get_int_DEPRECIATED(form.userid), form.content)
     raise HTTPSeeOther(location="/modcontrol")
 
 

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -16,7 +16,7 @@ def profile_(request):
     form = request.web_input(userid="", name="")
 
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
@@ -119,12 +119,12 @@ def profile_media_(request):
 def submissions_(request):
     form = request.web_input(userid="", name="", backid=None, nextid=None, folderid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
     otherid = profile.resolve(request.userid, form.userid, form.name)
-    folderid = define.get_int(form.folderid) or None
+    folderid = define.get_int_DEPRECIATED(form.folderid) or None
 
     if not otherid:
         raise WeasylError("userRecordMissing")
@@ -141,8 +141,8 @@ def submissions_(request):
                  folderquery="&folderid=%d" % folderid if folderid else "")
     result = pagination.PaginatedResult(
         submission.select_list, submission.select_count, 'submitid', url_format, request.userid, rating,
-        60, otherid=otherid, folderid=folderid, backid=define.get_int(form.backid),
-        nextid=define.get_int(form.nextid), config=config, profile_page_filter=not folderid)
+        60, otherid=otherid, folderid=folderid, backid=define.get_int_DEPRECIATED(form.backid),
+        nextid=define.get_int_DEPRECIATED(form.nextid), config=config, profile_page_filter=not folderid)
 
     page.append(define.render('user/submissions.html', [
         # Profile information
@@ -166,7 +166,7 @@ def collections_(request):
     form = request.web_input(userid="", name="", backid=None, nextid=None,
                              folderid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
@@ -185,7 +185,7 @@ def collections_(request):
     url_format = "/collections?userid={userid}&%s".format(userid=userprofile['userid'])
     result = pagination.PaginatedResult(
         collection.select_list, collection.select_count, 'submitid', url_format, request.userid, rating, 66,
-        otherid=otherid, backid=define.get_int(form.backid), nextid=define.get_int(form.nextid), config=config)
+        otherid=otherid, backid=define.get_int_DEPRECIATED(form.backid), nextid=define.get_int_DEPRECIATED(form.nextid), config=config)
 
     page.append(define.render('user/collections.html', [
         # Profile information
@@ -204,7 +204,7 @@ def collections_(request):
 def journals_(request):
     form = request.web_input(userid="", name="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
@@ -240,7 +240,7 @@ def journals_(request):
 def characters_(request):
     form = request.web_input(userid="", name="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
@@ -260,8 +260,8 @@ def characters_(request):
     result = pagination.PaginatedResult(
         character.select_list, character.select_count,
         'charid', url_format, request.userid, rating, 60,
-        otherid=otherid, backid=define.get_int(form.backid),
-        nextid=define.get_int(form.nextid), config=config)
+        otherid=otherid, backid=define.get_int_DEPRECIATED(form.backid),
+        nextid=define.get_int_DEPRECIATED(form.nextid), config=config)
 
     page.append(define.render('user/characters.html', [
         # Profile information
@@ -280,7 +280,7 @@ def characters_(request):
 def shouts_(request):
     form = request.web_input(userid="", name="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     otherid = profile.resolve(request.userid, form.userid, form.name)
 
@@ -315,7 +315,7 @@ def shouts_(request):
 @moderator_only
 def staffnotes_(request):
     form = request.web_input(userid="")
-    otherid = profile.resolve(request.userid, define.get_int(form.userid), request.matchdict.get('name', None))
+    otherid = profile.resolve(request.userid, define.get_int_DEPRECIATED(form.userid), request.matchdict.get('name', None))
     if not otherid:
         raise WeasylError("userRecordMissing")
 
@@ -360,7 +360,7 @@ def favorites_(request):
 
     form = request.web_input(userid="", name="", feature="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     config = define.get_config(request.userid)
     rating = define.get_rating(request.userid)
@@ -382,8 +382,8 @@ def favorites_(request):
     page = define.common_page_start(request.userid, title=page_title)
 
     if form.feature:
-        nextid = define.get_int(form.nextid)
-        backid = define.get_int(form.backid)
+        nextid = define.get_int_DEPRECIATED(form.nextid)
+        backid = define.get_int_DEPRECIATED(form.backid)
         url_format = (
             "/favorites?userid={userid}&feature={feature}&%s".format(userid=userprofile['userid'], feature=form.feature))
         id_field = form.feature + "id"
@@ -429,7 +429,7 @@ def friends_(request):
 
         form = request.web_input(userid="", name="", backid=None, nextid=None)
         form.name = request.matchdict.get('name', form.name)
-        form.userid = define.get_int(form.userid)
+        form.userid = define.get_int_DEPRECIATED(form.userid)
 
         otherid = profile.resolve(request.userid, form.userid, form.name)
 
@@ -449,7 +449,7 @@ def friends_(request):
             profile.select_relation(request.userid, otherid),
             # Friends
             frienduser.select_friends(request.userid, otherid, limit=44,
-                                      backid=define.get_int(form.backid), nextid=define.get_int(form.nextid)),
+                                      backid=define.get_int_DEPRECIATED(form.backid), nextid=define.get_int_DEPRECIATED(form.nextid)),
         ]))
 
 
@@ -458,7 +458,7 @@ def following_(request):
 
     form = request.web_input(userid="", name="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     otherid = profile.resolve(request.userid, form.userid, form.name)
 
@@ -478,7 +478,7 @@ def following_(request):
         profile.select_relation(request.userid, otherid),
         # Following
         followuser.select_following(request.userid, otherid, limit=44,
-                                    backid=define.get_int(form.backid), nextid=define.get_int(form.nextid)),
+                                    backid=define.get_int_DEPRECIATED(form.backid), nextid=define.get_int_DEPRECIATED(form.nextid)),
     ]))
 
 
@@ -487,7 +487,7 @@ def followed_(request):
 
     form = request.web_input(userid="", name="", backid=None, nextid=None)
     form.name = request.matchdict.get('name', form.name)
-    form.userid = define.get_int(form.userid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
 
     otherid = profile.resolve(request.userid, form.userid, form.name)
 
@@ -507,5 +507,5 @@ def followed_(request):
         profile.select_relation(request.userid, otherid),
         # Followed
         followuser.select_followed(request.userid, otherid, limit=44,
-                                   backid=define.get_int(form.backid), nextid=define.get_int(form.nextid)),
+                                   backid=define.get_int_DEPRECIATED(form.backid), nextid=define.get_int_DEPRECIATED(form.nextid)),
     ]))

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -135,7 +135,7 @@ def control_editcommishclass_(request):
 
     commishclass = orm.CommishClass()
     commishclass.title = form.title.strip()
-    commishclass.classid = define.get_int(form.classid)
+    commishclass.classid = define.get_int_DEPRECIATED(form.classid)
     commishinfo.edit_class(request.userid, commishclass)
     raise HTTPSeeOther(location="/control/editcommissionsettings")
 
@@ -157,7 +157,7 @@ def control_createcommishprice_(request):
 
     price = orm.CommishPrice()
     price.title = form.title.strip()
-    price.classid = define.get_int(form.classid)
+    price.classid = define.get_int_DEPRECIATED(form.classid)
     price.amount_min = commishinfo.parse_currency(form.min_amount)
     price.amount_max = commishinfo.parse_currency(form.max_amount)
     commishinfo.create_price(request.userid, price, currency=form.currency,
@@ -173,7 +173,7 @@ def control_editcommishprice_(request):
 
     price = orm.CommishPrice()
     price.title = form.title.strip()
-    price.priceid = define.get_int(form.priceid)
+    price.priceid = define.get_int_DEPRECIATED(form.priceid)
     price.amount_min = commishinfo.parse_currency(form.min_amount)
     price.amount_max = commishinfo.parse_currency(form.max_amount)
     edit_prices = bool(price.amount_min or price.amount_max)
@@ -246,10 +246,10 @@ def control_editpreferences_post_(request):
             follow_s="", follow_c="", follow_f="", follow_t="",
             follow_j="", timezone="", twelvehour="")
 
-        rating = ratings.CODE_MAP[define.get_int(form.rating)]
+        rating = ratings.CODE_MAP[define.get_int_DEPRECIATED(form.rating)]
         jsonb_settings = define.get_profile_settings(request.userid)
         jsonb_settings.disable_custom_thumbs = form.custom_thumbs == "disable"
-        jsonb_settings.max_sfw_rating = define.get_int(form.sfwrating)
+        jsonb_settings.max_sfw_rating = define.get_int_DEPRECIATED(form.sfwrating)
 
         preferences = profile.Config()
         preferences.twelvehour = bool(form.twelvehour)
@@ -292,7 +292,7 @@ def control_createfolder_(request):
 def control_renamefolder_(request):
     form = request.web_input(folderid="", title="")
 
-    if define.get_int(form.folderid):
+    if define.get_int_DEPRECIATED(form.folderid):
         folder.rename(request.userid, form)
     raise HTTPSeeOther(location="/manage/folders")
 
@@ -301,7 +301,7 @@ def control_renamefolder_(request):
 @token_checked
 def control_removefolder_(request):
     form = request.web_input(folderid="")
-    form.folderid = define.get_int(form.folderid)
+    form.folderid = define.get_int_DEPRECIATED(form.folderid)
 
     if form.folderid:
         folder.remove(request.userid, form.folderid)
@@ -335,9 +335,9 @@ def control_editfolder_post_(request):
 @token_checked
 def control_movefolder_(request):
     form = request.web_input(folderid="", parentid="")
-    form.folderid = define.get_int(form.folderid)
+    form.folderid = define.get_int_DEPRECIATED(form.folderid)
 
-    if form.folderid and define.get_int(form.parentid) >= 0:
+    if form.folderid and define.get_int_DEPRECIATED(form.parentid) >= 0:
         folder.move(request.userid, form)
     raise HTTPSeeOther(location="/manage/folders")
 
@@ -366,7 +366,7 @@ def control_streaming_get_(request):
     if form.target and request.userid not in staff.MODS:
         return Response(define.errorpage(request.userid, errorcode.permission))
     elif form.target:
-        target = define.get_int(form.target)
+        target = define.get_int_DEPRECIATED(form.target)
     else:
         target = request.userid
 
@@ -390,7 +390,7 @@ def control_streaming_post_(request):
     else:
         target = request.userid
 
-    stream_length = define.clamp(define.get_int(form.stream_length), 0, 360)
+    stream_length = define.clamp(define.get_int_DEPRECIATED(form.stream_length), 0, 360)
     p = orm.Profile()
     p.stream_text = form.stream_text
     p.stream_url = define.text_fix_url(form.stream_url.strip())
@@ -460,9 +460,9 @@ def manage_folders_(request):
 @login_required
 def manage_following_get_(request):
     form = request.web_input(userid="", backid="", nextid="")
-    form.userid = define.get_int(form.userid)
-    form.backid = define.get_int(form.backid)
-    form.nextid = define.get_int(form.nextid)
+    form.userid = define.get_int_DEPRECIATED(form.userid)
+    form.backid = define.get_int_DEPRECIATED(form.backid)
+    form.nextid = define.get_int_DEPRECIATED(form.nextid)
 
     if form.userid:
         return Response(define.webpage(request.userid, "manage/following_user.html", [
@@ -489,7 +489,7 @@ def manage_following_post_(request):
     watch_settings.char = bool(form.char)
     watch_settings.stream = bool(form.stream)
     watch_settings.journal = bool(form.journal)
-    followuser.update(request.userid, define.get_int(form.userid), watch_settings)
+    followuser.update(request.userid, define.get_int_DEPRECIATED(form.userid), watch_settings)
 
     raise HTTPSeeOther(location="/manage/following")
 
@@ -497,8 +497,8 @@ def manage_following_post_(request):
 @login_required
 def manage_friends_(request):
     form = request.web_input(feature="", backid="", nextid="")
-    form.backid = define.get_int(form.backid)
-    form.nextid = define.get_int(form.nextid)
+    form.backid = define.get_int_DEPRECIATED(form.backid)
+    form.nextid = define.get_int_DEPRECIATED(form.nextid)
 
     if form.feature == "pending":
         return Response(define.webpage(request.userid, "manage/friends_pending.html", [
@@ -514,8 +514,8 @@ def manage_friends_(request):
 @login_required
 def manage_ignore_(request):
     form = request.web_input(feature="", backid="", nextid="")
-    form.backid = define.get_int(form.backid)
-    form.nextid = define.get_int(form.nextid)
+    form.backid = define.get_int_DEPRECIATED(form.backid)
+    form.nextid = define.get_int_DEPRECIATED(form.nextid)
 
     return Response(define.webpage(request.userid, "manage/ignore.html", [
         ignoreuser.select(request.userid, 20, backid=form.backid, nextid=form.nextid),
@@ -569,8 +569,8 @@ def manage_collections_post_(request):
 @login_required
 def manage_thumbnail_get_(request):
     form = request.web_input(submitid="", charid="", auto="")
-    submitid = define.get_int(form.submitid)
-    charid = define.get_int(form.charid)
+    submitid = define.get_int_DEPRECIATED(form.submitid)
+    charid = define.get_int_DEPRECIATED(form.charid)
 
     if submitid and request.userid not in staff.ADMINS and request.userid != define.get_ownerid(submitid=submitid):
         return Response(define.errorpage(request.userid, errorcode.permissions))
@@ -609,8 +609,8 @@ def manage_thumbnail_get_(request):
 @token_checked
 def manage_thumbnail_post_(request):
     form = request.web_input(submitid="", charid="", x1="", y1="", x2="", y2="", thumbfile="")
-    submitid = define.get_int(form.submitid)
-    charid = define.get_int(form.charid)
+    submitid = define.get_int_DEPRECIATED(form.submitid)
+    charid = define.get_int_DEPRECIATED(form.charid)
 
     if submitid and request.userid not in staff.ADMINS and request.userid != define.get_ownerid(submitid=submitid):
         return Response(define.errorpage(request.userid))
@@ -649,7 +649,7 @@ def manage_tagfilters_post_(request):
     form = request.web_input(do="", title="", rating="")
 
     if form.do == "create":
-        blocktag.insert(request.userid, title=form.title, rating=define.get_int(form.rating))
+        blocktag.insert(request.userid, title=form.title, rating=define.get_int_DEPRECIATED(form.rating))
     elif form.do == "remove":
         blocktag.remove(request.userid, title=form.title)
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -1,19 +1,19 @@
 from __future__ import absolute_import
 
-import os
-import re
-import time
-import random
-import urllib
+import datetime
+import functools
 import hashlib
 import logging
 import numbers
-import datetime
-import urlparse
-import functools
+import os
+import random
+import re
 import string
 import subprocess
+import time
 import unicodedata
+import urllib
+import urlparse
 
 import anyjson as json
 import arrow
@@ -504,9 +504,33 @@ def get_display_name(userid):
 
 
 def get_int(target):
+    """
+    Attempt to convert `target` to an Integer, otherwise returns zero if an exception is thrown.
+
+    Parameters: An item to attempt to convert to an Integer (such as a string).
+
+    Returns: The integer representation of `target`--dropping any decimals--if `target` can be
+    resolved to an int(), otherwise zero (0).
+    """
+    try:
+        return int(float(target))
+    except:
+        return 0
+
+
+def get_int_DEPRECIATED(target):
+    """
+    As on the tin, this function is depreciated. It does not return correct results as one might expect in 100% of the cases.
+
+    Existing code should have this function replaced with get_int() if it can be verified if there is no negative consequence
+    in doing so.
+
+    Examples of this incorrect behavior:
+      - get_int_DEPRECIATED('123.234') => 123234
+      - get_int_DEPRECIATED('123aaaaaaa2234') => 1232234
+    """
     if isinstance(target, numbers.Number):
         return int(target)
-
     try:
         return int("".join(i for i in target if i.isdigit()))
     except:
@@ -681,7 +705,7 @@ def convert_unixdate(day, month, year, escape=True):
     the date is not valid, None is returned.
     """
     if escape:
-        day, month, year = (get_int(i) for i in [day, month, year])
+        day, month, year = (get_int_DEPRECIATED(i) for i in [day, month, year])
 
     try:
         ret = int(time.mktime(datetime.date(year, month, day).timetuple()))
@@ -709,8 +733,8 @@ def convert_inputdate(target):
     if re.match(r"[0-9]+ [a-z]+,? [0-9]+", target):
         # 1 January 1990
         target = target.split()
-        target[0] = get_int(target[0])
-        target[2] = get_int(target[2])
+        target[0] = get_int_DEPRECIATED(target[0])
+        target[2] = get_int_DEPRECIATED(target[2])
 
         if 1933 <= target[0] <= 2037:
             return convert_unixdate(target[2], _month(target[1]), target[0])
@@ -719,16 +743,16 @@ def convert_inputdate(target):
     elif re.match("[a-z]+ [0-9]+,? [0-9]+", target):
         # January 1 1990
         target = target.split()
-        target[1] = get_int(target[1])
-        target[2] = get_int(target[2])
+        target[1] = get_int_DEPRECIATED(target[1])
+        target[2] = get_int_DEPRECIATED(target[2])
 
         return convert_unixdate(target[1], _month(target[0]), target[2])
     elif re.match("[0-9]+ ?/ ?[0-9]+ ?/ ?[0-9]+", target):
         # 1/1/1990
         target = target.split("/")
-        target[0] = get_int(target[0])
-        target[1] = get_int(target[1])
-        target[2] = get_int(target[2])
+        target[0] = get_int_DEPRECIATED(target[0])
+        target[1] = get_int_DEPRECIATED(target[1])
+        target[2] = get_int_DEPRECIATED(target[2])
 
         if target[0] > 12:
             return convert_unixdate(target[0], target[1], target[2])

--- a/weasyl/folder.py
+++ b/weasyl/folder.py
@@ -47,7 +47,7 @@ def check(userid, folderid=None, title=None, parentid=None, root=True):
 
 def create(userid, form):
     form.title = form.title.strip()[:_TITLE]
-    form.parentid = d.get_int(form.parentid)
+    form.parentid = d.get_int_DEPRECIATED(form.parentid)
 
     if not check(userid, form.parentid, parentid=0, root=True):
         raise WeasylError("folderRecordMissing")
@@ -253,7 +253,7 @@ def select_list(userid, feature, root=False, limit=None):
 
 def rename(userid, form):
     form.title = form.title.strip()[:_TITLE]
-    form.folderid = d.get_int(form.folderid)
+    form.folderid = d.get_int_DEPRECIATED(form.folderid)
 
     query = d.execute("SELECT userid FROM folder WHERE folderid = %i",
                       [form.folderid], options="element")
@@ -274,8 +274,8 @@ def rename(userid, form):
 #   parentid
 
 def move(userid, form):
-    form.folderid = d.get_int(form.folderid)
-    form.parentid = d.get_int(form.parentid)
+    form.folderid = d.get_int_DEPRECIATED(form.folderid)
+    form.parentid = d.get_int_DEPRECIATED(form.parentid)
 
     folder_query = d.execute(
         "SELECT folderid, parentid, userid, title FROM folder WHERE folderid = %i",

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -41,7 +41,7 @@ def create(userid, journal, friends_only=False, tags=None):
 
     journalid = d.engine.scalar(jo.insert().returning(jo.c.journalid), {
         "userid": userid,
-        "title": journal.title,
+        "title": journal.title[0:200],  # Max len = 200
         "rating": journal.rating.code,
         "unixtime": arrow.now(),
         "settings": settings,

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -282,7 +282,7 @@ def get_suspension(userid):
 
 
 def finduser(userid, form):
-    form.userid = d.get_int(form.userid)
+    form.userid = d.get_int_DEPRECIATED(form.userid)
     lo = d.meta.tables['login']
     sh = d.meta.tables['comments']
     q = d.sa.select([

--- a/weasyl/note.py
+++ b/weasyl/note.py
@@ -196,8 +196,8 @@ def send(userid, form):
 #   folderid
 
 def move(userid, form):
-    noteid = d.get_int(form.noteid)
-    folderid = d.get_int(form.folderid)
+    noteid = d.get_int_DEPRECIATED(form.noteid)
+    folderid = d.get_int_DEPRECIATED(form.folderid)
     query = d.execute("SELECT userid, otherid, settings FROM message WHERE noteid = %i", [noteid], options="single")
 
     if not query:

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -104,7 +104,7 @@ def resolve(userid, otherid, othername, myself=True):
     result = None
 
     if otherid:
-        result = d.execute("SELECT userid FROM login WHERE userid = %i", [d.get_int(otherid)], ["element"])
+        result = d.execute("SELECT userid FROM login WHERE userid = %i", [d.get_int_DEPRECIATED(otherid)], ["element"])
 
         if result:
             return result
@@ -498,17 +498,21 @@ def edit_userinfo(userid, form):
             continue
         row = {
             'userid': userid,
-            'link_type': site_name,
+            'link_type': site_name[0:64],  # Max length = 64
             'link_value': site_value,
         }
         row['userid'] = userid
         social_rows.append(row)
 
+    # Enforce attribute length limits
+    gender = form.gender[0:100].strip()  # Max length = 100
+    country = form.country[0:50].strip()  # Max length = 50
+
     d.engine.execute("""
         UPDATE userinfo
         SET gender = %(gender)s, country = %(country)s
         WHERE userid = %(userid)s
-    """, userid=userid, gender=form.gender.strip(), country=form.country.strip())
+    """, userid=userid, gender=gender, country=country)
     d.engine.execute("""
         DELETE FROM user_links
         WHERE userid = %(userid)s

--- a/weasyl/report.py
+++ b/weasyl/report.py
@@ -43,10 +43,10 @@ def _dict_of_targetid(submitid, charid, journalid):
 #   journalid
 
 def create(userid, form):
-    form.submitid = d.get_int(form.submitid)
-    form.charid = d.get_int(form.charid)
-    form.journalid = d.get_int(form.journalid)
-    form.violation = d.get_int(form.violation)
+    form.submitid = d.get_int_DEPRECIATED(form.submitid)
+    form.charid = d.get_int_DEPRECIATED(form.charid)
+    form.journalid = d.get_int_DEPRECIATED(form.journalid)
+    form.violation = d.get_int_DEPRECIATED(form.violation)
     form.content = form.content.strip()[:_CONTENT]
 
     # get the violation type from allowed types

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -403,8 +403,8 @@ def select(**kwargs):
 #   cat     nextid
 
 def browse(userid, rating, limit, form, find=None, config=None):
-    backid = d.get_int(form.backid)
-    nextid = d.get_int(form.nextid)
+    backid = d.get_int_DEPRECIATED(form.backid)
+    nextid = d.get_int_DEPRECIATED(form.nextid)
 
     if find:
         form.find = find
@@ -415,7 +415,7 @@ def browse(userid, rating, limit, form, find=None, config=None):
         query = journal.select_user_list(userid, rating, limit, backid=backid, nextid=nextid, config=config)
     else:
         query = submission.select_list(userid, rating, limit, backid=backid, nextid=nextid,
-                                       subcat=d.get_int(form.cat) if d.get_int(form.cat) in [1000, 2000, 3000] else None,
+                                       subcat=d.get_int_DEPRECIATED(form.cat) if d.get_int_DEPRECIATED(form.cat) in [1000, 2000, 3000] else None,
                                        config=config)
 
     if query and not backid:

--- a/weasyl/test/test_define.py
+++ b/weasyl/test/test_define.py
@@ -157,3 +157,18 @@ def test_viewing_own_profile(db):
 
 def test_sysname():
     assert d.get_sysname(u"ź") == "z"
+
+
+def test_get_int():
+    assert d.get_int(42) == 42
+    assert d.get_int("42") == 42
+    assert d.get_int(u"42") == 42
+    assert d.get_int(42.1) == 42
+    assert d.get_int(42.9) == 42
+    assert d.get_int("42.1") == 42
+    assert d.get_int("42.9") == 42
+    assert d.get_int(u"42.1") == 42
+    assert d.get_int(u"42.9") == 42
+    assert d.get_int("' OR 1=1;--") == 0
+    assert d.get_int("42aaaaaa24") == 0
+    assert d.get_int("42aaa1aaa24") == 0

--- a/weasyl/thumbnail.py
+++ b/weasyl/thumbnail.py
@@ -89,7 +89,7 @@ def upload(userid, filedata, submitid=None, charid=None):
 
 
 def _create_char(userid, x1, y1, x2, y2, charid, config=None, remove=True):
-    x1, y1, x2, y2 = d.get_int(x1), d.get_int(y1), d.get_int(x2), d.get_int(y2)
+    x1, y1, x2, y2 = d.get_int_DEPRECIATED(x1), d.get_int_DEPRECIATED(y1), d.get_int_DEPRECIATED(x2), d.get_int_DEPRECIATED(y2)
     filename = d.url_make(charid, "char/.thumb", root=True)
     if not m.os.path.exists(filename):
         filename = d.url_make(charid, "char/cover", root=True)
@@ -122,7 +122,7 @@ def create(userid, x1, y1, x2, y2, submitid=None, charid=None,
         return _create_char(userid, x1, y1, x2, y2, charid, config, remove)
 
     db = d.connect()
-    x1, y1, x2, y2 = d.get_int(x1), d.get_int(y1), d.get_int(x2), d.get_int(y2)
+    x1, y1, x2, y2 = d.get_int_DEPRECIATED(x1), d.get_int_DEPRECIATED(y1), d.get_int_DEPRECIATED(x2), d.get_int_DEPRECIATED(y2)
     source = thumbnail_source(submitid)
     im = db.query(orm.MediaItem).get(source['mediaid']).as_image()
     size = im.size.width, im.size.height


### PR DESCRIPTION
* Add function to validate claimed integers

define.get_int() is broken, and invalid input is getting through to the point where Sentry is picking up on it. Implements define.get_int() as a sane/safe function, and relies solely on Python primitives to determine type (AKA, return an Integer if it gets through int(float(number)), else return zero.

This, however, cuts down on many shenanigans or triggering of Sentry alerts, or will once all _DEPRECIATED calls are changed over to the current get_int()

Redefines the old/insecure version as define.get_int_DEPRECIATED() at the request of Charmander until we can validate that things won't break.

Sentry issues this should resolve:
https://sentry.weasyldev.com/weasyl/weasyl/issues/1483/ - weasyl/profile.py & HTML maxlength added
https://sentry.weasyldev.com/weasyl/weasyl/issues/1538/ - weasyl/profile.py & HTML maxlength added
https://sentry.weasyldev.com/weasyl/weasyl/issues/1513/ - weasyl/journal.py & HTML maxlength added
https://sentry.weasyldev.com/weasyl/weasyl/issues/1377/ - controllers/general.py
https://sentry.weasyldev.com/weasyl/weasyl/issues/1562/ - controllers/marketplace.py