### PR TITLE
2FA: Lower bcrypt work-factor to minimum

### DIFF
--- a/weasyl/two_factor_auth.py
+++ b/weasyl/two_factor_auth.py
@@ -19,7 +19,7 @@ from weasyl import define as d
 # Number of recovery codes to provide the user
 _TFA_RECOVERY_CODES = 10
 # Work factor for bcrypt to be used in hashing each recovery code
-BCRYPT_WORK_FACTOR = 10
+BCRYPT_WORK_FACTOR = 4
 # This length is configurable as needed; see generate_recovery_codes() below for keyspace/character set
 LENGTH_RECOVERY_CODE = 20
 # TOTP code length of 6 is the standard length, and is supported by Google Authenticator


### PR DESCRIPTION
Per discussion in Gitter, discussing the performance factor and how the recovery codes aren't exactly able to be brute-forced (easily, at least); the alternative was sha-256/512 unsalted, however per Charmander this 'makes it impossible to use a timing-unsafe lookup or comparison, as a side benefit'; lowers the bcrypt work-factor from 10 to the pyca/bcrypt minimum of 4.

No alterations needed to any other 2FA code. Bcrypt will handle Bcrypt.