### PR TITLE
Write new journal entries to database

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/088e13f2ae70_add_journal_content_column.py
+++ b/libweasyl/libweasyl/alembic/versions/088e13f2ae70_add_journal_content_column.py
@@ -1,0 +1,22 @@
+"""Add journal content column
+
+Revision ID: 088e13f2ae70
+Revises: 7147da2a1adf
+Create Date: 2017-08-21 04:34:29.541975
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '088e13f2ae70'
+down_revision = '7147da2a1adf'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('journal', sa.Column('content', sa.Text(), nullable=True))
+
+
+def downgrade():
+    raise Exception('Reversing this migration could delete new journal content')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -297,6 +297,7 @@ journal = Table(
     Column('journalid', Integer(), primary_key=True, nullable=False),
     Column('userid', Integer(), nullable=False),
     Column('title', String(length=200), nullable=False),
+    Column('content', Text(), nullable=True),
     Column('rating', RatingColumn, nullable=False),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
     Column('settings', CharSettingsColumn({


### PR DESCRIPTION
The first step in moving journal content out of files. Must be deployed first to avoid any period where new content could be discarded or where errors could be produced.

Also fixes the bug of journal entries being inserted before their files exist.