### PR TITLE
Remove unused favorite.settings

### DIFF
--- a/etc/SETTINGS.txt
+++ b/etc/SETTINGS.txt
@@ -151,14 +151,6 @@ s  Submission
 f  Character
 j  Journal entry
 
---------------------
-favorite.settings ()
---------------------
-
-p  Private
-f  Friends-only
-m  Members-only
-
 ---------------------
 character.settings ()
 ---------------------

--- a/libweasyl/libweasyl/alembic/versions/39f2ff4b7fa6_remove_unused_favorite_settings.py
+++ b/libweasyl/libweasyl/alembic/versions/39f2ff4b7fa6_remove_unused_favorite_settings.py
@@ -1,0 +1,22 @@
+"""Remove unused favorite.settings
+
+Revision ID: 39f2ff4b7fa6
+Revises: 8e98a1be126e
+Create Date: 2019-10-26 20:06:58.166678
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '39f2ff4b7fa6'
+down_revision = '8e98a1be126e'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('favorite', 'settings')
+
+
+def downgrade():
+    op.add_column('favorite', sa.Column('settings', sa.VARCHAR(length=20), server_default=sa.text(u"''::character varying"), autoincrement=False, nullable=False))

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -196,7 +196,6 @@ favorite = Table(
     Column('targetid', Integer(), primary_key=True, nullable=False, autoincrement=False),
     Column('type', String(length=5), primary_key=True, nullable=False, server_default=''),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('settings', String(length=20), nullable=False, server_default=''),
     default_fkey(['userid'], ['login.userid'], name='favorite_userid_fkey'),
 )
 


### PR DESCRIPTION
Confirmed that there are no rows in production with a non-empty value.