### PR TITLE
Implement rate limiting tween/middleware/route decorator

### DIFF
--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -121,6 +121,9 @@ error_messages = {
     "passwordInsecure": "Passwords must be at least 10 characters in length.",
     "passwordMismatch": "The password you entered did not match the password confirmation.",
     "priceidInvalid": "You did not specify a price to edit.",
+    "rateLimitExceeded": (
+        "Multiple invalid requests have been detected, and as such you have been rate limited. "
+        "Please wait a while, and try again."),
     "RatingExceeded": rating,
     "ratingInvalid": "The specified rating is invalid.",
     "recipientExcessive": "You specified too many recipients for this message.",
@@ -157,7 +160,7 @@ error_messages = {
         "You have incorrectly entered your 2FA token or recovery code too many times. Please try logging in again."),
     "TwoFactorAuthenticationAuthenticationTimeout": "Your authentication session has timed out. Please try logging in again.",
     "TwoFactorAuthenticationRequireEnabled": "Two-Factor Authentication must be enabled to access this page.",
-    "TwoFactorAuthenticationRequireDisbled": "Two-Factor Authentication must not be enabled to access this page.",
+    "TwoFactorAuthenticationRequireDisabled": "Two-Factor Authentication must not be enabled to access this page.",
     "TwoFactorAuthenticationZeroRecoveryCodesRemaining": (
         "Your account had zero recovery codes remaining, and as such 2FA was disabled to prevent "
         "you from being permanently unable to log into your account. You may re-enable 2FA if you desire to do so."),
@@ -178,10 +181,11 @@ error_messages = {
 # put it here. Errors without a corresponding entry in this list will use
 # the default status code.
 error_status_code = {
-    "userRecordMissing": 404,
-    "submissionRecordMissing": 404,
-    "journalRecordMissing": 404,
     "characterRecordMissing": 404,
+    "journalRecordMissing": 404,
+    "submissionRecordMissing": 404,
+    "userRecordMissing": 404,
+    "rateLimitExceeded": 429,
 }
 
 

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -156,8 +156,6 @@ error_messages = {
         "The link you followed does not appear to be valid. You may have already added these premium terms "
         "to your account, or you may have copied the link incorrectly."),
     "tooManyPreferenceTags": "You cannot have more than 50 preference tags.",
-    "TwoFactorAuthenticationAuthenticationAttemptsExceeded": (
-        "You have incorrectly entered your 2FA token or recovery code too many times. Please try logging in again."),
     "TwoFactorAuthenticationAuthenticationTimeout": "Your authentication session has timed out. Please try logging in again.",
     "TwoFactorAuthenticationRequireEnabled": "Two-Factor Authentication must be enabled to access this page.",
     "TwoFactorAuthenticationRequireDisabled": "Two-Factor Authentication must not be enabled to access this page.",

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -270,7 +270,6 @@ def rate_limit_check_tween_factory(handler, registry):
             elif 400 <= resp.status_code < 500:
                 # Only increment the counter if we experienced an error.
                 region.set(key=cache_key, value=attempts)
-
         return resp
     return limit_check
 

--- a/weasyl/wsgi.py
+++ b/weasyl/wsgi.py
@@ -15,6 +15,7 @@ from weasyl import staff_config
 
 # Get a configurator and register some tweens to handle cleanup, etc.
 config = Configurator()
+config.add_tween("weasyl.middleware.rate_limit_check_tween_factory")
 config.add_tween("weasyl.middleware.status_check_tween_factory")
 config.add_tween("weasyl.middleware.sql_debug_tween_factory")
 config.add_tween("weasyl.middleware.session_tween_factory")


### PR DESCRIPTION
Adds a new Pyramid middleware tween, which leverages the dogpile.cache to track requests which fail (via 4xx responses), and rate limits requests on a configurable cooldown window and failed request count.

Inspired, at least in part, by RoR's Rack::Attack, but I couldn't find any pre-made Pyramid middleware of a similar nature. While not as fully featured as Rack::Attack, it should function for our needs.

The middleware tween increments the failed counts on any response which has a value in the 4xx range.

Rate limiting is achieved by decorating a route in the following manner:
```python
# Implies 120 second rate limit window, and 5 failed attempts
@rate_limit_route()
def route_a():
    pass

# The decorator can be configured as desired
@rate_limit_route(expiration_time=60 * 1, limit=6)
def route_a():
    pass
```

Currently, the following routes are limited:
1) /signin
2) /signin/2fa-auth