### PR TITLE
Check login session early for editing journals

### DIFF
--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -532,6 +532,8 @@ def edit_journal_get_(request):
     ], title="Edit Journal"))
 
 
+@login_required
+@token_checked
 def edit_journal_post_(request):
     form = request.web_input(journalid="", title="", rating="", friends="", content="")
 


### PR DESCRIPTION
``edit_journal_post_`` lacks the decorators to check for a login session early and check for the CSRF token. This adds them, as well as adds two tests to validate our assumption that we do, indeed, need a login and a CSRF token to edit a journal.