### PR TITLE
Email Blacklist: Block subdomains of blacklisted domains

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -21,4 +21,3 @@ pyotp==2.2.6                # For Two-Factor Authentication
 qrcodegen==1.2.0            # For Two-Factor Authentication
 cryptography==2.1.4         # For Two-Factor Authentication
 publicsuffixlist==0.5.0     # For extracting the base domain for the email blacklist
-

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -20,3 +20,5 @@ WebTest==2.0.29
 pyotp==2.2.6                # For Two-Factor Authentication
 qrcodegen==1.2.0            # For Two-Factor Authentication
 cryptography==2.1.4         # For Two-Factor Authentication
+publicsuffixlist==0.5.0     # For extracting the base domain for the email blacklist
+

--- a/templates/directorcontrol/emailblacklist.html
+++ b/templates/directorcontrol/emailblacklist.html
@@ -33,8 +33,8 @@ $:{RENDER("common/stage_title.html", ["Edit Account Creation Email Blacklist", "
 
 <div class="content">
   <form method="POST" action="/directorcontrol/emailblacklist" class="form skinny clear">
-    <label for="domain_name">Domain Name to Blacklist</label>
-    <input type="text" class="input" maxlength="252" name="domain_name" id="domain_name" required>
+    <label for="domain_name">Domain Name(s) to Blacklist</label>
+    <textarea rows="4" class="input" name="domain_name" id="domain_name" placeholder="Enter domain names one per line... spammer.net"></textarea>
 
     <label for="reason">Reason Why Blacklisted</label>
     <textarea rows="4" cols="60" class="input" name="reason" id="reason"></textarea>

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -38,13 +38,13 @@ def directorcontrol_emailblacklist_post_(request):
         d.engine.execute("DELETE FROM emailblacklist WHERE id = ANY (%(selected_ids)s)",
                          selected_ids=map(int, form.remove_selection))
 
-    # Add entry to blacklist, if there is an entry in form.domain_name
+    # Add any entries to blacklist, if any in form.domain_name; duplicate entries are silently discarded.
     elif form.action == "add" and form.domain_name:
         d.engine.execute("""
             INSERT INTO emailblacklist (domain_name, reason, added_by)
                 SELECT UNNEST(%(domain_name)s), %(reason)s, %(added_by)s
             ON CONFLICT (domain_name) DO NOTHING
-        """, domain_name=form.domain_name.splitlines(), reason=form.reason, added_by=request.userid)
+        """, domain_name=form.domain_name.split(), reason=form.reason, added_by=request.userid)
 
     raise HTTPSeeOther(location="/directorcontrol/emailblacklist")
 

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -42,9 +42,9 @@ def directorcontrol_emailblacklist_post_(request):
     elif form.action == "add" and form.domain_name:
         d.engine.execute("""
             INSERT INTO emailblacklist (domain_name, reason, added_by)
-                VALUES (%(domain_name)s, %(reason)s, %(added_by)s)
-                ON CONFLICT (domain_name) DO NOTHING
-        """, domain_name=form.domain_name.lower(), reason=form.reason, added_by=request.userid)
+                SELECT UNNEST(%(domain_name)s), %(reason)s, %(added_by)s
+            ON CONFLICT (domain_name) DO NOTHING
+        """, domain_name=form.domain_name.splitlines(), reason=form.reason, added_by=request.userid)
 
     raise HTTPSeeOther(location="/directorcontrol/emailblacklist")
 

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -339,9 +339,8 @@ def is_email_blacklisted(address):
 
     # Check the disposable email address list
     disposable_domains = _retrieve_disposable_email_domains()
-    for site in disposable_domains:
-        if private_suffix == site:
-            return True
+    if private_suffix in disposable_domains:
+        return True
 
     # Check the explicitly defined/blacklisted domains.
     blacklisted_domains = d.engine.execute("""

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 
 import arrow
 import bcrypt
+from publicsuffixlist import PublicSuffixList
 from sqlalchemy.sql.expression import select
 
 from libweasyl import security
 from libweasyl import staff
+from libweasyl.cache import region
 
 from weasyl import define as d
 from weasyl import macro as m
@@ -331,12 +333,42 @@ def is_email_blacklisted(address):
     Returns:
         Boolean True if present on the blacklist, or False otherwise.
     """
-    local, domain = address.rsplit("@", 1)
+    _, domain = address.rsplit("@", 1)
+    psl = PublicSuffixList()
+    private_suffix = psl.privatesuffix(domain=domain)
 
-    return d.engine.scalar(
-        "SELECT EXISTS (SELECT 0 FROM emailblacklist WHERE domain_name = %(domain_name)s)",
-        domain_name=domain,
-    )
+    # Check the disposable email address list
+    disposable_domains = _retrieve_disposable_email_domains()
+    for site in disposable_domains:
+        if private_suffix == site:
+            return True
+
+    # Check the explicitly defined/blacklisted domains.
+    blacklisted_domains = d.engine.execute("""
+        SELECT domain_name
+        FROM emailblacklist
+    """).fetchall()
+    for site in blacklisted_domains:
+        if private_suffix == site['domain_name']:
+            return True
+
+    # If we get here, the domain (or subdomain) is not blacklisted
+    return False
+
+
+@region.cache_on_arguments(expiration_time=12*60*60)
+def _retrieve_disposable_email_domains():
+    """
+    Retrieves a periodically updated list of disposable email address domains from the 'url' variable, below.
+
+    :return: A [list] of disposable email address domains. Results are cached for 12 hours.
+    """
+    url = "https://raw.githubusercontent.com/ivolo/disposable-email-domains/master/index.json"
+    resp = d.http_get(url=url)
+    if resp.status_code == 200:
+        return resp.json()
+    else:
+        return []
 
 
 def verify_email_change(userid, token):

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -143,6 +143,7 @@ def deterministic_marketplace_tests(monkeypatch):
 
     monkeypatch.setattr(commishinfo, '_fetch_rates', _fetch_rates)
 
+
 @pytest.fixture(autouse=True)
 def do_not_retrieve_disposable_email_domains(monkeypatch):
     """ Don't hammer GitHub's server with testing requests. """

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -23,6 +23,7 @@ from weasyl import (
     commishinfo,
     define,
     emailer,
+    login,
     macro,
     media,
     middleware
@@ -141,3 +142,11 @@ def deterministic_marketplace_tests(monkeypatch):
         return json.loads(rates)
 
     monkeypatch.setattr(commishinfo, '_fetch_rates', _fetch_rates)
+
+@pytest.fixture(autouse=True)
+def do_not_retrieve_disposable_email_domains(monkeypatch):
+    """ Don't hammer GitHub's server with testing requests. """
+    def _retrieve_disposable_email_domains():
+        return ['test-domain-0001.co.nz', 'test-domain-0001.com']
+
+    monkeypatch.setattr(login, '_retrieve_disposable_email_domains', _retrieve_disposable_email_domains)

--- a/weasyl/test/login/test_create.py
+++ b/weasyl/test/login/test_create.py
@@ -178,27 +178,6 @@ def test_create_fails_if_another_account_has_email_linked_to_their_account():
 
 
 @pytest.mark.usefixtures('db')
-def test_create_fails_if_email_domain_is_blacklisted():
-    """
-    Test verifies that login.create() will properly fail to register new accounts
-    when the domain portion of the email address is contained in the emailblacklist
-    table.
-    """
-    d.engine.execute(d.meta.tables["emailblacklist"].insert(), {
-        "domain_name": "blacklisted.com",
-        "reason": "test case for login.create()",
-        "added_by": db_utils.create_user(),
-    })
-    blacklisted_email = "test@blacklisted.com"
-    form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
-               email=blacklisted_email, emailcheck=blacklisted_email,
-               day='12', month='12', year=arrow.now().year - 19)
-    with pytest.raises(WeasylError) as err:
-        login.create(form)
-    assert 'emailBlacklisted' == err.value.value
-
-
-@pytest.mark.usefixtures('db')
 def test_create_fails_if_pending_account_has_same_email():
     """
     Test checks to see if an email is tied to a pending account creation entry
@@ -304,3 +283,94 @@ def test_verify_correct_information_creates_account():
     assert d.engine.scalar(
         "SELECT EXISTS (SELECT 0 FROM logincreate WHERE login_name = %(name)s)",
         name=form.username)
+
+
+class TestAccountCreationBlacklist(object):
+    @pytest.mark.usefixtures('db')
+    def test_create_fails_if_email_domain_is_blacklisted(self):
+        """
+        Test verifies that login.create() will properly fail to register new accounts
+        when the domain portion of the email address is contained in the emailblacklist
+        table.
+        """
+        d.engine.execute(d.meta.tables["emailblacklist"].insert(), {
+            "domain_name": "blacklisted.com",
+            "reason": "test case for login.create()",
+            "added_by": db_utils.create_user(),
+        })
+        blacklisted_email = "test@blacklisted.com"
+        form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
+                   email=blacklisted_email, emailcheck=blacklisted_email,
+                   day='12', month='12', year=arrow.now().year - 19)
+        with pytest.raises(WeasylError) as err:
+            login.create(form)
+        assert 'emailBlacklisted' == err.value.value
+
+    @pytest.mark.usefixtures('db')
+    def test_verify_subdomains_of_blocked_sites_blocked(self):
+        """
+        Blacklisted: badsite.net
+        Blocked: badsite.net
+        Also blocked: subdomain.badsite.net
+        """
+        d.engine.execute(d.meta.tables["emailblacklist"].insert(), {
+            "domain_name": "blacklisted.com",
+            "reason": "test case for login.create()",
+            "added_by": db_utils.create_user(),
+        })
+        # Test the domains from the emailblacklist table
+        blacklisted_email = "test@subdomain.blacklisted.com"
+        form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
+                   email=blacklisted_email, emailcheck=blacklisted_email,
+                   day='12', month='12', year=arrow.now().year - 19)
+        with pytest.raises(WeasylError) as err:
+            login.create(form)
+        assert 'emailBlacklisted' == err.value.value
+
+        # Test the domains from the code that would download the list of disposable domains
+        blacklisted_email = "test@mail.sub.test-domain-0001.co.nz"
+        form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
+                   email=blacklisted_email, emailcheck=blacklisted_email,
+                   day='12', month='12', year=arrow.now().year - 19)
+        with pytest.raises(WeasylError) as err:
+            login.create(form)
+        assert 'emailBlacklisted' == err.value.value
+
+        # Ensure address in the form of <domain.domain> is blocked
+        blacklisted_email = "test@test-domain-0001.co.nz.test-domain-0001.co.nz"
+        form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
+                   email=blacklisted_email, emailcheck=blacklisted_email,
+                   day='12', month='12', year=arrow.now().year - 19)
+        with pytest.raises(WeasylError) as err:
+            login.create(form)
+        assert 'emailBlacklisted' == err.value.value
+
+    @pytest.mark.usefixtures('db')
+    def test_similarly_named_domains_are_not_blocked(self):
+        """
+        Blacklisted: badsite.net
+        /Not/ Blocked: notabadsite.net
+        Also /Not/ blocked: subdomain.notabadsite.net
+        """
+        d.engine.execute(d.meta.tables["emailblacklist"].insert(), {
+            "domain_name": "blacklisted.com",
+            "reason": "test case for login.create()",
+            "added_by": db_utils.create_user(),
+        })
+        mail = "test@notblacklisted.com"
+        form = Bag(username=user_name, password='0123456789', passcheck='0123456789',
+                   email=mail, emailcheck=mail,
+                   day='12', month='12', year=arrow.now().year - 19)
+        login.create(form)
+
+        mail = "test@also.notblacklisted.com"
+        form = Bag(username=user_name + "1", password='0123456789', passcheck='0123456789',
+                   email=mail, emailcheck=mail,
+                   day='12', month='12', year=arrow.now().year - 19)
+        login.create(form)
+
+        mail = "test@blacklisted.com.notblacklisted.com"
+        form = Bag(username=user_name + "2", password='0123456789', passcheck='0123456789',
+                   email=mail, emailcheck=mail,
+                   day='12', month='12', year=arrow.now().year - 19)
+        login.create(form)


### PR DESCRIPTION
Requested by Hendikins. Also, leverage [this repository's](https://github.com/ivolo/disposable-email-domains) list of disposable email domains to block known domains that could potentially be used for spam.

Tweak the director's view of adding additional domains to blacklist to be a text area, one-per-line addition, which enables adding domains much easier.