### PR TITLE
Remove unused media type popup

### DIFF
--- a/etc/SETTINGS.txt
+++ b/etc/SETTINGS.txt
@@ -4,7 +4,6 @@ File type indicators
 
 ~  cover
 -  thumb
-+  popup
 =  submit
 >  avatar
 <  banner

--- a/libweasyl/libweasyl/images.py
+++ b/libweasyl/libweasyl/images.py
@@ -20,12 +20,6 @@ COVER_SIZE = 1024, 3000
 THUMB_HEIGHT = 250
 "The maximum height of a thumbnail, in pixels."
 
-POPUP_MIN_EDGE = 100
-"The minimum edge length or width for a popup image, in pixels."
-
-POPUP_MAX_SIZE = 300, 300
-"The maximum size of a popup image, in pixels."
-
 
 read = Image.read
 """
@@ -191,54 +185,6 @@ def make_cover_image(im):
     return resize_image(im, *COVER_SIZE)
 
 
-def _shrinkcrop(im, size, bounds=None):
-    if bounds is not None:
-        ret = im
-        if bounds.position != geometry.origin or bounds.size != ret.size:
-            ret = ret.cropped(bounds)
-        if ret.size != size:
-            ret = ret.resized(size)
-        return ret
-    elif im.size == size:
-        return im
-    shrunk_size = im.size.fit_around(size)
-    shrunk = im
-    if shrunk.size != shrunk_size:
-        shrunk = shrunk.resized(shrunk_size)
-    if shrunk.size == size:
-        return shrunk
-    x1 = (shrunk.size.width - size.width) // 2
-    y1 = (shrunk.size.height - size.height) // 2
-    bounds = geometry.Rectangle(x1, y1, x1 + size.width, y1 + size.height)
-    return shrunk.cropped(bounds)
-
-
-def shrinkcrop(im, size, bounds=None):
-    """
-    Resize and crop an image so that it is exactly a particular size.
-
-    If *im* is larger than the given size, it will first be resized so that its
-    smaller dimension is equal to *size*'s larger dimension. Then, the
-    remaining image that 'overflows' *size* will be cropped equally from both
-    sides so that the size is exactly *size*.
-
-    Parameters:
-        im: A sanpera ``Image``.
-        size: The desired exact size of the resulting image, as a ``(width,
-            height)`` 2-tuple.
-        bounds: Optionally, a sanpera ``Rectangle`` to use to crop *im* before
-            resizing it.
-
-    Returns:
-        *im*, if it is exactly *size*. Otherwise, a new ``Image`` with a size
-        of exactly *size*.
-    """
-    ret = correct_image_and_call(_shrinkcrop, im, size, bounds)
-    if ret.size != size or (len(ret) == 1 and ret[0].size != size):
-        raise ThumbnailingError(ret.size, ret[0].size)
-    return ret
-
-
 def _height_resize(im, height, bounds=None):
     """Creates an image scaled to no more than the specified height with 0.5 <= aspect ratio <= 2."""
     def crop_image_to_width(image, width):  # Crops from both sides equally.
@@ -336,30 +282,3 @@ def make_thumbnail(im, bounds=None):
         a new single-frame ``Image`` resized to fit within the bounds.
     """
     return height_resize(unanimate(im), THUMB_HEIGHT, bounds)
-
-
-def _determine_popup_size(size):
-    shrunk = size.fit_inside(POPUP_MAX_SIZE)
-    return geometry.Size(
-        max(shrunk.width, POPUP_MIN_EDGE), max(shrunk.height, POPUP_MIN_EDGE))
-
-
-def make_popup(im):
-    """
-    Make a popup image.
-
-    That is, resize an image so that it's equal to or smaller than
-    :py:data:`POPUP_MAX_SIZE`, ensuring that no edge is smaller than
-    :py:data:`POPUP_MIN_EDGE`. Images which, when proportionally resized so
-    that their size fits within :py:data:`POPUP_MAX_SIZE`, have an edge smaller
-    than :py:data:`POPUP_MIN_EDGE` will be cropped along their greater edge.
-
-    Parameters:
-        im: A sanpera ``Image``.
-
-    Returns:
-        *im*, if the image's size fits within the constraints. Otherwise, a new
-        ``Image`` resized and possibly cropped to fit.
-    """
-    im = unanimate(im)
-    return shrinkcrop(im, _determine_popup_size(im.size))

--- a/libweasyl/libweasyl/models/content.py
+++ b/libweasyl/libweasyl/models/content.py
@@ -133,15 +133,6 @@ class Submission(Base):
             return ret[0]
         return None
 
-    @reify
-    def popup_media(self):
-        ret = self.media.get('popup')
-        if not ret and self.thumbnail_media:
-            return self.thumbnail_media
-        elif ret:
-            return ret[0]
-        return None
-
     @validator()
     def validate_rating(self, value, old_value, initiator):
         if self.owner is None:
@@ -254,9 +245,6 @@ class Submission(Base):
 
         if submission_media_item is not None:
             SubmissionMediaLink.make_or_replace_link(inst.submitid, 'submission', submission_media_item)
-            if category == Category.visual:
-                popup_media_item = submission_media_item.make_popup(submission_image)
-                SubmissionMediaLink.make_or_replace_link(inst.submitid, 'popup', popup_media_item)
         if cover_media_item is not None:
             SubmissionMediaLink.make_or_replace_link(inst.submitid, 'cover', cover_media_item)
         if thumbnail_media_item is not None:

--- a/libweasyl/libweasyl/models/helpers.py
+++ b/libweasyl/libweasyl/models/helpers.py
@@ -89,7 +89,6 @@ class CharSettingsColumn(types.TypeDecorator):
     file_type_things = {
         '~': 'cover',
         '-': 'thumb',
-        '+': 'popup',
         '=': 'submit',
         '>': 'avatar',
         '<': 'banner',

--- a/libweasyl/libweasyl/models/media.py
+++ b/libweasyl/libweasyl/models/media.py
@@ -92,19 +92,6 @@ class MediaItem(Base):
                 thumbnail.to_buffer(format=self.file_type.encode()), file_type=self.file_type,
                 im=thumbnail)
 
-    def make_popup(self, source_image=None):
-        if self.file_type not in {'jpg', 'png', 'gif'}:
-            raise ValueError('can only auto-popup image media items')
-        if source_image is None:
-            source_image = self.as_image()
-        thumbnail = images.make_popup(source_image)
-        if thumbnail is source_image:
-            return self
-        else:
-            return fetch_or_create_media_item(
-                thumbnail.to_buffer(format=self.file_type.encode()), file_type=self.file_type,
-                im=thumbnail)
-
 
 class DiskMediaItem(MediaItem):
     __table__ = tables.disk_media


### PR DESCRIPTION
Popup is strange. It has existed since the beginning of accessible weasyl-old history, and was unused even then. It *was* used in weasyl3 for submission thumbnails, but it just doesn’t seem like a very good idea in general (it scales smaller images up). I still don’t know why it’s called what it is.

I’ve confirmed that there are no popups in production, so this won’t affect API consumers, either.

```
weasyl=# SELECT count(*) FROM submission_media_links WHERE link_type = 'popup';
 count
-------
     0
(1 row)

weasyl=# SELECT count(*) FROM media_media_links WHERE link_type = 'popup';
 count
-------
     0
(1 row)

weasyl=# SELECT count(*) FROM user_media_links WHERE link_type = 'popup';
 count
-------
     0
(1 row)

weasyl=# SELECT count(*) FROM character WHERE position('+' in settings) != 0;
 count
-------
     0
(1 row)
```