### PR TITLE
Modify Vagrantfile to use Debian 9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Quickstart
 ----------
 
 The easiest way to get Weasyl running is within a virtual environment using
-`Vagrant`_ (1.6 or greater) with `VirtualBox`_ (4.3.16 or greater). From inside the
+`Vagrant`_ (2.0.0 or greater) with `VirtualBox`_ (5.1.28 or greater). From inside the
 ``weasyl`` directory, simply run::
 
   $ make setup-vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -121,7 +121,7 @@ SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "weasyl-debian91.box"
-  config.vm.box_url = "http://deploy.weasyldev.com/weasyl-debian91.box"
+  config.vm.box_url = "https://deploy.weasyldev.com/weasyl-debian91.box"
   config.vm.box_download_checksum = "7bcfa1c96505d80664e23121c80763125838ba2193f41e3deb9688df4cbec945"
   config.vm.box_download_checksum_type = "sha256"
   config.vm.hostname = "vagrant-weasyl"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -122,7 +122,7 @@ SCRIPT
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "weasyl-debian91.box"
   config.vm.box_url = "http://deploy.weasyldev.com/weasyl-debian91.box"
-  config.vm.box_download_checksum = "12500d0ea31b9bd4b58aa1624980e8306da00e71b8a587f7e9e11ca9c744d751"
+  config.vm.box_download_checksum = "7bcfa1c96505d80664e23121c80763125838ba2193f41e3deb9688df4cbec945"
   config.vm.box_download_checksum_type = "sha256"
   config.vm.hostname = "vagrant-weasyl"
   config.vm.provision :shell, :privileged => true, :inline => $priv_script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,11 +31,11 @@ echo "server=/i.weasyl.com/10.10.10.103" > /etc/dnsmasq.d/i.weasyl.com
 apt-get install -y dnsmasq
 echo "prepend domain-name-servers 127.0.0.1;" >> /etc/dhcp/dhclient.conf
 dhclient -x
-dhclient eth0
+dhclient enp0s3
 
 apt-get -y install \
-    git-core libffi-dev libmagickcore-dev libpam-systemd libpq-dev libssl-dev \
-    libxml2-dev libxslt-dev memcached nginx pkg-config \
+    git-core libffi-dev libmagickcore-dev libpam-systemd libpq-dev \
+    libssl-dev libxml2-dev libxslt-dev memcached nginx pkg-config \
     postgresql-9.6 postgresql-contrib-9.6 \
     liblzma-dev python-dev python-virtualenv \
     ruby-sass nodejs

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,15 +9,15 @@ apt-get update
 apt-get install -y ca-certificates apt-transport-https
 
 echo >/etc/apt/sources.list.d/weasyl.list \
-    'deb http://apt.weasyldev.com/repos/apt/debian jessie main'
+    'deb http://apt.weasyldev.com/repos/apt/debian stretch main'
 echo >/etc/apt/sources.list.d/postgresql.list \
-    'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main 9.5'
+    'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main 9.6'
 
 curl https://deploy.weasyldev.com/weykent-key.asc | apt-key add -
 curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 
 echo >/etc/apt/sources.list.d/nodesource.list \
-    'deb https://deb.nodesource.com/node_6.x jessie main'
+    'deb https://deb.nodesource.com/node_6.x stretch main'
 
 curl https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
@@ -34,9 +34,9 @@ dhclient -x
 dhclient eth0
 
 apt-get -y install \
-    git-core libffi-dev libmagickcore-dev libpam-systemd libpq-dev \
+    git-core libffi-dev libmagickcore-dev libpam-systemd libpq-dev libssl-dev \
     libxml2-dev libxslt-dev memcached nginx pkg-config \
-    postgresql-9.5 postgresql-contrib-9.5 \
+    postgresql-9.6 postgresql-contrib-9.6 \
     liblzma-dev python-dev python-virtualenv \
     ruby-sass nodejs
 
@@ -120,9 +120,9 @@ make install-libweasyl upgrade-db
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "weasyl-debian81.box"
-  config.vm.box_url = "http://deploy.weasyldev.com/weasyl-debian81.box"
-  config.vm.box_download_checksum = "34592e65ebd4753d6f74a54b019e36d1ce006010cb4f03ed8ec131824f45ff9b"
+  config.vm.box = "weasyl-debian91.box"
+  config.vm.box_url = "http://deploy.weasyldev.com/weasyl-debian91.box"
+  config.vm.box_download_checksum = "12500d0ea31b9bd4b58aa1624980e8306da00e71b8a587f7e9e11ca9c744d751"
   config.vm.box_download_checksum_type = "sha256"
   config.vm.hostname = "vagrant-weasyl"
   config.vm.provision :shell, :privileged => true, :inline => $priv_script

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,22 +1,22 @@
 # these are all pinned versions available from https://pypi.weasyldev.com
-zope.interface==4.3.2       # for twisted
-service_identity==16.0.0    # Newer Twisted wants this for cert verification
+zope.interface==4.4.2       # for twisted
+service_identity==17.0.0    # Newer Twisted wants this for cert verification
 Twisted==16.3.2             # Twisted 16.4+ will need additional code work
 web.py==0.37+weasyl.2       # https://github.com/Weasyl/webpy
 jsonlib2==1.5.2             # optional, but for convenience
-pyOpenSSL==16.1.0           # as above
+pyOpenSSL==17.3.0           # as above
 raven==6.1.0
-requests[security]==2.11.1
+requests[security]==2.18.4
 oauth2==1.9.0.post1
 python-memcached==1.58
 txstatsd==1.0.0+weasyl.2    # https://github.com/Weasyl/txstatsd
-crochet==1.5.0
+crochet==1.9.0
 txyam2==0.5.1+weasyl.1      # https://github.com/Weasyl/txyam2
 mock==2.0.0
-Dozer==0.5                  # For WSGI memory profiling
-Pillow==3.3.1               # For WSGI memory profiling
+Dozer==0.6                  # For WSGI memory profiling
+Pillow==4.2.1               # For WSGI memory profiling
 pyramid==1.7.3
 WebTest==2.0.23
-pyotp==2.2.4                # For Two-Factor Authentication
-qrcodegen==1.0.0            # For Two-Factor Authentication
-cryptography==1.8.1         # For Two-Factor Authentication
+pyotp==2.2.6                # For Two-Factor Authentication
+qrcodegen==1.2.0            # For Two-Factor Authentication
+cryptography==2.0.3         # For Two-Factor Authentication

--- a/libweasyl/requirements.txt
+++ b/libweasyl/requirements.txt
@@ -1,14 +1,14 @@
-alembic==0.9.1
+alembic==0.9.5
 anyjson==0.3.3
-arrow==0.7.0
-bcrypt==3.1.1
-dogpile.cache==0.6.2
-lxml==3.6.4
+arrow==0.10.0
+bcrypt==3.1.3
+dogpile.cache==0.6.4
+lxml==4.0.0
 misaka==1.0.3+weasyl.6    # https://github.com/Weasyl/misaka
-oauthlib==2.0.0
-psycopg2cffi==2.7.4
-pytz==2016.6.1
+oauthlib==2.0.4
+psycopg2cffi==2.7.6
+pytz==2017.2
 pyyaml==3.12
 sanpera==0.1.1+weasyl.6   # https://github.com/Weasyl/sanpera
-sqlalchemy==1.0.15
+sqlalchemy==1.1.14
 translationstring==1.3


### PR DESCRIPTION
Upgrades the Vagrant .box file to use Debian 9.1 (and associated libraries), and Postgresql 9.6.

Wheels for Weasyl specific libraries are not available yet, so build must be performed as it exists in the Makefile (i.e., with no-binary). If this pull is approved, back end wheel builds will be upgraded as well as production workers are upgraded.