### PR TITLE
Drop sequences only if they don’t exist

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/e50f34d62fd2_remove_incorrect_autoincrements.py
+++ b/libweasyl/libweasyl/alembic/versions/e50f34d62fd2_remove_incorrect_autoincrements.py
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.execute("DROP SEQUENCE favorite_targetid_seq CASCADE")
-    op.execute("DROP SEQUENCE views_targetid_seq CASCADE")
+    op.execute("DROP SEQUENCE IF EXISTS favorite_targetid_seq CASCADE")
+    op.execute("DROP SEQUENCE IF EXISTS views_targetid_seq CASCADE")
 
 
 def downgrade():


### PR DESCRIPTION
Several database copies exist in various states of mismatch with the migrations.