### PR TITLE
Prefer wheels over building from source. Fixes #474.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@
 VE ?= weasyl-env
 
 # Whether to install from wheels
-USE_WHEEL := --no-binary :all:
+# Build specific binaries from source, where binaries have been problematic in the past
+USE_WHEEL := --no-binary sanpera,lxml,psycopg2cffi
 
 # Static directories
 STATIC_DIRS := character fonts journal submission tile user media

--- a/libweasyl/Makefile
+++ b/libweasyl/Makefile
@@ -11,7 +11,8 @@ VE ?= ve
 PYVENV ?= virtualenv
 
 # Whether to install from wheels
-USE_WHEEL ?= --no-binary :all:
+# Build specific binaries from source, where binaries have been problematic in the past
+USE_WHEEL ?= --no-binary sanpera,lxml,psycopg2cffi
 
 #
 # Rules


### PR DESCRIPTION
Some packages have begun to depend on Python 3 build tools (i.e., ``flake8``), though currently the pre-built wheels still support Python 2.

Uses pip's ``--no-binary`` option to exclude ``sanpera``, ``psycopg2cffi``, and ``lxml`` from wheels, since issues have been encountered per Charmander using the pre-built wheels.

Fixes #474.