### PR TITLE
/admincontrol/finduser Enhancements

### DIFF
--- a/templates/admincontrol/finduser.html
+++ b/templates/admincontrol/finduser.html
@@ -1,5 +1,8 @@
 $def with (query = None, form = None, row_offset=0)
 $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Panel", "/admincontrol"])}
+$code:
+  def _CHECKED(x):
+    return ' checked="checked"' if x in form else ''
 
 <div class="content">
   $if(query == None):
@@ -21,27 +24,28 @@ $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Pan
         <div>
           <h4>View information for...</h4>
 
-          <label for="suspendedorbanned-all">All Accounts</label>
-          <input id="suspendedorbanned-all" type="radio" name="suspendedorbanned" value="all" checked />
-
-          <label for="suspendedorbanned-suspended">Only Suspended</label>
-          <input id="suspendedorbanned-suspended" type="radio" name="suspendedorbanned" value="suspended" />
-
-          <label for="suspendedorbanned-banned">Only Banned</label>
-          <input id="suspendedorbanned-banned" type="radio" name="suspendedorbanned" value="banned" />
-
-          <label for="suspendedorbanned-both">Suspended or Banned</label>
-          <input id="suspendedorbanned-both" type="radio" name="suspendedorbanned" value="both" />
+          <label class="input-checkbox" style="margin-top: 0.5em">
+            <input type="checkbox" name="excludebanned" />
+            Exclude banned accounts from results
+          </label>
+          <label class="input-checkbox" style="margin-top: 0.5em">
+            <input type="checkbox" name="excludesuspended" />
+            Exclude suspended accounts from results
+          </label>
+          <label class="input-checkbox" style="margin-top: 0.5em">
+            <input type="checkbox" name="excludeactive" />
+            Exclude active accounts from results
+          </label>
         </div>
         <br />
         <div>
-          <h4>Only show accounts created...</h4>
+          <label for="timespan-after">Accounts created after
+            <input id="timespan-after" type="date" name="dateafter" />
+          </label>
 
-          <label for="timespan-after">After</label>
-          <input id="timespan-after" type="date" name="dateafter" />
-
-          <label for="timespan-before">Before</label>
-          <input id="timespan-before" type="date" name="datebefore" />
+          <label for="timespan-before">Accounts created before
+            <input id="timespan-before" type="date" name="datebefore" />
+          </label>
         </div>
 
         <button type="submit" class="button positive" style="float: right;">Search</button>
@@ -51,6 +55,8 @@ $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Pan
     <div>
       $if query.rowcount == 1:
         <h3>Search Results - ${query.rowcount} Account Found</h3>
+      $if query.rowcount == 250:
+        <h3>Search Results - Many Accounts Found (250+)</h3>
       $else:
         <h3>Search Results - ${query.rowcount} Accounts Found</h3>
 
@@ -80,13 +86,17 @@ $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Pan
         <input type="hidden" name="userid" value="${form.userid}" />
         <input type="hidden" name="username" value="${form.username}" />
         <input type="hidden" name="email" value="${form.email}" />
-        <input type="hidden" name="suspendedorbanned" value="${form.suspendedorbanned}" />
+        <input type="hidden" name="excludebanned" $:{_CHECKED("excludebanned")} />
+        <input type="hidden" name="excludesuspended" $:{_CHECKED("excludesuspended")} />
+        <input type="hidden" name="excludeactive" $:{_CHECKED("excludeactive")} />
         <input type="hidden" name="dateafter" value="${form.dateafter}" />
         <input type="hidden" name="datebefore" value="${form.datebefore}" />
         <div class="clear">
           $if row_offset > 0:
-            <button class="button" name="row_offset" value=${row_offset - 100}>Previous 100</button>
-          <button class="button" name="row_offset" value=${row_offset + 100}>Next 100</button>
+            <button class="button" name="row_offset" value=${row_offset - 250}>Previous 250</button>
+          $if query.rowcount == 250:
+            <button class="button" name="row_offset" value=${row_offset + 250}>Next 250</button>
+          <a class="button positive" href="/admincontrol/finduser" style="float: right;">New search</a>
         </div>
       </form>
     </div>

--- a/templates/admincontrol/finduser.html
+++ b/templates/admincontrol/finduser.html
@@ -1,8 +1,5 @@
 $def with (query = None, form = None, row_offset=0)
 $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Panel", "/admincontrol"])}
-$code:
-  def _CHECKED(x):
-    return ' checked="checked"' if x in form else ''
 
 <div class="content">
   $if(query == None):
@@ -83,12 +80,12 @@ $code:
       </table>
       <form action="/admincontrol/finduser" method="post">
         $:{CSRF()}
-        <input type="hidden" name="userid" value="${form.userid}" />
+        <input type="hidden" name="userid" value="${form.userid if form.userid != 0 else None}" />
         <input type="hidden" name="username" value="${form.username}" />
         <input type="hidden" name="email" value="${form.email}" />
-        <input type="hidden" name="excludebanned" $:{_CHECKED("excludebanned")} />
-        <input type="hidden" name="excludesuspended" $:{_CHECKED("excludesuspended")} />
-        <input type="hidden" name="excludeactive" $:{_CHECKED("excludeactive")} />
+        <input type="hidden" name="excludebanned" ${'value=on' if form.excludebanned == "on" else ''} />
+        <input type="hidden" name="excludesuspended" ${'value=on' if form.excludesuspended == "on" else ''} />
+        <input type="hidden" name="excludeactive" ${'value=on' if form.excludeactive == "on" else ''} />
         <input type="hidden" name="dateafter" value="${form.dateafter}" />
         <input type="hidden" name="datebefore" value="${form.datebefore}" />
         <div class="clear">

--- a/templates/admincontrol/finduser.html
+++ b/templates/admincontrol/finduser.html
@@ -55,7 +55,7 @@ $code:
     <div>
       $if query.rowcount == 1:
         <h3>Search Results - ${query.rowcount} Account Found</h3>
-      $if query.rowcount == 250:
+      $elif query.rowcount == 250:
         <h3>Search Results - Many Accounts Found (250+)</h3>
       $else:
         <h3>Search Results - ${query.rowcount} Accounts Found</h3>
@@ -102,7 +102,8 @@ $code:
     </div>
   $else:
     <div>
-      <h3>Search Results</h3>
-      There are no search results to display.
+      <h3>No search criteria were specified</h3>
+      Whoops! Looks like you didn't specify any search criteria. Head on back to <a href="/admincontrol/finduser">
+      re-enter your search parameters.</a>
     </div>
 </div>

--- a/templates/admincontrol/finduser.html
+++ b/templates/admincontrol/finduser.html
@@ -1,4 +1,4 @@
-$def with (query = None)
+$def with (query = None, form = None, row_offset=0)
 $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Panel", "/admincontrol"])}
 
 <div class="content">
@@ -65,11 +65,30 @@ $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Pan
         $for i in query:
           <tr>
             <td>${i.userid}</td>
-            <td><a href="/~${i.login_name}">${i.login_name}</a></td>
+            $if i.settings['account-state'] == "banned":
+              <td><a href="/~${i.login_name}">${i.login_name}</a> <b>(Banned)</b></td>
+            $elif i.settings['account-state'] == "suspended":
+              <td><a href="/~${i.login_name}">${i.login_name}</a> <b>(Suspended)</b></td>
+            $else:
+              <td><a href="/~${i.login_name}">${i.login_name}</a></td>
             <td>${i.email}</td>
             <td><a href="/staffnotes/${i.login_name}">${i.staff_notes} of &apos;em</a></td>
           </tr>
       </table>
+      <form action="/admincontrol/finduser" method="post">
+        $:{CSRF()}
+        <input type="hidden" name="userid" value="${form.userid}" />
+        <input type="hidden" name="username" value="${form.username}" />
+        <input type="hidden" name="email" value="${form.email}" />
+        <input type="hidden" name="suspendedorbanned" value="${form.suspendedorbanned}" />
+        <input type="hidden" name="dateafter" value="${form.dateafter}" />
+        <input type="hidden" name="datebefore" value="${form.datebefore}" />
+        <div class="clear">
+          $if row_offset > 0:
+            <button class="button" name="row_offset" value=${row_offset - 100}>Previous 100</button>
+          <button class="button" name="row_offset" value=${row_offset + 100}>Next 100</button>
+        </div>
+      </form>
     </div>
   $else:
     <div>

--- a/templates/admincontrol/finduser.html
+++ b/templates/admincontrol/finduser.html
@@ -18,12 +18,41 @@ $:{RENDER("common/stage_title.html", ["Search Users", "Administrator Control Pan
         <label for="adminsearchemail">Email Address:</label>
         <input type="text" class="input last-input" name="email" id="adminsearchemail" />
 
+        <div>
+          <h4>View information for...</h4>
+
+          <label for="suspendedorbanned-all">All Accounts</label>
+          <input id="suspendedorbanned-all" type="radio" name="suspendedorbanned" value="all" checked />
+
+          <label for="suspendedorbanned-suspended">Only Suspended</label>
+          <input id="suspendedorbanned-suspended" type="radio" name="suspendedorbanned" value="suspended" />
+
+          <label for="suspendedorbanned-banned">Only Banned</label>
+          <input id="suspendedorbanned-banned" type="radio" name="suspendedorbanned" value="banned" />
+
+          <label for="suspendedorbanned-both">Suspended or Banned</label>
+          <input id="suspendedorbanned-both" type="radio" name="suspendedorbanned" value="both" />
+        </div>
+        <br />
+        <div>
+          <h4>Only show accounts created...</h4>
+
+          <label for="timespan-after">After</label>
+          <input id="timespan-after" type="date" name="dateafter" />
+
+          <label for="timespan-before">Before</label>
+          <input id="timespan-before" type="date" name="datebefore" />
+        </div>
+
         <button type="submit" class="button positive" style="float: right;">Search</button>
       </form>
     </div>
   $elif(query):
     <div>
-      <h3>Search Results</h3>
+      $if query.rowcount == 1:
+        <h3>Search Results - ${query.rowcount} Account Found</h3>
+      $else:
+        <h3>Search Results - ${query.rowcount} Accounts Found</h3>
 
       <table>
         <tr>

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -171,7 +171,7 @@ def admincontrol_finduser_get_(request):
 @admin_only
 @token_checked
 def admincontrol_finduser_post_(request):
-    form = request.web_input(userid="", username="", email="", suspendedorbanned="",
+    form = request.web_input(userid="", username="", email="", excludebanned="", excludesuspended="", excludeactive="",
                              dateafter="", datebefore="", row_offset=0)
 
     # Redirect negative row offsets (PSQL errors on negative offset values)

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -171,7 +171,7 @@ def admincontrol_finduser_get_(request):
 @admin_only
 @token_checked
 def admincontrol_finduser_post_(request):
-    form = request.web_input(userid="", username="", email="")
+    form = request.web_input(userid="", username="", email="", suspendedorbanned="", dateafter="", datebefore="")
 
     return Response(d.webpage(request.userid, "admincontrol/finduser.html", [
         # Search results

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -171,9 +171,17 @@ def admincontrol_finduser_get_(request):
 @admin_only
 @token_checked
 def admincontrol_finduser_post_(request):
-    form = request.web_input(userid="", username="", email="", suspendedorbanned="", dateafter="", datebefore="")
+    form = request.web_input(userid="", username="", email="", suspendedorbanned="",
+                             dateafter="", datebefore="", row_offset=0)
+
+    # Redirect negative row offsets (PSQL errors on negative offset values)
+    if int(form.row_offset) < 0:
+        raise HTTPSeeOther("/admincontrol/finduser")
 
     return Response(d.webpage(request.userid, "admincontrol/finduser.html", [
         # Search results
-        moderation.finduser(request.userid, form)
+        moderation.finduser(request.userid, form),
+        # Pass the form and row offset in to enable pagination
+        form,
+        int(form.row_offset)
     ], title="Search Users: Results"))

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -309,15 +309,15 @@ def finduser(userid, form):
         ))
 
     # Filter for banned and/or suspended accounts
-    if form.suspendedorbanned == "banned":
-        q = q.where(lo.c.settings.op('~')('b'))
-    elif form.suspendedorbanned == "suspended":
-        q = q.where(lo.c.settings.op('~')('s'))
-    elif form.suspendedorbanned == "both":
+    if form.excludeactive == "on":
         q = q.where(d.sa.or_(
             lo.c.settings.op('~')('b'),
             lo.c.settings.op('~')('s'),
         ))
+    if form.excludebanned == "on":
+        q = q.where(lo.c.settings.op('!~')('b'))
+    if form.excludesuspended == "on":
+        q = q.where(lo.c.settings.op('!~')('s'))
 
     # Filter for date-time
     if form.dateafter and form.datebefore:
@@ -331,10 +331,11 @@ def finduser(userid, form):
     if form.row_offset:
         q = q.offset(form.row_offset)
 
-    if not form.userid and not form.username and not form.email and not form.dateafter and not form.datebefore and not form.suspendedorbanned:
+    if not form.userid and not form.username and not form.email and not form.dateafter \
+            and not form.datebefore and not form.excludesuspended and not form.excludebanned and not form.excludeactive:
         return []
 
-    q = q.limit(100).order_by(lo.c.login_name.asc())
+    q = q.limit(250).order_by(lo.c.login_name.asc())
     db = d.connect()
     return db.execute(q)
 

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -295,6 +295,7 @@ def finduser(userid, form):
          .select_from(sh)
          .where(sh.c.target_user == lo.c.userid)
          .where(sh.c.settings.op('~')('s'))).label('staff_notes'),
+        lo.c.settings,
     ]).select_from(lo.join(pr, lo.c.userid == pr.c.userid))
 
     if form.userid:
@@ -325,6 +326,10 @@ def finduser(userid, form):
         q = q.where(pr.c.unixtime.op('>=')(arrow.get(form.dateafter)))
     elif form.datebefore:
         q = q.where(pr.c.unixtime.op('<=')(arrow.get(form.datebefore)))
+
+    # Apply any row offset
+    if form.row_offset:
+        q = q.offset(form.row_offset)
 
     if not form.userid and not form.username and not form.email and not form.dateafter and not form.datebefore and not form.suspendedorbanned:
         return []


### PR DESCRIPTION
Enhancements for #124.

Enables /admincontrol/finduser to search for banned and/or suspended users, and for searching for accounts created before, after, or between a range of dates. Providing a username/ID/email is optional with the new features (e.g., you can search for all banned accounts created between X-Y dates).