### PR TITLE
Avoid error on non-ASCII search terms in Marketplace

### DIFF
--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -296,7 +296,7 @@ def select_commissionable(userid, q, commishclass, min_price, max_price, currenc
         dinfo['localmax'] = convert_currency(info.pricemax, info.pricesettings, currency)
         if tags:
             terms = ["user:" + d.get_sysname(info.username)] + ["|" + tag for tag in tags]
-            dinfo['searchquery'] = "q=" + urllib.quote(" ".join(terms))
+            dinfo['searchquery'] = "q=" + urllib.quote(u" ".join(terms).encode("utf-8"))
         else:
             dinfo['searchquery'] = ""
         return dinfo


### PR DESCRIPTION
Python 2 is bad. Fixes #238.