### PR TITLE
Add lazy load exemptions for above-the-fold images

### DIFF
--- a/templates/common/thumbnail_grid_item.html
+++ b/templates/common/thumbnail_grid_item.html
@@ -1,4 +1,4 @@
-$def with (query, notifications=None)
+$def with (query, notifications=None, lazy_load=True)
 
 <li class="item">
   $if notifications:
@@ -50,21 +50,31 @@ $def with (query, notifications=None)
       $if query['contype'] in (30, 50):
         <img src="${avatar['display_url']}" alt="avatar" />
       $elif webp_thumb is not None:
-        <picture>
-          <source type="image/webp" data-srcset="${webp_thumb['display_url']}" />
-          <img class="lazy" data-src="${display_url}" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>" alt="" />
-        </picture>
-        <noscript>
+        $if lazy_load:
+          <picture>
+            <source type="image/webp" data-srcset="${webp_thumb['display_url']}" />
+            <img class="lazy" data-src="${display_url}" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>" alt="" />
+          </picture>
+          <noscript>
+            <picture>
+              <source type="image/webp" srcset="${webp_thumb['display_url']}" />
+              <img src="${display_url}" alt="" />
+            </picture>
+          </noscript>
+        $else:
           <picture>
             <source type="image/webp" srcset="${webp_thumb['display_url']}" />
             <img src="${display_url}" alt="" />
           </picture>
-        </noscript>
       $else:
-        <img class="lazy" data-src="${display_url}" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>" alt="" />
-        <noscript>
+        $if lazy_load:
+          <img class="lazy" data-src="${display_url}" src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>" alt="" />
+          <noscript>
+            <img src="${display_url}" alt="" />
+          </noscript>
+        $else:
           <img src="${display_url}" alt="" />
-        </noscript>
+
     </a>
 
     $if playable and playable[0].get('file_type') == 'mp3':

--- a/templates/etc/index.html
+++ b/templates/etc/index.html
@@ -12,8 +12,9 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
   <h3 class="pad-left typeface-a color-b">Latest Uploads</h3>
 
   <ul class="thumbnail-grid large-footprint">
+    $# Items that are front and center on the main page, quite close to the top; skip lazy loading entirely.
     $for i in everything:
-      $:{_GRID_ITEM(i)}
+      $:{_GRID_ITEM(i, lazy_load=False)}
     </li><li class="clear more"><a class="more" href="/search"><i>Browse</i> <span>Everything</span></a></li>
   </ul><!-- /.thumbnail-grid -->
 

--- a/templates/etc/popular.html
+++ b/templates/etc/popular.html
@@ -9,8 +9,11 @@ $code:
 
 <div id="search-stage" class="stage clear">
   <ul class="thumbnail-grid">
-    $for i in submissions:
-      <!-- score: ${i['score']} -->
-      $:{_GRID_ITEM(i)}
+    $for index, item in enumerate(submissions):
+      <!-- score: ${item['score']} -->
+      $if index < 10:
+        $:{_GRID_ITEM(item, lazy_load=False)}
+      $else:
+        $:{_GRID_ITEM(item)}
   </ul><!-- /.thumbnail-grid -->
 </div><!-- /#search-stage -->

--- a/templates/etc/search.html
+++ b/templates/etc/search.html
@@ -89,8 +89,11 @@ $code:
             Your search terms are too broad. Only the first 100 results will be displayed.
           </p>
         <ul class="thumbnail-grid sectioned">
-          $for i in results:
-            $:{_GRID_ITEM(i)}
+          $for index, result in enumerate(results):
+            $if index < 10:
+              $:{_GRID_ITEM(result, lazy_load=False)}
+            $else:
+              $:{_GRID_ITEM(result)}
         </ul><!-- /.thumbnail-grid -->
 
         <div style="padding-top: 1.4em;" class="pad-left pad-right">
@@ -116,8 +119,11 @@ $code:
 
     $if results:
       <ul class="thumbnail-grid">
-        $for i in results:
-          $:{_GRID_ITEM(i)}
+        $for index, result in enumerate(results):
+          $if index < 10:
+            $:{_GRID_ITEM(result, lazy_load=False)}
+          $else:
+            $:{_GRID_ITEM(result)}
       </ul><!-- /.thumbnail-grid -->
 
       <div style="padding-top: 1.4em;" class="pad-left pad-right">
@@ -142,7 +148,7 @@ $code:
       <h3 class="pad-left">Submissions</h3>
       <ul class="thumbnail-grid medium-footprint">
         $for i in results['submit']:
-          $:{_GRID_ITEM(i)}
+          $:{_GRID_ITEM(i, lazy_load=False)}
         </li><li class="clear more"><a class="more" href="/search?find=submit"><i>More</i> <span>Submissions</span></a></li>
       </ul><!-- /.thumbnail-grid -->
     $else:

--- a/templates/message/submissions_thumbnails.html
+++ b/templates/message/submissions_thumbnails.html
@@ -12,8 +12,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
     $if query:
       <ul class="thumbnail-grid">
-        $for i in query:
-          $:{_GRID_ITEM(i, 1)}
+        $for index, item in enumerate(query):
+          $if index < 10:
+            $:{_GRID_ITEM(item, 1, lazy_load=False)}
+          $else:
+            $:{_GRID_ITEM(item, 1)}
       </ul><!-- /.thumbnail-grid -->
 
       <div class="notifs-actions sub-notifs-actions clear">

--- a/templates/user/characters.html
+++ b/templates/user/characters.html
@@ -11,8 +11,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
   $if result.query:
     <ul class="thumbnail-grid">
-      $for i in result.query:
-        $:{_GRID_ITEM(i)}
+      $for index, item in enumerate(result.query):
+        $if index < 10:
+          $:{_GRID_ITEM(item, lazy_load=False)}
+        $else:
+          $:{_GRID_ITEM(item)}
     </ul><!-- /.thumbnail-grid -->
     $:{RENDER("common/page_navigation.html", [result])}
   $else:

--- a/templates/user/collections.html
+++ b/templates/user/collections.html
@@ -11,8 +11,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
   $if result.query:
     <ul class="thumbnail-grid">
-      $for i in result.query:
-        $:{_GRID_ITEM(i)}
+      $for index, item in enumerate(result.query):
+        $if index < 10:
+          $:{_GRID_ITEM(item, lazy_load=False)}
+        $else:
+          $:{_GRID_ITEM(item)}
     </ul><!-- /.thumbnail-grid -->
     $:{RENDER("common/page_navigation.html", [result])}
   $else:

--- a/templates/user/favorites.html
+++ b/templates/user/favorites.html
@@ -17,8 +17,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
     $if result.query:
       <ul class="thumbnail-grid">
-        $for i in result.query:
-          $:{_GRID_ITEM(i)}
+        $for index, item in enumerate(result.query):
+          $if index < 10:
+            $:{_GRID_ITEM(item, lazy_load=False)}
+          $else:
+            $:{_GRID_ITEM(item)}
       </ul><!-- /.thumbnail-grid -->
 
       $:{RENDER("common/page_navigation.html", [result])}
@@ -31,7 +34,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
         <ul class="grid avatar-grid">
           $for i in result['char']:
-            $:{_GRID_ITEM(i)}
+            $:{_GRID_ITEM(i, lazy_load=False)}
           </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=char"><i>More</i> <span>Characters</span></a></li>
         </ul><!-- /.thumbnail-grid -->
 
@@ -40,7 +43,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
         <ul class="thumbnail-grid medium-footprint">
           $for i in result['submit']:
-            $:{_GRID_ITEM(i)}
+            $:{_GRID_ITEM(i, lazy_load=False)}
           </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=submit"><i>More</i> <span>Submissions</span></a></li>
         </ul><!-- /.thumbnail-grid -->
 
@@ -49,7 +52,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
         <ul class="grid avatar-grid">
           $for i in result['journal']:
-            $:{_GRID_ITEM(i)}
+            $:{_GRID_ITEM(i, lazy_load=False)}
           </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=journal"><i>More</i> <span>Journals</span></a></li>
         </ul><!-- /.thumbnail-grid -->
 

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -5,10 +5,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
 
+  $# The submissions/favorite grids are above/straddling the fold, so omit lazy load.
   $if(submissions):
     <ul id="user-thumbs" class="thumbnail-grid small-footprint">
       $for i in submissions:
-        $:{_GRID_ITEM(i)}
+        $:{_GRID_ITEM(i, lazy_load=False)}
       </li><li class="clear"><a class="more" href="/${more_submissions}/${LOGIN(profile['username'])}"><span>${profile['username']}'s ${more_submissions.title()}</span></a></li>
     </ul><!-- /.thumbnail-grid -->
 
@@ -18,7 +19,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
   $if favorites:
     <ul id="fav-thumbs" class="thumbnail-grid tiny-footprint">
       $for i in favorites:
-        $:{_GRID_ITEM(i)}
+        $:{_GRID_ITEM(i, lazy_load=False)}
       </li><li class="clear"><a class="more" href="/favorites/${LOGIN(profile['username'])}"><span>${profile['username']}'s Favorites</span></a></li>
     </ul><!-- /.thumbnail-grid -->
 

--- a/templates/user/submissions.html
+++ b/templates/user/submissions.html
@@ -31,8 +31,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
     $if result.query:
       <div class="${div_class}">
         <ul class="${grid_class}">
-          $for i in result.query:
-            $:{_GRID_ITEM(i)}
+          $for index, item in enumerate(result.query):
+            $if index < 10:
+              $:{_GRID_ITEM(item, lazy_load=False)}
+            $else:
+              $:{_GRID_ITEM(item)}
         </ul><!-- /.thumbnail-grid -->
         <div style="padding-top: 1.4em;" class="pad-left pad-right">
           $:{RENDER("common/page_navigation.html", [result])}


### PR DESCRIPTION
Next iteration for lazy loading.

Lazy loading images above the fold is considered an anti-pattern, and may result in images not beginning to load until everything else has loaded. This PR attempts to pick sane values in places where the ``thumbnail_grid_item`` items are used.

Additionally, adds the ability to exempt ``thumbnail_grid_item`` from lazy-loading by default, via ``lazy_load=False`` being passed as a parameter to the template rendering call.