### PR TITLE
Purge logincreate records after two days

### DIFF
--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -61,7 +61,7 @@ def run_periodic_tasks():
             db.execute("""
                 DELETE FROM logincreate
                 WHERE unixtime < %(time)s
-            """, time=now - (86400 * 7))
+            """, time=now - (86400 * 2))
             log.msg('cleared stale account creation records')
 
         db.execute("UPDATE cron_runs SET last_run = %(now)s", now=now.naive)


### PR DESCRIPTION
Change stems from a discussion on Gitter surrounding the changes made to support plausible deniability of email addresses (20180111@0242 EST). Further, most people who sign up for a website will almost immediately turn around and confirm their account.

Two days (approximately) is more than a fair window to permit completion of a signup request.