### PR TITLE
Add query timing option for devs

### DIFF
--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -128,7 +128,7 @@ def session_tween_factory(handler, registry):
 
 def sql_debug_tween_factory(handler, registry):
     """
-    A tween that allows developers to view SQL timing.
+    A tween that allows developers to view SQL timing per query.
     """
     def _quote(s):
         """

--- a/weasyl/wsgi.py
+++ b/weasyl/wsgi.py
@@ -16,6 +16,7 @@ from weasyl import read_staff_yaml
 # Get a configurator and register some tweens to handle cleanup, etc.
 config = Configurator()
 config.add_tween("weasyl.middleware.status_check_tween_factory")
+config.add_tween("weasyl.middleware.sql_debug_tween_factory")
 config.add_tween("weasyl.middleware.session_tween_factory")
 config.add_tween("weasyl.middleware.db_timer_tween_factory")
 config.add_tween("weasyl.middleware.cache_clear_tween_factory")


### PR DESCRIPTION
Add `?sql_debug` to a request to get timing information in response headers.