### PR TITLE
Disable Marketplace currency conversion temporarily

### DIFF
--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -65,11 +65,7 @@ def _fetch_rates():
 
     :return: see http://fixer.io/
     """
-    try:
-        return d.http_get("http://api.fixer.io/latest?base=USD").json()
-    except WeasylError:
-        # There was an HTTP error while fetching from the API
-        return None
+    return None
 
 
 def _charmap_to_currency_code(charmap):


### PR DESCRIPTION
The API we were using has shut down in a way that causes Marketplace to crash. The new one requires some setup (an account contact), so turn it off as a quick fix for now.