### PR TITLE
Default to HTTPS for Tumblr links

### DIFF
--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -238,7 +238,7 @@ SOCIAL_SITES = {
     },
     "tumblr": {
         "name": "Tumblr",
-        "url": "http://%s.tumblr.com/",
+        "url": "https://%s.tumblr.com/",
     },
     "twitter": {
         "name": "Twitter",


### PR DESCRIPTION
A redirect is served if the target blog doesn’t support it.