### PR TITLE
Make all division Python-3-compatible

### DIFF
--- a/libweasyl/libweasyl/images.py
+++ b/libweasyl/libweasyl/images.py
@@ -6,6 +6,8 @@ This module defines functions which work on sanpera_ ``Image`` objects.
 .. _sanpera: https://pypi.python.org/pypi/sanpera
 """
 
+from __future__ import division
+
 from sanpera.image import Image
 from sanpera import geometry
 

--- a/libweasyl/libweasyl/models/media.py
+++ b/libweasyl/libweasyl/models/media.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import collections
 import hashlib
 from io import BytesIO

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import os
 import re
@@ -749,7 +749,7 @@ def convert_inputdate(target):
 
 
 def convert_age(target):
-    return (get_time() - target) / 31556926
+    return (get_time() - target) // 31556926
 
 
 def age_in_years(birthdate):

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 import urlparse
 from io import BytesIO
@@ -536,7 +536,7 @@ def reupload(userid, submitid, submitfile):
     elif "v" in query[2] or "D" in query[2]:
         raise WeasylError("Unexpected")
 
-    subcat = query[1] / 1000 * 1000
+    subcat = query[1] // 1000 * 1000
     if subcat not in m.ALL_SUBMISSION_CATEGORIES:
         raise WeasylError("Unexpected")
 
@@ -769,7 +769,7 @@ def twitter_card(submitid):
 
     ret['description'] = content
 
-    subcat = subtype / 1000 * 1000
+    subcat = subtype // 1000 * 1000
     media_items = media.get_submission_media(submitid)
     if subcat == m.ART_SUBMISSION_CATEGORY and media_items.get('submission'):
         ret['card'] = 'photo'
@@ -983,7 +983,7 @@ def edit(userid, submission, embedlink=None, friends_only=False, critique=False)
         raise WeasylError("Unexpected")
     elif not folder.check(query[0], submission.folderid):
         raise WeasylError("Unexpected")
-    elif submission.subtype / 1000 != query[1] / 1000:
+    elif submission.subtype // 1000 != query[1] // 1000:
         raise WeasylError("Unexpected")
     elif 'v' in query[2] and not embed.check_valid(embedlink):
         raise WeasylError("embedlinkInvalid")


### PR DESCRIPTION
This might change the behaviour of libweasyl.images.

Necessary for Python 3, #629.