### PR TITLE
Use exact versions of codecov and pytest-cov in CI

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -5,4 +5,4 @@ else
     weasyl_reqs='-r etc/requirements.txt -c etc/requirements.txt'
     make setup
 fi
-pip install -U $weasyl_reqs -e './libweasyl[development]' codecov pytest-cov
+pip install -U $weasyl_reqs -e './libweasyl[development]' codecov==2.0.15 pytest-cov==2.6.0


### PR DESCRIPTION
pytest-cov 2.6.1 appears to have dropped support for pytest<3.5 (something 2.6.0 claimed to do); CI uses pytest 3.3.0 somehow (we don’t specify it, but it looks like there’s no virtualenv and the Travis build configuration in use includes it). Attempt at a minimal change to get things working again.