### PR TITLE
Improve loading times for submission notifications

### DIFF
--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -417,7 +417,7 @@ def api_messages_submissions_(request):
         count = min(count or 100, 100)
 
     submissions = message.select_submissions(
-        request.userid, count + 1, backtime=backtime, nexttime=nexttime)
+        request.userid, count + 1, include_tags=True, backtime=backtime, nexttime=nexttime)
     backtime, nexttime = d.paginate(submissions, backtime, nexttime, count, 'unixtime')
 
     ret = []

--- a/weasyl/controllers/messages.py
+++ b/weasyl/controllers/messages.py
@@ -71,6 +71,6 @@ def messages_submissions_(request):
         # Feature
         form.feature,
         # Submissions
-        message.select_submissions(request.userid, 66,
+        message.select_submissions(request.userid, 66, include_tags=False,
                                    backtime=define.get_int(form.backtime), nexttime=define.get_int(form.nexttime)),
     ]))

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -94,9 +94,9 @@ def select_journals(userid):
 
 def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None):
     if backtime:
-        time_filter = "WHERE we.unixtime > %(backtime)s"
+        time_filter = "AND we.unixtime > %(backtime)s"
     elif nexttime:
-        time_filter = "WHERE we.unixtime < %(nexttime)s"
+        time_filter = "AND we.unixtime < %(nexttime)s"
     else:
         time_filter = ""
 
@@ -117,7 +117,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 ch.charid AS id,
                 ch.char_name AS title,
                 ch.rating,
-                ch.unixtime,
+                we.unixtime,
                 ch.userid,
                 pr.username,
                 ch.settings,
@@ -132,6 +132,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 we.type = 2050 AND
                 we.userid = %(userid)s AND
                 ch.rating <= %(rating)s
+                {time_filter}
             {char_tags_groupby}
             ORDER BY welcomeid DESC LIMIT %(limit)s
         ) t
@@ -141,7 +142,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 su.submitid AS id,
                 su.title,
                 su.rating,
-                su.unixtime,
+                we.unixtime,
                 we.otherid AS userid,
                 pr.username,
                 su.settings,
@@ -156,6 +157,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 we.type = 2030 AND
                 we.userid = %(userid)s AND
                 su.rating <= %(rating)s
+                {time_filter}
             ORDER BY welcomeid DESC LIMIT %(limit)s
         ) t
         UNION ALL SELECT * FROM (
@@ -164,7 +166,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 su.submitid AS id,
                 su.title,
                 su.rating,
-                su.unixtime,
+                we.unixtime,
                 su.userid,
                 pr.username,
                 su.settings,
@@ -179,9 +181,9 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 we.type = 2010 AND
                 we.userid = %(userid)s AND
                 su.rating <= %(rating)s
+                {time_filter}
             ORDER BY welcomeid DESC LIMIT %(limit)s
         ) t
-        {time_filter}
         ORDER BY welcomeid DESC LIMIT %(limit)s
     """.format(
         time_filter=time_filter,

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -92,13 +92,23 @@ def select_journals(userid):
     } for j in journals]
 
 
-def select_submissions(userid, limit, backtime=None, nexttime=None):
+def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None):
     if backtime:
-        time_filter = "AND unixtime > %(backtime)s"
+        time_filter = "WHERE we.unixtime > %(backtime)s"
     elif nexttime:
-        time_filter = "AND unixtime < %(nexttime)s"
+        time_filter = "WHERE we.unixtime < %(nexttime)s"
     else:
         time_filter = ""
+
+    if include_tags:
+        char_tags_select = ", array_agg(tagid) AS tags"
+        char_tags_join = "LEFT JOIN searchmapchar AS smc ON ch.charid = smc.targetid"
+        char_tags_groupby = "GROUP BY ch.charid, pr.username, we.welcomeid"
+
+        submission_tags_select = ", tags"
+        submission_tags_join = "INNER JOIN submission_tags USING (submitid)"
+    else:
+        char_tags_select = char_tags_join = char_tags_groupby = submission_tags_select = submission_tags_join = ""
 
     statement = """
         SELECT * FROM (
@@ -112,21 +122,21 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 pr.username,
                 ch.settings,
                 we.welcomeid,
-                0 AS subtype,
-                array_agg(tags.title) AS tags
+                0 AS subtype
+                {char_tags_select}
             FROM welcome we
                 INNER JOIN character ch ON we.targetid = ch.charid
                 INNER JOIN profile pr ON ch.userid = pr.userid
-                LEFT JOIN searchmapchar AS smc ON ch.charid = smc.targetid
-                LEFT JOIN searchtag AS tags USING (tagid)
+                {char_tags_join}
             WHERE
                 we.type = 2050 AND
-                we.userid = %(userid)s
-            GROUP BY
-                ch.charid,
-                pr.username,
-                we.welcomeid
-            UNION SELECT
+                we.userid = %(userid)s AND
+                ch.rating <= %(rating)s
+            {char_tags_groupby}
+            ORDER BY welcomeid DESC LIMIT %(limit)s
+        ) t
+        UNION ALL SELECT * FROM (
+            SELECT
                 40 AS contype,
                 su.submitid AS id,
                 su.title,
@@ -136,21 +146,20 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 pr.username,
                 su.settings,
                 we.welcomeid,
-                su.subtype,
-                array_agg(tags.title) AS tags
+                su.subtype
+                {submission_tags_select}
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON we.otherid = pr.userid
-                LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
-                LEFT JOIN searchtag AS tags USING (tagid)
+                {submission_tags_join}
             WHERE
                 we.type = 2030 AND
-                we.userid = %(userid)s
-            GROUP BY
-                su.submitid,
-                pr.username,
-                we.welcomeid
-            UNION SELECT
+                we.userid = %(userid)s AND
+                su.rating <= %(rating)s
+            ORDER BY welcomeid DESC LIMIT %(limit)s
+        ) t
+        UNION ALL SELECT * FROM (
+            SELECT
                 10 AS contype,
                 su.submitid AS id,
                 su.title,
@@ -160,27 +169,28 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
                 pr.username,
                 su.settings,
                 we.welcomeid,
-                su.subtype,
-                array_agg(tags.title) AS tags
+                su.subtype
+                {submission_tags_select}
             FROM welcome we
                 INNER JOIN submission su ON we.targetid = su.submitid
                 INNER JOIN profile pr ON su.userid = pr.userid
-                LEFT JOIN searchmapsubmit AS sms ON su.submitid = sms.targetid
-                LEFT JOIN searchtag AS tags USING (tagid)
+                {submission_tags_join}
             WHERE
                 we.type = 2010 AND
-                we.userid = %(userid)s
-            GROUP BY
-                su.submitid,
-                pr.username,
-                we.welcomeid
-        ) results
-        WHERE
-            rating <= %(rating)s
-            {time_filter}
-        ORDER BY unixtime DESC
-        LIMIT %(limit)s
-    """.format(time_filter=time_filter)
+                we.userid = %(userid)s AND
+                su.rating <= %(rating)s
+            ORDER BY welcomeid DESC LIMIT %(limit)s
+        ) t
+        {time_filter}
+        ORDER BY welcomeid DESC LIMIT %(limit)s
+    """.format(
+        time_filter=time_filter,
+        char_tags_select=char_tags_select,
+        char_tags_join=char_tags_join,
+        char_tags_groupby=char_tags_groupby,
+        submission_tags_select=submission_tags_select,
+        submission_tags_join=submission_tags_join,
+    )
 
     query = d.engine.execute(
         statement,
@@ -189,21 +199,38 @@ def select_submissions(userid, limit, backtime=None, nexttime=None):
         nexttime=nexttime,
         backtime=backtime,
         limit=limit,
-    )
+    ).fetchall()
 
-    results = [{
-        "contype": i.contype,
-        "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,
-        "welcomeid": i.welcomeid,
-        "title": i.title,
-        "rating": i.rating,
-        "unixtime": i.unixtime,
-        "userid": i.userid,
-        "username": i.username,
-        "subtype": i.subtype,
-        "tags": i.tags,
-        "sub_media": _fake_media_items(i),
-    } for i in query]
+    if include_tags:
+        all_tags = list(frozenset(chain.from_iterable(i.tags for i in query)))
+        tag_map = {t.tagid: t.title for t in d.engine.execute("SELECT tagid, title FROM searchtag WHERE tagid = ANY (%(tags)s)", tags=all_tags)}
+
+        results = [{
+            "contype": i.contype,
+            "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,
+            "welcomeid": i.welcomeid,
+            "title": i.title,
+            "rating": i.rating,
+            "unixtime": i.unixtime,
+            "userid": i.userid,
+            "username": i.username,
+            "subtype": i.subtype,
+            "tags": [tag_map[tag] for tag in i.tags],
+            "sub_media": _fake_media_items(i),
+        } for i in query]
+    else:
+        results = [{
+            "contype": i.contype,
+            "submitid" if i.contype != _CONTYPE_CHAR else "charid": i.id,
+            "welcomeid": i.welcomeid,
+            "title": i.title,
+            "rating": i.rating,
+            "unixtime": i.unixtime,
+            "userid": i.userid,
+            "username": i.username,
+            "subtype": i.subtype,
+            "sub_media": _fake_media_items(i),
+        } for i in query]
 
     media.populate_with_submission_media(
         [i for i in results if i["contype"] != _CONTYPE_CHAR])


### PR DESCRIPTION
Faster query; tags only when necessary (i.e. when requested via the API). Also corrects sorting order to its intended descending welcome id, previously descending submission time because both tables used `unixtime`. Only affects collection notifications, but affects them significantly.