### PR TITLE
Don’t cdnify resources to push

### DIFF
--- a/templates/common/page_end.html
+++ b/templates/common/page_end.html
@@ -73,10 +73,10 @@ $def with (options=None, active_users_string='')
 
 </div><!-- /page-container -->
 
-<script src="${CDNIFY('/static/jquery-2.2.4.min.js')}"></script>
-<script src="${CDNIFY('/static/typeahead.bundle.min.js')}"></script>
-<script src="${CDNIFY('/static/marked.js?' + SHA)}"></script>
-<script src="${CDNIFY('/static/scripts.js?' + SHA)}"></script>
+<script src="/static/jquery-2.2.4.min.js"></script>
+<script src="/static/typeahead.bundle.min.js"></script>
+<script src="/static/marked.js?${SHA}"></script>
+<script src="/static/scripts.js?${SHA}"></script>
 
 $if options and "imageselect" in options:
   <script src="${CDNIFY('/static/scripts/imageselect/imageselect.js?' + SHA)}"></script>

--- a/templates/common/page_start.html
+++ b/templates/common/page_start.html
@@ -18,7 +18,7 @@ $code:
   $else:
     <title>Weasyl</title>
 
-  <link rel="stylesheet" href="${CDNIFY('/static/fonts/museo500.css')}" />
+  <link rel="stylesheet" href="/static/fonts/museo500.css" />
   <link rel="stylesheet" href="${resource_path('css/site.css')}" />
 
   <link type="image/png" rel="icon" href="${CDNIFY('/static/images/favicon.png')}" />

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -1044,7 +1044,7 @@ def get_resource_path(resource):
     if reload_assets:
         _load_resources()
 
-    return cdnify_url('/' + resource_paths[resource])
+    return '/' + resource_paths[resource]
 
 
 def absolutify_url(url):

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -165,16 +165,16 @@ def _generate_http2_server_push_headers():
     css_preload = [
         '<' + item + '>; rel=preload; as=style' for item in [
             d.get_resource_path('css/site.css'),
-            d.cdnify_url('/static/fonts/museo500.css'),
+            '/static/fonts/museo500.css',
         ]
     ]
 
     js_preload = [
         '<' + item + '>; rel=preload; as=script' for item in [
-            d.cdnify_url('/static/jquery-2.2.4.min.js'),
-            d.cdnify_url('/static/typeahead.bundle.min.js'),
-            d.cdnify_url('/static/marked.js?' + d.CURRENT_SHA),
-            d.cdnify_url('/static/scripts.js?' + d.CURRENT_SHA),
+            '/static/jquery-2.2.4.min.js',
+            '/static/typeahead.bundle.min.js',
+            '/static/marked.js?' + d.CURRENT_SHA,
+            '/static/scripts.js?' + d.CURRENT_SHA,
         ]
     ]
 


### PR DESCRIPTION
`www.weasyl.com` doesn’t look authoritative for `cdn.weasyl.com`, but that’s only maybe the reason.