### PR TITLE
Vagrant: Add required packages to build Pillow>=5.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -41,9 +41,7 @@ apt-get -y install \
     ruby-sass nodejs
 
 # Required to get Pillow >= 5.0.0 to build from source (since we've disabled using wheels from PyPI)
-apt-get -y install libtiff5-dev libjpeg62-turbo-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
-    tcl8.6-dev tk8.6-dev python-tk
+apt-get -y install build-essential
 
 npm install -g gulp-cli
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,6 +40,11 @@ apt-get -y install \
     liblzma-dev python-dev python-virtualenv \
     ruby-sass nodejs
 
+# Required to get Pillow >= 5.0.0 to build from source (since we've disabled using wheels from PyPI)
+apt-get -y install libtiff5-dev libjpeg62-turbo-dev zlib1g-dev \
+    libfreetype6-dev liblcms2-dev libwebp-dev libharfbuzz-dev libfribidi-dev \
+    tcl8.6-dev tk8.6-dev python-tk
+
 npm install -g gulp-cli
 
 sudo -u postgres dropdb weasyl


### PR DESCRIPTION
Since merging Pillow 5.0.0, Pillow will fail to build from source during a ``vagrant provision`` with output similar to the following:

https://paste.weasyldev.com/show/As7fqhhIenbAIFLVvcy3/
https://paste.weasyldev.com/show/yxFdoHekq1T0jhHid5Qn/

Adding the packages in the diff permit a build of the package to succeed from a clean ``vagrant destroy/make distclean/vagrant up``. Packages sourced from https://pillow.readthedocs.io/en/latest/installation.html#building-on-linux