### PR TITLE
Downgrade lxml to 4.3.0 to avoid memory corruption

### DIFF
--- a/libweasyl/setup.py
+++ b/libweasyl/setup.py
@@ -29,7 +29,7 @@ setup(
         'arrow==0.13.0',
         'bcrypt==3.1.6',
         'dogpile.cache==0.7.1',
-        'lxml==4.3.1',
+        'lxml==4.3.0',
         'misaka==1.0.3+weasyl.6',    # https://github.com/Weasyl/misaka
         'oauthlib==2.1.0',
         'psycopg2cffi==2.7.7',


### PR DESCRIPTION
lxml 4.3.1 frees something it shouldn’t when you set the `tail` of top-level elements in `fragment_fromstring` with `create_parent=True`:

```python
from lxml import html

rendered = u"<p></p>\n"
fragment = html.fragment_fromstring(rendered, create_parent=True)
fragment[0].tail = u""  # use after free
```

This happens in Weasyl with *every* Markdown rendering.