### PR TITLE
Improve profile load times for users with large numbers of public favorites

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/36b4c0d45d93_add_index_for_profile_favorites.py
+++ b/libweasyl/libweasyl/alembic/versions/36b4c0d45d93_add_index_for_profile_favorites.py
@@ -1,0 +1,22 @@
+"""Add index for profile favorites
+
+Revision ID: 36b4c0d45d93
+Revises: b194ab27295e
+Create Date: 2018-07-08 18:10:43.095681
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '36b4c0d45d93'
+down_revision = 'b194ab27295e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ind_favorite_userid_type_unixtime', 'favorite', ['userid', 'type', 'unixtime'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ind_favorite_userid_type_unixtime', table_name='favorite')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -198,7 +198,8 @@ favorite = Table(
 )
 
 Index('ind_favorite_userid', favorite.c.userid)
-Index('ind_favorite_type_targetid', favorite.c.type, favorite.c.targetid, unique=False)
+Index('ind_favorite_type_targetid', favorite.c.type, favorite.c.targetid)
+Index('ind_favorite_userid_type_unixtime', favorite.c.userid, favorite.c.type, favorite.c.unixtime)
 
 
 folder = Table(


### PR DESCRIPTION
Drops the query for a profile with 27,498 favorites from 200 ms to 2 ms locally, but the difference on production should be more significant.