### PR TITLE
[Enhancement] Add Safari Pinned Icon

### DIFF
--- a/static/images/favicon.svg
+++ b/static/images/favicon.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="favicon.svg">
+  <g
+     id="Page-1"
+     transform="matrix(0.09913865,0,0,0.10745354,0.671152,2.0134569)"
+     style="fill:none;fill-rule:evenodd;stroke:none;stroke-width:1">
+    <g
+       id="Artboard"
+       transform="translate(-8,-27)"
+       style="fill:#000000">
+      <path
+         d="M 57.668029,64.742729 C 56.886446,62.944128 56.315842,61.863092 55.956217,61.499622 47.529501,52.98278 48.329098,36.062237 48.749027,30.85845 49.168955,25.654663 63.275499,27.221269 64.992301,27.221269 61.695788,46.478082 62.347587,57.667666 66.947699,60.790022 76.253617,48.151895 89.320202,40.666947 106.14745,38.335176 131.38833,34.83752 170.4967,71.394852 153.75899,96.36532 142.60052,113.0123 123.76022,125.94707 97.238079,135.16965 65.365166,144.72999 37.261297,137.2788 12.926472,112.81609 -0.78618378,83.418171 14.127668,67.393719 57.668029,64.742729 Z m -19.54082,8.238189 18.15723,59.220712 17.164319,0 12.725305,-43.362371 12.954147,39.828861 22.33664,-9.69069 19.89694,-59.891246 -16.28346,0 -16.63467,53.193936 -15.735388,-54.375053 -10.210435,0 L 66.000339,113.4188 53.888354,71.666925 38.127209,72.980918 Z"
+         id="Path"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/templates/common/page_start.html
+++ b/templates/common/page_start.html
@@ -22,6 +22,7 @@ $code:
   <link rel="stylesheet" href="${resource_path('css/site.css')}" />
 
   <link type="image/png" rel="icon" href="${CDNIFY('/static/images/favicon.png')}" />
+  <link rel="mask-icon" color="#850002" href="${CDNIFY('/static/images/favicon.svg')}" />
 
   $if "imageselect" in options:
     <link type="text/css" rel="stylesheet" href="${CDNIFY('/static/scripts/imageselect/imageselect.css?' + SHA)}" />


### PR DESCRIPTION
This pull request should add the Safari pinned icon to Weasyl. The code added is straightforward, it adds the favicon SVG in the same folder as the PNG favicon and adds the needed meta tags to the page start.

This fulfills Issue #255.

A preview of the icon is below and on [this page](http://owo.zone/weasyl.html):

<img width="179" alt="Favicon Preview" src="https://user-images.githubusercontent.com/10801851/30088207-e274d436-9272-11e7-9004-7d3d70a4ed29.png">