### PR TITLE
Fix int/float mixups in stat collection

### DIFF
--- a/weasyl/polecat.py
+++ b/weasyl/polecat.py
@@ -218,7 +218,7 @@ class FetchRequestBreakdownStats(amp.Command):
         ('totalTimeInSQL', amp.Float(optional=True)),
         ('totalTimeInMemcached', amp.Float(optional=True)),
         ('totalTimeInPython', amp.Float(optional=True)),
-        ('queries', amp.ListOf(amp.Float(), optional=True)),
+        ('queries', amp.ListOf(amp.Integer(), optional=True)),
     ]
 
 

--- a/weasyl/polecat.py
+++ b/weasyl/polecat.py
@@ -84,7 +84,7 @@ class WeasylSite(Site):
 
     def readRequestCount(self):
         "Return and reset the request count, request error percentage, and maximum active client count."
-        errorPercentage = 0
+        errorPercentage = 0.0
         if self.requestCount:
             errorPercentage = self.errorCount / self.requestCount * 100
         ret = self.requestCount, errorPercentage, self.mostActiveClients


### PR DESCRIPTION
This should get the request breakdown graphs (e.g. https://status.weasyl.com/munin/weasyl.com/web2.i.weasyl.com/weasyl_request_length_weasyl_1.html) working again.