### PR TITLE
Avoid redundant friend, follow, and follower queries on profile page

### DIFF
--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -1,4 +1,4 @@
-$def with (profile, userinfo, social_sites, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, commishinfo, friends, following, followed)
+$def with (profile, userinfo, social_sites, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <section><div id="user-header" class="stage clear">
@@ -114,7 +114,7 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
     </div><!-- /user-commissions -->
 
 
-  $if(statistics):
+  $if show_statistics:
     <div id="user-stats" class="clear on-side">
       <h3>Statistics</h3>
       <p>Joined ${DATE(profile['unixtime'])}</p>
@@ -134,7 +134,7 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
       </dl>
     </div><!-- /user_stats -->
 
-  $if(friends or following or followed):
+  $if statistics['following'] != 0 or statistics['followed'] != 0 or has_friends():
     <div id="user-connections" class="clear on-side">
       <h3>Connections</h3>
       <a class="more more-block" href="/friends/${LOGIN(profile['username'])}"><i>View</i> <span>Friends of</span> <i>${profile['username']}</i></a>

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -345,10 +345,10 @@ def api_user_view_(request):
 
     user['featured_submission'] = featured
 
-    statistics = profile.select_statistics(otherid)
+    statistics, show_statistics = profile.select_statistics(otherid)
     if statistics:
         statistics.pop('staff_notes')
-    user['statistics'] = statistics
+    user['statistics'] = statistics if show_statistics else None
 
     user_info = profile.select_userinfo(otherid)
     if user_info:

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -79,6 +79,8 @@ def profile_(request):
     else:
         favorites = None
 
+    statistics, show_statistics = profile.select_statistics(otherid)
+
     page.append(define.render('user/profile.html', [
         # Profile information
         userprofile,
@@ -100,15 +102,12 @@ def profile_(request):
         # Recent shouts
         shout.select(request.userid, ownerid=otherid, limit=8),
         # Statistics information
-        profile.select_statistics(otherid),
+        statistics,
+        show_statistics,
         # Commission information
         commishinfo.select_list(otherid),
         # Friends
-        frienduser.select(request.userid, otherid, 5, choose=None),
-        # Following
-        followuser.select_following(request.userid, otherid, choose=5),
-        # Followed
-        followuser.select_followed(request.userid, otherid, choose=5),
+        lambda: frienduser.has_friends(otherid),
     ]))
 
     return Response(define.common_page_end(request.userid, page))

--- a/weasyl/followuser.py
+++ b/weasyl/followuser.py
@@ -65,7 +65,7 @@ def select_settings(userid, otherid):
     return query[0]
 
 
-def select_followed(userid, otherid, limit=None, backid=None, nextid=None, choose=None, following=False):
+def select_followed(userid, otherid, limit=None, backid=None, nextid=None, following=False):
     """
     Returns the users who are following the specified user; note that
     ``following`` need never be passed explicitly.
@@ -87,10 +87,7 @@ def select_followed(userid, otherid, limit=None, backid=None, nextid=None, choos
     elif nextid:
         statement.append(" AND pr.username > (SELECT username FROM profile WHERE userid = %i)" % (nextid,))
 
-    if choose:
-        statement.append(" ORDER BY RANDOM() LIMIT %i" % (choose,))
-    else:
-        statement.append(" ORDER BY pr.username%s LIMIT %i" % (" DESC" if backid else "", limit))
+    statement.append(" ORDER BY pr.username%s LIMIT %i" % (" DESC" if backid else "", limit))
 
     query = [{
         "userid": i[0],
@@ -101,11 +98,11 @@ def select_followed(userid, otherid, limit=None, backid=None, nextid=None, choos
     return query[::-1] if backid else query
 
 
-def select_following(userid, otherid, limit=None, backid=None, nextid=None, choose=None):
+def select_following(userid, otherid, limit=None, backid=None, nextid=None):
     """
     Returns the users whom the specified user is following.
     """
-    return select_followed(userid, otherid, limit, backid, nextid, choose, following=True)
+    return select_followed(userid, otherid, limit, backid, nextid, following=True)
 
 
 def manage_following(userid, limit, backid=None, nextid=None):

--- a/weasyl/frienduser.py
+++ b/weasyl/frienduser.py
@@ -35,7 +35,7 @@ def already_pending(userid, otherid, myself=True):
 
 
 def has_friends(otherid):
-    return d.engine.execute(
+    return d.engine.scalar(
         "SELECT EXISTS (SELECT 0 FROM frienduser WHERE %(user)s IN (userid, otherid) AND settings !~ 'p')",
         user=otherid,
     )

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -347,9 +347,8 @@ def _select_statistics(userid):
 
 
 def select_statistics(userid):
-    if "i" in d.get_config(userid) and d.get_userid() not in staff.MODS:
-        return
-    return _select_statistics(userid)
+    show = "i" not in d.get_config(userid) or d.get_userid() in staff.MODS
+    return _select_statistics(userid), show
 
 
 def select_streaming(userid, rating, limit, following=True, order_by=None):


### PR DESCRIPTION
Profile pages don’t display a random selection of those anymore. Also saves queries for their profile pictures and fixes a bug that might never have been encountered where users who accepted friend requests but never sent them, never followed anybody, and were never followed by anybody would appear not to have friends.