### PR TITLE
Remove CSRF token backwards compatibility for guest sessions

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/b194ab27295e_ensure_no_guest_sessions_remain_in_.py
+++ b/libweasyl/libweasyl/alembic/versions/b194ab27295e_ensure_no_guest_sessions_remain_in_.py
@@ -1,0 +1,26 @@
+"""Ensure no guest sessions remain in database
+
+Revision ID: b194ab27295e
+Revises: 5491fc6b3d51
+Create Date: 2018-06-19 23:06:42.395887
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b194ab27295e'
+down_revision = '5491fc6b3d51'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_check_constraint(
+        'sessions_no_guest_check',
+        'sessions',
+        "userid IS NOT NULL OR additional_data != ''",
+    )
+
+
+def downgrade():
+    op.drop_constraint('sessions_no_guest_check', 'sessions')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -695,6 +695,7 @@ sessions = Table(
     Column('user_agent_id', Integer(), nullable=True),
     default_fkey(['userid'], ['login.userid'], name='sessions_userid_fkey'),
     default_fkey(['user_agent_id'], ['user_agents.user_agent_id'], name='sessions_user_agent_id_fkey'),
+    CheckConstraint("userid IS NOT NULL OR additional_data != ''", name='sessions_no_guest_check'),
 )
 
 Index('ind_sessions_created_at', sessions.c.created_at)

--- a/libweasyl/libweasyl/models/users.py
+++ b/libweasyl/libweasyl/models/users.py
@@ -207,13 +207,9 @@ class Session(Base):
         else:
             return UserTimezone.load_from_memcached_or_database(self.userid) or _server_time
 
-    @property
-    def csrf_tokens(self):
-        return () if self.csrf_token is None else (self.csrf_token,)
-
 
 class GuestSession(object):
-    __slots__ = ('sessionid', 'csrf_token', 'csrf_tokens', 'create')
+    __slots__ = ('sessionid', 'csrf_token', 'create')
 
     userid = None
     additional_data = None
@@ -221,7 +217,6 @@ class GuestSession(object):
     def __init__(self, sessionid):
         self.sessionid = sessionid
         self.csrf_token = sessionid
-        self.csrf_tokens = [sessionid]
         self.create = False
 
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -354,8 +354,8 @@ def get_userid():
 
 
 def is_csrf_valid(request, token):
-    token = str(token)
-    return any(hmac.compare_digest(token, str(expected)) for expected in request.weasyl_session.csrf_tokens)
+    expected = request.weasyl_session.csrf_token
+    return expected is not None and hmac.compare_digest(str(token), str(expected))
 
 
 def get_token():


### PR DESCRIPTION
Breaks form submissions by guests (log in, register, reset password) when those forms have been left open since before 2018-06-20.