### PR TITLE
Remove broken libweasyl.legacy.plaintext and its unused dependent; merge libweasyl.legacy.login_name and weasyl.define.get_sysname

### DIFF
--- a/libweasyl/libweasyl/legacy.py
+++ b/libweasyl/libweasyl/legacy.py
@@ -7,7 +7,8 @@ module are supporting old, crufty code, and newly-written code should not need
 to use them.
 """
 
-from __future__ import unicode_literals
+import string
+import unicodedata
 
 
 UNIXTIME_OFFSET = -18000
@@ -16,31 +17,35 @@ The offset added to UNIX timestamps before storing them in the database.
 """
 
 
-def plaintext(target):
-    """
-    Remove non-ASCII characters from a string.
-
-    Parameters:
-        target: :term:`unicode`.
-
-    Returns:
-        :term:`unicode` with all non-ASCII characters removed from *target*.
-    """
-    return ''.join(i for i in target if i.isalnum() and ord(i) < 128)
+_SYSNAME_CHARACTERS = frozenset(string.ascii_lowercase + string.digits)
 
 
-def login_name(target):
-    """
-    Convert a username to a login name.
+if isinstance(u"", str):
+    def get_sysname(target):
+        """
+        Convert a username to a login name.
 
-    This is the same as lowercasing the result of calling :py:func:`.plaintext`
-    on a string.
+        Parameters:
+            target: :term:`str`.
 
-    Parameters:
-        target: :term:`unicode`.
+        Returns:
+            :term:`str` stripped of characters other than ASCII alphanumerics and lowercased.
+        """
+        normalized = unicodedata.normalize("NFD", target.lower())
+        return "".join(i for i in normalized if i in _SYSNAME_CHARACTERS)
+else:
+    def get_sysname(target):
+        """
+        Convert a username to a login name.
 
-    Returns:
-        :term:`unicode` with all non-ASCII characters removed from a lowercase
-        *target*.
-    """
-    return plaintext(target).lower()
+        Parameters:
+            target: :term:`str` or :term:`unicode`.
+
+        Returns:
+            :term:`str` stripped of characters other than ASCII alphanumerics and lowercased.
+        """
+        if isinstance(target, unicode):
+            normalized = unicodedata.normalize("NFD", target.lower())
+            return u"".join(i for i in normalized if i in _SYSNAME_CHARACTERS).encode("ascii")
+        else:
+            return "".join(i for i in target if i.isalnum()).lower()

--- a/libweasyl/libweasyl/models/users.py
+++ b/libweasyl/libweasyl/models/users.py
@@ -10,7 +10,6 @@ from sqlalchemy import orm
 import sqlalchemy as sa
 
 from libweasyl.common import minimize_media
-from libweasyl.legacy import plaintext
 from libweasyl.models.helpers import clauses_for
 from libweasyl.models.meta import Base
 from libweasyl.models import tables
@@ -139,25 +138,6 @@ class AuthBCrypt(Base):
     __table__ = tables.authbcrypt
 
     user = orm.relationship(Login, backref=orm.backref('bcrypt', uselist=False))
-
-    def does_authenticate(self, password):
-        """
-        If the given password matches the hashed password in the database,
-        returns True. Otherwise, returns False.
-
-        If the hashed password isn't stored as utf-8, it will be updated to the
-        newer utf-8 format while the plaintext password is available.
-        """
-        expected_hash = self.hashsum.encode('ascii')
-
-        if bcrypt.checkpw(password.encode('utf-8'), expected_hash):
-            return True
-        elif bcrypt.checkpw(plaintext(password).encode('utf-8'), expected_hash):
-            log.debug('updated old non-ASCII password for userid %d', self.userid)
-            self.set_password(password)
-            return True
-        else:
-            return False
 
     def set_password(self, password):
         """

--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -8,7 +8,7 @@ import misaka
 
 from .compat import unicode
 from .defang import defang
-from .legacy import login_name
+from .legacy import get_sysname
 
 try:
     from html.parser import locatestarttagend
@@ -111,7 +111,7 @@ def _markdown(target):
 
 def create_link(t, username):
     link = etree.Element(u"a")
-    link.set(u"href", u"/~" + login_name(username))
+    link.set(u"href", u"/~" + get_sysname(username))
 
     if t == "~":
         link.text = username
@@ -119,7 +119,7 @@ def create_link(t, username):
         link.set(u"class", u"user-icon")
 
         image = etree.SubElement(link, u"img")
-        image.set(u"src", u"/~{username}/avatar".format(username=login_name(username)))
+        image.set(u"src", u"/~{username}/avatar".format(username=get_sysname(username)))
         image.set(u"alt", username)
 
         if t != "!":
@@ -217,7 +217,7 @@ def _markdown_fragment(target, image):
             t, _, user = href.partition(":")
 
             if t == "user":
-                link.attrib["href"] = u"/~{user}".format(user=login_name(user))
+                link.attrib["href"] = u"/~{user}".format(user=get_sysname(user))
             elif t == "da":
                 link.attrib["href"] = u"https://www.deviantart.com/{user}".format(user=_deviantart(user))
             elif t == "ib":
@@ -259,10 +259,10 @@ def _markdown_fragment(target, image):
 
                     continue
 
-                image.set(u"src", u"/~{user}/avatar".format(user=login_name(user)))
+                image.set(u"src", u"/~{user}/avatar".format(user=get_sysname(user)))
 
                 link = etree.Element(u"a")
-                link.set(u"href", u"/~{user}".format(user=login_name(user)))
+                link.set(u"href", u"/~{user}".format(user=get_sysname(user)))
                 link.set(u"class", u"user-icon")
                 parent.insert(list(parent).index(image), link)
                 parent.remove(image)

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -13,9 +13,7 @@ import numbers
 import datetime
 import urlparse
 import functools
-import string
 import subprocess
-import unicodedata
 
 import anyjson as json
 import arrow
@@ -29,7 +27,7 @@ from sqlalchemy.exc import OperationalError
 from web.template import frender
 
 import libweasyl.constants
-from libweasyl.legacy import UNIXTIME_OFFSET as _UNIXTIME_OFFSET
+from libweasyl.legacy import UNIXTIME_OFFSET as _UNIXTIME_OFFSET, get_sysname
 from libweasyl.models.tables import metadata as meta
 from libweasyl import html, text, ratings, security, staff
 
@@ -395,22 +393,6 @@ def get_token():
 
 def _get_csrf_input():
     return '<input type="hidden" name="token" value="%s" />' % (get_token(),)
-
-
-_SYSNAME_CHARACTERS = (
-    set(unicode(string.ascii_lowercase)) |
-    set(unicode(string.digits)))
-
-
-def get_sysname(target):
-    """
-    Return `target` stripped of all non-alphanumeric characters and lowercased.
-    """
-    if isinstance(target, unicode):
-        normalized = unicodedata.normalize("NFD", target.lower())
-        return "".join(i for i in normalized if i in _SYSNAME_CHARACTERS).encode("ascii")
-    else:
-        return "".join(i for i in target if i.isalnum()).lower()
 
 
 @region.cache_on_arguments()

--- a/weasyl/report.py
+++ b/weasyl/report.py
@@ -8,7 +8,7 @@ import web
 
 from libweasyl.models.content import Report, ReportComment
 from libweasyl.models.users import Login
-from libweasyl import constants, legacy, staff
+from libweasyl import constants, staff
 from weasyl.error import WeasylError
 from weasyl import macro as m, define as d, media, note
 
@@ -147,7 +147,7 @@ def select_list(userid, form):
     # If filtering by the report's content's owner, iterate over the previously
     # collected Login model aliases to compare against Login.login_name.
     if form.submitter:
-        submitter = legacy.login_name(form.submitter)
+        submitter = d.get_sysname(form.submitter)
         q = q.filter(sa.or_(l.login_name == submitter for l in login_aliases))
 
     # If filtering by violation type, see if the violation is in the array

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -4,9 +4,9 @@ import itertools
 
 import arrow
 
-from libweasyl import legacy
 from libweasyl import ratings
 from libweasyl import staff
+from libweasyl.legacy import get_sysname
 from libweasyl.models import content, users
 from libweasyl.models.content import Journal
 import weasyl.define as d
@@ -43,7 +43,7 @@ def create_user(full_name="", birthday=arrow.get(586162800), config=None,
         username = "User-" + str(next(_user_index))
 
     while True:
-        user = add_entity(users.Login(login_name=legacy.login_name(username),
+        user = add_entity(users.Login(login_name=get_sysname(username),
                                       last_login=arrow.get(0)))
 
         if user.userid not in staff.MODS and user.userid not in staff.DEVELOPERS:


### PR DESCRIPTION
libweasyl.legacy.plaintext didn’t do what it claimed to, and the Unicode-stripped password check in libweasyl.models.users was broken because of it – but it isn’t used in the current version of Weasyl anyway.

libweasyl.legacy.login_name was similar to weasyl.define.get_sysname, and intended to be used in the same situations. It’s better to have only one. It’s now reexported by weasyl.define (though unfortunately not explicitly, like via `__all__`), because it seemed like changing its references would be unnecessary noise.