### PR TITLE
Fix session token not changing on login and potential CSRF timing vulnerability

### DIFF
--- a/weasyl/controllers/decorators.py
+++ b/weasyl/controllers/decorators.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import anyjson as json
+import hmac
 from pyramid.httpexceptions import HTTPForbidden
 from pyramid.response import Response
 
@@ -98,7 +99,7 @@ def twofactorauth_disabled_required(view_callable):
 
 def token_checked(view_callable):
     def inner(request):
-        if not weasyl.api.is_api_user() and request.params.get('token', "") != define.get_token():
+        if not weasyl.api.is_api_user() and not hmac.compare_digest(request.params.get('token', ""), define.get_token()):
             return Response(define.errorpage(request.userid, errorcode.token), status=403)
         return view_callable(request)
     return inner

--- a/weasyl/controllers/two_factor_auth.py
+++ b/weasyl/controllers/two_factor_auth.py
@@ -75,7 +75,7 @@ def tfa_init_get_(request):
 @twofactorauth_disabled_required
 def tfa_init_post_(request):
     userid, status = login.authenticate_bcrypt(define.get_display_name(request.userid),
-                                               request.params['password'], session=False)
+                                               request.params['password'], request=None)
     # The user's password failed to authenticate
     if status == "invalid":
         return Response(define.webpage(request.userid, "control/2fa/init.html", [
@@ -243,7 +243,7 @@ def tfa_generate_recovery_codes_verify_password_get_(request):
 @twofactorauth_enabled_required
 def tfa_generate_recovery_codes_verify_password_post_(request):
     userid, status = login.authenticate_bcrypt(define.get_display_name(request.userid),
-                                               request.params['password'], session=False)
+                                               request.params['password'], request=None)
     # The user's password failed to authenticate
     if status == "invalid":
         return Response(define.webpage(

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -35,7 +35,7 @@ def signin_post_(request):
     form = request.web_input(username="", password="", referer="", sfwmode="nsfw")
     form.referer = form.referer or '/'
 
-    logid, logerror = login.authenticate_bcrypt(form.username, form.password, ip_address=request.client_addr, user_agent=request.user_agent)
+    logid, logerror = login.authenticate_bcrypt(form.username, form.password, request=request, ip_address=request.client_addr, user_agent=request.user_agent)
 
     if logid and logerror == 'unicode-failure':
         raise HTTPSeeOther(location='/signin/unicode-failure')
@@ -160,7 +160,7 @@ def signin_2fa_auth_post_(request):
     elif two_factor_auth.verify(tfa_userid, request.params["tfaresponse"]):
         # 2FA passed, so login and cleanup.
         _cleanup_2fa_session()
-        login.signin(tfa_userid, ip_address=request.client_addr, user_agent=request.user_agent)
+        login.signin(request, tfa_userid, ip_address=request.client_addr, user_agent=request.user_agent)
         ref = request.params["referer"] or "/"
         # User is out of recovery codes, so force-deactivate 2FA
         if two_factor_auth.get_number_of_recovery_codes(tfa_userid) == 0:

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -139,6 +139,10 @@ def authenticate_bcrypt(username, password, request, ip_address=None, user_agent
     if request is not None:
         # If the user's record has ``login.twofa_secret`` set (not nulled), return that password authentication succeeded.
         if TWOFA:
+            request.pg_connection.delete(request.weasyl_session)
+            request.pg_connection.flush()
+            request.weasyl_session = create_session(None)
+            request.weasyl_session.additional_data = {}
             return USERID, "2fa"
         else:
             signin(request, USERID, ip_address=ip_address, user_agent=user_agent)

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -14,6 +14,7 @@ from weasyl import macro as m
 from weasyl import emailer
 from weasyl import moderation
 from weasyl.error import WeasylError
+from weasyl.sessions import create_session
 
 
 _EMAIL = 100
@@ -21,7 +22,7 @@ _PASSWORD = 10
 _USERNAME = 25
 
 
-def signin(userid, ip_address=None, user_agent=None):
+def signin(request, userid, ip_address=None, user_agent=None):
     # Update the last login record for the user
     d.execute("UPDATE login SET last_login = %i WHERE userid = %i", [d.get_time(), userid])
 
@@ -30,11 +31,14 @@ def signin(userid, ip_address=None, user_agent=None):
     d.metric('increment', 'logins')
 
     # set the userid on the session
-    sess = d.get_weasyl_session()
-    sess.userid = userid
+    sess = create_session(userid)
     sess.ip_address = ip_address
     sess.user_agent_id = get_user_agent_id(user_agent)
-    sess.save = True
+    sess.create = True
+
+    request.pg_connection.delete(request.weasyl_session)
+    request.pg_connection.flush()
+    request.weasyl_session = sess
 
 
 def get_user_agent_id(ua_string=None):
@@ -57,21 +61,19 @@ def get_user_agent_id(ua_string=None):
 
 
 def signout(request):
-    sess = request.weasyl_session
+    request.pg_connection.delete(request.weasyl_session)
+    request.pg_connection.flush()
+    request.weasyl_session = create_session(None)
+
     # unset SFW-mode cookie on logout
     request.delete_cookie_on_response("sfwmode")
-    sess.userid = None
-    # We aren't (currently) tracking userid-to-IP after logout, also clear IP/useragent.
-    sess.ip_address = None
-    sess.user_agent_id = None
-    sess.save = True
 
 
-def authenticate_bcrypt(username, password, ip_address=None, user_agent=None, session=True):
+def authenticate_bcrypt(username, password, request, ip_address=None, user_agent=None):
     """
     Return a result tuple of the form (userid, error); `error` is None if the
-    login was successful. Pass `session` as False to authenticate a user without
-    creating a new session.
+    login was successful. Pass None as the `request` to authenticate a user
+    without creating a new session.
 
     :param username: The username of the user attempting authentication.
     :param password: The user's claimed password to check against the stored hash.
@@ -132,14 +134,14 @@ def authenticate_bcrypt(username, password, ip_address=None, user_agent=None, se
             # account has been temporarily suspended)
             return USERID, "suspended"
 
-    # Attempt to create a new session if `session` is True, then log the signin
+    # Attempt to create a new session if this is a request to log in, then log the signin
     # if it succeeded.
-    if session:
+    if request is not None:
         # If the user's record has ``login.twofa_secret`` set (not nulled), return that password authentication succeeded.
         if TWOFA:
             return USERID, "2fa"
         else:
-            signin(USERID, ip_address=ip_address, user_agent=user_agent)
+            signin(request, USERID, ip_address=ip_address, user_agent=user_agent)
 
     status = None
     if not unicode_success:

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -64,7 +64,7 @@ def authorize_post_(request):
     scopes = credentials.pop('scopes')
     error = None
     if form.not_me and form.username:
-        userid, error = login.authenticate_bcrypt(form.username, form.password, bool(form.remember_me))
+        userid, error = login.authenticate_bcrypt(form.username, form.password, request=request if form.remember_me else None)
         if error:
             error = errorcode.login_errors.get(error, 'Unknown error.')
     elif not request.userid:

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -560,7 +560,7 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
     changes_made = ""
 
     # Check that credentials are correct
-    logid, logerror = login.authenticate_bcrypt(username, password, session=False)
+    logid, logerror = login.authenticate_bcrypt(username, password, request=None)
 
     # Run checks prior to modifying anything...
     if userid != logid or logerror is not None:

--- a/weasyl/sessions.py
+++ b/weasyl/sessions.py
@@ -1,0 +1,10 @@
+from libweasyl import security
+from libweasyl.models.users import Session
+
+
+def create_session(userid):
+    sess_obj = Session(userid=userid)
+    sess_obj.sessionid = security.generate_key(64)
+    sess_obj.create = True
+    sess_obj.save = True
+    return sess_obj

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -129,6 +129,11 @@ def cache_(request):
     cache.region.configure('dogpile.cache.memory', replace_existing_backend=True)
 
 
+@pytest.fixture(autouse=True)
+def template_cache():
+    define._template_cache.clear()
+
+
 @pytest.fixture
 def no_csrf(monkeypatch):
     monkeypatch.setattr(define, 'get_token', lambda: '')

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -6,13 +6,13 @@ import arrow
 
 from libweasyl import legacy
 from libweasyl import ratings
-from libweasyl import security
 from libweasyl import staff
 from libweasyl.models import content, users
 from libweasyl.models.content import Journal
 import weasyl.define as d
 from weasyl import login
 from weasyl import orm
+from weasyl import sessions
 
 _user_index = itertools.count()
 TEST_DATABASE = "weasyl_test"
@@ -75,9 +75,7 @@ def create_session(user):
     """
     Creates a session for a user and returns the corresponding WZL cookie.
     """
-    session = orm.Session()
-    session.sessionid = security.generate_key(64)
-    session.userid = user
+    session = sessions.create_session(user)
 
     db = d.connect()
     db.add(session)

--- a/weasyl/test/login/test_authenticate_bcrypt.py
+++ b/weasyl/test/login/test_authenticate_bcrypt.py
@@ -19,19 +19,19 @@ raw_password = "0123456789"
 
 @pytest.mark.usefixtures('db')
 def test_login_fails_if_no_username_provided():
-    result = login.authenticate_bcrypt(username='', password='password')
+    result = login.authenticate_bcrypt(username='', password='password', request=None)
     assert result == (0, 'invalid')
 
 
 @pytest.mark.usefixtures('db')
 def test_login_fails_if_no_password_provided():
-    result = login.authenticate_bcrypt(username=user_name, password='')
+    result = login.authenticate_bcrypt(username=user_name, password='', request=None)
     assert result == (0, 'invalid')
 
 
 @pytest.mark.usefixtures('db')
 def test_login_fails_if_incorrect_username_is_provided():
-    result = login.authenticate_bcrypt(username=user_name, password=raw_password)
+    result = login.authenticate_bcrypt(username=user_name, password=raw_password, request=None)
     assert result == (0, 'invalid')
 
 
@@ -40,7 +40,7 @@ def test_login_fails_for_incorrect_credentials():
     random_password = "ThisIsARandomPassword"
     db_utils.create_user(password=random_password, username=user_name)
     another_random_password = "ThisIsNotTheSamePassword"
-    result = login.authenticate_bcrypt(username=user_name, password=another_random_password)
+    result = login.authenticate_bcrypt(username=user_name, password=another_random_password, request=None)
     assert result == (0, 'invalid')
 
 
@@ -64,7 +64,7 @@ def test_login_fails_for_invalid_auth_and_logs_failure_if_mod_account(tmpdir, mo
         pass
     postrun_loglines = 0
     # Item under test
-    result = login.authenticate_bcrypt(username='ikani', password='FakePassword')
+    result = login.authenticate_bcrypt(username='ikani', password='FakePassword', request=None)
     # Verify we are writing to the log file as expected
     with open(log_path, 'r') as log:
         for line in log:
@@ -81,7 +81,7 @@ def test_login_fails_for_invalid_auth_and_logs_failure_if_mod_account(tmpdir, mo
 def test_login_fails_if_user_is_banned():
     user_id = db_utils.create_user(password=raw_password, username=user_name)
     d.engine.execute("UPDATE login SET settings = 'b' WHERE userid = %(id)s", id=user_id)
-    result = login.authenticate_bcrypt(username=user_name, password=raw_password)
+    result = login.authenticate_bcrypt(username=user_name, password=raw_password, request=None)
     assert result == (user_id, 'banned')
 
 
@@ -92,7 +92,7 @@ def test_login_fails_if_user_is_suspended():
     release_date = d.get_time() + 60
     d.engine.execute("INSERT INTO suspension VALUES (%(id)s, %(reason)s, %(rel)s)",
                      id=user_id, reason='test', rel=release_date)
-    result = login.authenticate_bcrypt(username=user_name, password=raw_password, session=False)
+    result = login.authenticate_bcrypt(username=user_name, password=raw_password, request=None)
     assert result == (user_id, 'suspended')
 
 
@@ -103,7 +103,7 @@ def test_login_succeeds_if_suspension_duration_has_expired():
     release_date = d.convert_unixdate(31, 12, 2015)
     d.engine.execute("INSERT INTO suspension VALUES (%(id)s, %(reason)s, %(rel)s)",
                      id=user_id, reason='test', rel=release_date)
-    result = login.authenticate_bcrypt(username=user_name, password=raw_password, session=False)
+    result = login.authenticate_bcrypt(username=user_name, password=raw_password, request=None)
     assert result == (user_id, None)
 
 
@@ -114,12 +114,12 @@ def test_logins_with_unicode_failures_succeed_with_corresponding_status():
     old_2a_bcrypt_hash = '$2a$04$uOBx2JziJoxjq/F88NjQZ.8mRGE8FgLi3q0Rm3QUlBZnhhInXCb9K'
     d.engine.execute("UPDATE authbcrypt SET hashsum = %(hash)s WHERE userid = %(id)s",
                      hash=old_2a_bcrypt_hash, id=user_id)
-    result = login.authenticate_bcrypt(user_name, u"passwordé", session=False)
+    result = login.authenticate_bcrypt(user_name, u"passwordé", request=None)
     assert result == (user_id, 'unicode-failure')
 
 
 @pytest.mark.usefixtures('db')
 def test_login_succeeds_for_valid_username_and_password():
     user_id = db_utils.create_user(password=raw_password, username=user_name)
-    result = login.authenticate_bcrypt(username=user_name, password=raw_password, session=False)
+    result = login.authenticate_bcrypt(username=user_name, password=raw_password, request=None)
     assert result == (user_id, None)

--- a/weasyl/test/login/test_signin.py
+++ b/weasyl/test/login/test_signin.py
@@ -6,16 +6,19 @@ from pyramid.threadlocal import get_current_request
 
 from weasyl import login
 from weasyl import define as d
+from weasyl.sessions import create_session
 from weasyl.test import db_utils
-from weasyl.test.utils import Bag
 
 
 @pytest.mark.usefixtures('db')
 def test_verify_login_record_is_updated():
     # Use a fake session for this test.
-    get_current_request().weasyl_session = Bag()
     user_id = db_utils.create_user()
+    sess = get_current_request().weasyl_session = create_session(user_id)
+    db = d.connect()
+    db.add(sess)
+    db.flush()
     d.engine.execute("UPDATE login SET last_login = -1 WHERE userid = %(id)s", id=user_id)
-    login.signin(user_id)
+    login.signin(get_current_request(), user_id)
     last_login = d.engine.scalar("SELECT last_login FROM login WHERE userid = %(id)s", id=user_id)
     assert last_login > -1

--- a/weasyl/test/resetpassword/test_force.py
+++ b/weasyl/test/resetpassword/test_force.py
@@ -36,5 +36,5 @@ def test_verify_success_if_correct_information_provided():
     password = '01234567890123'
     form = Bag(password=password, passcheck=password)
     resetpassword.force(user_id, form)
-    result = login.authenticate_bcrypt(username=user_name, password=password, session=False)
+    result = login.authenticate_bcrypt(username=user_name, password=password, request=None)
     assert result == (user_id, None)

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -6,7 +6,7 @@ from weasyl.test import db_utils
 from weasyl.test.web.wsgi import app
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures('db', 'cache')
 def test_user_change_changes_token():
     db_utils.create_user(username='user1', password='password1')
 

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+import pytest
+
+from weasyl.test import db_utils
+from weasyl.test.web.wsgi import app
+
+
+@pytest.mark.usefixtures('db')
+def test_user_change_changes_token():
+    db_utils.create_user(username='user1', password='password1')
+
+    resp = app.get('/')
+    cookie = resp.headers['Set-Cookie'].split(';', 1)[0]
+    csrf = resp.html.find('html')['data-csrf-token']
+
+    resp = app.get('/', headers={'Cookie': cookie})
+    assert resp.html.find('html')['data-csrf-token'] == csrf
+
+    resp = app.post('/signin', {'token': csrf, 'username': 'user1', 'password': 'password1'}, headers={'Cookie': cookie})
+    assert 'Set-Cookie' in resp.headers
+    new_cookie = resp.headers['Set-Cookie'].split(';', 1)[0]
+    resp = resp.follow()
+    new_csrf = resp.html.find('html')['data-csrf-token']
+    assert new_cookie != cookie
+    assert new_csrf != csrf
+
+    resp = app.get('/signout?token=' + new_csrf[:8], headers={'Cookie': new_cookie})
+    assert 'Set-Cookie' in resp.headers
+    new_cookie_2 = resp.headers['Set-Cookie'].split(';', 1)[0]
+    resp = resp.follow()
+    new_csrf_2 = resp.html.find('html')['data-csrf-token']
+    assert new_cookie_2 != new_cookie
+    assert new_cookie_2 != cookie
+    assert new_csrf_2 != new_csrf
+    assert new_csrf_2 != csrf

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
+import pyotp
 import pytest
 
 from weasyl import define as d
+from weasyl import two_factor_auth as tfa
 from weasyl.test import db_utils
 from weasyl.test.web.wsgi import app
 
@@ -40,3 +42,27 @@ def test_user_change_changes_token():
     assert new_csrf_2 != csrf
 
     assert not d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE sessionid = %(id)s)", id=sessionid)
+
+
+@pytest.mark.usefixtures('db', 'cache')
+def test_2fa_changes_token():
+    user = db_utils.create_user(username='user1', password='password1')
+
+    resp = app.get('/')
+    cookie = resp.headers['Set-Cookie'].split(';', 1)[0]
+    csrf = resp.html.find('html')['data-csrf-token']
+
+    assert tfa.store_recovery_codes(user, ','.join(tfa.generate_recovery_codes()))
+    tfa_secret = pyotp.random_base32()
+    totp = pyotp.TOTP(tfa_secret)
+    tfa_response = totp.now()
+    assert tfa.activate(user, tfa_secret, tfa_response)
+
+    resp = app.post('/signin', {'token': csrf, 'username': 'user1', 'password': 'password1'}, headers={'Cookie': cookie})
+    assert 'Set-Cookie' in resp.headers
+    new_cookie = resp.headers['Set-Cookie'].split(';', 1)[0]
+    new_csrf = resp.html.find('html')['data-csrf-token']
+    assert new_cookie != cookie
+    assert new_csrf != csrf
+    assert not d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE userid = %(user)s)", user=user)
+    assert d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE additional_data->'2fa_pwd_auth_userid' = %(user)s::text)", user=user)


### PR DESCRIPTION
There are more security fixes, but they involve changing the `sessions` table so should come after the removal of guest sessions. The session token fix, on the other hand, is a dependency of that change.