### PR TITLE
Revert "Bump pyyaml from 3.12 to 4.1 in /libweasyl"

### DIFF
--- a/libweasyl/setup.py
+++ b/libweasyl/setup.py
@@ -34,7 +34,7 @@ setup(
         'oauthlib==2.0.4',
         'psycopg2cffi==2.7.7',
         'pytz==2018.4',
-        'pyyaml==4.1',
+        'pyyaml==3.12',
         'sanpera==0.1.1+weasyl.6',   # https://github.com/Weasyl/sanpera
         'sqlalchemy==1.2.8',
         'translationstring==1.3',


### PR DESCRIPTION
Reverts Weasyl/weasyl#386

4.1 was removed, and only 4.2b1 exists now.