### PR TITLE
Add the ability for admins to view accounts pending creation

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/8cde5e07b63f_store_invalid_email_in_logincreate.py
+++ b/libweasyl/libweasyl/alembic/versions/8cde5e07b63f_store_invalid_email_in_logincreate.py
@@ -1,0 +1,24 @@
+"""Store invalid email in logincreate records to permit viewing pending records.
+
+Revision ID: 8cde5e07b63f
+Revises: 2ab6c695c709
+Create Date: 2018-01-16 00:36:43.973449
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '8cde5e07b63f'
+down_revision = '2ab6c695c709'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # Provide a column to store the original email address so admins can view pending accounts, and know if an email
+    # collided with one that is in use (logincreate.email is a unique field, so we can't use that to store the email).
+    op.add_column('logincreate', sa.Column('invalid_email_addr', sa.String(length=100), nullable=True))
+
+
+def downgrade():
+    op.drop_column('logincreate', 'invalid_email_addr')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -381,6 +381,7 @@ logincreate = Table(
     #   AKA, create a logincreate entry if an in-use email address is provided, thus preserving the effect of
     #   a pending username triggering a username taken error.
     Column('invalid', Boolean(), server_default='f', nullable=False),
+    Column('invalid_email_addr', String(length=100), nullable=True, server_default=None),
 )
 
 

--- a/templates/admincontrol/acctverifylink.html
+++ b/templates/admincontrol/acctverifylink.html
@@ -1,4 +1,6 @@
 $def with (token)
+$:{RENDER("common/stage_title.html", ["Get Confirmation Link", "Administrator Control Panel", "/admincontrol"])}
+
 <div id="error_content" class="content">
   <p><a href="/verify/account?token=${token}">https://www.weasyl.com/verify/account?token=${token}</a></p>
 

--- a/templates/admincontrol/admincontrol.html
+++ b/templates/admincontrol/admincontrol.html
@@ -14,6 +14,10 @@ $:{TITLE("Administrator Control Panel")}
       <p><a href="/admincontrol/finduser">Search Users</a></p><br />
     </div>
 
+    <div style="font-size:1.3em;">
+      <p><a href="/admincontrol/pending_accounts">View Pending Accounts</a></p><br />
+    </div>
+
     <label>Manage User Account</label>
     <p>Username</p>
     <form action="/admincontrol/manageuser">

--- a/templates/admincontrol/admincontrol.html
+++ b/templates/admincontrol/admincontrol.html
@@ -15,7 +15,7 @@ $:{TITLE("Administrator Control Panel")}
     </div>
 
     <div style="font-size:1.3em;">
-      <p><a href="/admincontrol/pending_accounts">View Pending Accounts</a></p><br />
+      <p><a href="/admincontrol/pending_accounts">View Accounts Pending Creation</a></p><br />
     </div>
 
     <label>Manage User Account</label>

--- a/templates/admincontrol/pending_accounts.html
+++ b/templates/admincontrol/pending_accounts.html
@@ -20,8 +20,11 @@ $:{RENDER("common/stage_title.html", ["Accounts Pending Creation", "Administrato
             <tr>
               <td style="padding-bottom:1em;"><button class="button negative" name="logincreatetoken" value="${i.token}">Purge</button></td>
               <td style="padding-bottom:1em;">${i.username}</td>
-              $if i.invalid_email_addr:
-                <td style="padding-bottom:1em;"><em>Invalid <code>logincreate</code> record -- Email in use:</em> ${i.invalid_email_addr}</a></td>
+              $if i.invalid:
+                $if i.invalid_email_addr:
+                  <td style="padding-bottom:1em;"><em>Invalid <code>logincreate</code> record -- Email in use:</em> ${i.invalid_email_addr}</td>
+                $else:
+                  <td style="padding-bottom:1em;"><em>Invalid <code>logincreate</code> record -- Email in use, but not recorded</em></td>
               $else:
                 <td style="padding-bottom:1em;">${i.email}</td>
               <td style="padding-bottom:1em;">${date.isoformat()}</td>

--- a/templates/admincontrol/pending_accounts.html
+++ b/templates/admincontrol/pending_accounts.html
@@ -1,9 +1,10 @@
 $def with (query)
+$:{RENDER("common/stage_title.html", ["Accounts Pending Creation", "Administrator Control Panel", "/admincontrol"])}
 
 <div class="content">
   $if query:
     <div>
-      <h3>Pending Accounts</h3>
+      <h3>Accounts Pending Creation</h3>
       <form action="/admincontrol/pending_accounts" method="POST">
         $:{CSRF()}
         <table>
@@ -17,20 +18,20 @@ $def with (query)
           $for i in query:
             $ date = arrow.get(i.unixtime)
             <tr>
-              <td><button class="button negative" name="logincreatetoken" value="${i.token}">Purge</button></td>
-              <td>${i.username}</td>
+              <td style="padding-bottom:1em;"><button class="button negative" name="logincreatetoken" value="${i.token}">Purge</button></td>
+              <td style="padding-bottom:1em;">${i.username}</td>
               $if i.invalid_email_addr:
-                <td><em>Invalid <code>logincreate</code> record -- Email in use:</em> ${i.invalid_email_addr}</a></td>
+                <td style="padding-bottom:1em;"><em>Invalid <code>logincreate</code> record -- Email in use:</em> ${i.invalid_email_addr}</a></td>
               $else:
-                <td>${i.email}</td>
-              <td>${date.isoformat()}</td>
+                <td style="padding-bottom:1em;">${i.email}</td>
+              <td style="padding-bottom:1em;">${date.isoformat()}</td>
             </tr>
         </table>
       </form>
     </div>
   $else:
     <div>
-      <h3>Pending Accounts</h3>
+      <h3>Accounts Pending Creation</h3>
       There are no pending accounts to display.
     </div>
 </div>

--- a/templates/admincontrol/pending_accounts.html
+++ b/templates/admincontrol/pending_accounts.html
@@ -1,0 +1,36 @@
+$def with (query)
+
+<div class="content">
+  $if query:
+    <div>
+      <h3>Pending Accounts</h3>
+      <form action="/admincontrol/pending_accounts" method="POST">
+        $:{CSRF()}
+        <table>
+          <tr>
+            <td width="10%" style="font-weight:700;">Purge?</td>
+            <td style="font-weight:700;">User Name</td>
+            <td style="font-weight:700;">E-mail Address</td>
+            <td style="font-weight:700;">Creation Date</td>
+          </tr>
+
+          $for i in query:
+            $ date = arrow.get(i.unixtime)
+            <tr>
+              <td><button class="button negative" name="logincreatetoken" value="${i.token}">Purge</button></td>
+              <td>${i.username}</td>
+              $if i.invalid_email_addr:
+                <td><em>Invalid <code>logincreate</code> record -- Email in use:</em> ${i.invalid_email_addr}</a></td>
+              $else:
+                <td>${i.email}</td>
+              <td>${date.isoformat()}</td>
+            </tr>
+        </table>
+      </form>
+    </div>
+  $else:
+    <div>
+      <h3>Pending Accounts</h3>
+      There are no pending accounts to display.
+    </div>
+</div>

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -133,6 +133,7 @@ def admincontrol_pending_accounts_get_(request):
     query = d.engine.execute("""
         SELECT token, username, email, invalid_email_addr, unixtime
         FROM logincreate
+        ORDER BY username
     """).fetchall()
 
     return Response(d.webpage(request.userid, "admincontrol/pending_accounts.html", [query]))
@@ -147,13 +148,12 @@ def admincontrol_pending_accounts_post_(request):
     :param request: A Pyramid request.
     :return: HTTPSeeOther to /admincontrol/pending_accounts
     """
-    form = request.web_input(logincreatetoken="")
-    print(form.logincreatetoken)
-    if form.token:
+    logincreatetoken = request.POST.get("logincreatetoken")
+    if logincreatetoken:
         d.engine.execute("""
             DELETE FROM logincreate
             WHERE token = %(token)s
-        """, token=form.logincreatetoken)
+        """, token=logincreatetoken)
 
     raise HTTPSeeOther(location="/admincontrol/pending_accounts")
 

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -131,12 +131,17 @@ def admincontrol_pending_accounts_get_(request):
     :return: A Pyramid response with a webpage containing the pending accounts.
     """
     query = d.engine.execute("""
-        SELECT token, username, email, invalid_email_addr, unixtime
+        SELECT token, username, email, invalid, invalid_email_addr, unixtime
         FROM logincreate
         ORDER BY username
     """).fetchall()
 
-    return Response(d.webpage(request.userid, "admincontrol/pending_accounts.html", [query]))
+    return Response(d.webpage(
+        request.userid,
+        "admincontrol/pending_accounts.html",
+        [query],
+        title="Accounts Pending Creation"
+    ))
 
 
 @admin_only

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -123,6 +123,42 @@ def admincontrol_acctverifylink_(request):
 
 
 @admin_only
+def admincontrol_pending_accounts_get_(request):
+    """
+    Retrieve a listing of any active pending accounts in the logincreate table.
+
+    :param request: The Pyramid request object.
+    :return: A Pyramid response with a webpage containing the pending accounts.
+    """
+    query = d.engine.execute("""
+        SELECT token, username, email, invalid_email_addr, unixtime
+        FROM logincreate
+    """).fetchall()
+
+    return Response(d.webpage(request.userid, "admincontrol/pending_accounts.html", [query]))
+
+
+@admin_only
+@token_checked
+def admincontrol_pending_accounts_post_(request):
+    """
+    Purges a specified logincreate record.
+
+    :param request: A Pyramid request.
+    :return: HTTPSeeOther to /admincontrol/pending_accounts
+    """
+    form = request.web_input(logincreatetoken="")
+    print(form.logincreatetoken)
+    if form.token:
+        d.engine.execute("""
+            DELETE FROM logincreate
+            WHERE token = %(token)s
+        """, token=form.logincreatetoken)
+
+    raise HTTPSeeOther(location="/admincontrol/pending_accounts")
+
+
+@admin_only
 def admincontrol_finduser_get_(request):
     return Response(d.webpage(request.userid, "admincontrol/finduser.html", title="Search Users"))
 

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -287,6 +287,10 @@ routes = (
         'GET': admin.admincontrol_finduser_get_,
         'POST': admin.admincontrol_finduser_post_,
     }),
+    Route("/admincontrol/pending_accounts", "admincontrol_pending_accounts", {
+        'GET': admin.admincontrol_pending_accounts_get_,
+        'POST': admin.admincontrol_pending_accounts_post_,
+    }),
 
     # Director control routes.
     Route("/directorcontrol", "directorcontrol", director.directorcontrol_),

--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -8,7 +8,10 @@ from weasyl import index, submission
 
 
 def run_periodic_tasks():
-    now = arrow.utcnow().timestamp
+    # An arrow object representing the current UTC time
+    now = arrow.utcnow()
+
+    # An integer representing the current unixtime (with an offset applied sourced from libweasyl.legacy)
     time_now = get_time()
 
     db = engine.connect()
@@ -61,7 +64,7 @@ def run_periodic_tasks():
             db.execute("""
                 DELETE FROM logincreate
                 WHERE unixtime < %(time)s
-            """, time=now - (86400 * 2))
+            """, time=time_now - (86400 * 2))
             log.msg('cleared stale account creation records')
 
         db.execute("UPDATE cron_runs SET last_run = %(now)s", now=now.naive)

--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -57,7 +57,7 @@ def run_periodic_tasks():
             """)
             log.msg('cleared stale email change records')
 
-            # Purge stale logincreate records older than seven days
+            # Purge stale logincreate records older than two days
             db.execute("""
                 DELETE FROM logincreate
                 WHERE unixtime < %(time)s

--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -8,7 +8,7 @@ from weasyl import index, submission
 
 
 def run_periodic_tasks():
-    now = arrow.utcnow()
+    now = arrow.utcnow().timestamp
     time_now = get_time()
 
     db = engine.connect()

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -209,6 +209,8 @@ def create(form):
             "birthday": arrow.now(),
             "unixtime": arrow.now(),
             "invalid": True,
+            # So we have a way for admins to determine which email address collided in the View Pending Accounts Page
+            "invalid_email_addr": email,
         })
         # The email address in question is already in use in either `login` or `logincreate`;
         #   let the already registered user know this via email (perhaps they forgot their username/password)


### PR DESCRIPTION
Provides a new admin-restricted page to view, and optionally purge, account creation requests in the ``logincreate`` table. In the event of an invalid ``logincreate`` record, the email wouldn't normally be displayed. So this also adds an ``invalid_email_addr`` field to the ``logincreate`` table to permit storing the originally provided email (since the email field is unique to the table).

Addresses the first and second proposals in #302.