### PR TITLE
Add required upgrade step to Alembic migration

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/b194ab27295e_ensure_no_guest_sessions_remain_in_.py
+++ b/libweasyl/libweasyl/alembic/versions/b194ab27295e_ensure_no_guest_sessions_remain_in_.py
@@ -15,6 +15,12 @@ import sqlalchemy as sa
 
 
 def upgrade():
+    # We need to purge any guest sessions first, so that our CHECK constraint doesn't fail to be set
+    op.execute("""
+        DELETE FROM sessions
+        WHERE userid IS NULL AND additional_data = ''
+    """)
+
     op.create_check_constraint(
         'sessions_no_guest_check',
         'sessions',


### PR DESCRIPTION
The prerequisite to adding the CHECK constraint here is no guest sessions remaining. So actually verify our assumptions that guest sessions don't exist by trying to clear guest sessions prior to adding the constraint.

(Labelled bug because we ran into this glitch trying to deploy https://github.com/Weasyl/weasyl/commit/f432db5be5d90e722365ceb45563617bb1c4f0d2 to testing, leading to a violation of the ``CHECK`` constraint. The actual code as it exists is _technically_ correct, but a straight upgrade isn't possible without a manual step.)