### PR TITLE
Add web tests for reuploaded thumbnails and covers on visual submissions

### DIFF
--- a/weasyl/test/web/common.py
+++ b/weasyl/test/web/common.py
@@ -1,0 +1,31 @@
+# encoding: utf-8
+from __future__ import absolute_import, division
+
+import os
+from io import BytesIO
+
+from PIL import Image
+
+from weasyl.macro import MACRO_APP_ROOT, MACRO_STORAGE_ROOT
+
+
+_static_cache = {}
+
+
+def read_static(path):
+    full_path = os.path.join(MACRO_APP_ROOT, 'static', path)
+
+    if full_path not in _static_cache:
+        with open(full_path, 'rb') as f:
+            _static_cache[full_path] = f.read()
+
+    return _static_cache[full_path]
+
+
+def read_static_image(path):
+    return Image.open(BytesIO(read_static(path))).convert('RGBA')
+
+
+def read_storage_image(image_url):
+    full_path = os.path.join(MACRO_STORAGE_ROOT, image_url[1:])
+    return Image.open(full_path).convert('RGBA')

--- a/weasyl/test/web/test_characters.py
+++ b/weasyl/test/web/test_characters.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import
 import os
 import pytest
 import webtest
-from io import BytesIO
 from PIL import Image
 
-from weasyl.macro import MACRO_APP_ROOT, MACRO_STORAGE_ROOT
+from weasyl.macro import MACRO_STORAGE_ROOT
 from weasyl.test import db_utils
+from weasyl.test.web.common import read_static, read_static_image
 
 
 _BASE_FORM = {
@@ -24,28 +24,11 @@ _BASE_FORM = {
 }
 
 
-_static_cache = {}
-
-
-def _static(path):
-    full_path = os.path.join(MACRO_APP_ROOT, 'static', path)
-
-    if full_path not in _static_cache:
-        with open(full_path, 'rb') as f:
-            _static_cache[full_path] = f.read()
-
-    return _static_cache[full_path]
-
-
 def _read_character_image(image_url):
     parts = image_url.split('/')[1:]
     parts[-1] = parts[-1].split('-', 1)[1]
     full_path = os.path.join(MACRO_STORAGE_ROOT, *parts)
     return Image.open(full_path).convert('RGBA')
-
-
-def _read_static_image(path):
-    return Image.open(BytesIO(_static(path))).convert('RGBA')
 
 
 @pytest.fixture(name='character_user')
@@ -59,7 +42,7 @@ def _character(app, db, character_user, no_csrf):
 
     form = dict(
         _BASE_FORM,
-        submitfile=webtest.Upload('wesley', _static('images/wesley1.png'), 'image/png'),
+        submitfile=webtest.Upload('wesley', read_static('images/wesley1.png'), 'image/png'),
     )
 
     resp = app.post('/submit/character', form, headers={'Cookie': cookie}).follow(headers={'Cookie': cookie})
@@ -81,7 +64,7 @@ def test_create_default_thumbnail(app, character):
     assert resp.html.find(id='char-stats').find('dt', text=u'Gender:').findNext('dd').string == u'🦊'
 
     image_url = resp.html.find(id='detail-art').a['href']
-    assert _read_character_image(image_url).tobytes() == _read_static_image('images/wesley1.png').tobytes()
+    assert _read_character_image(image_url).tobytes() == read_static_image('images/wesley1.png').tobytes()
 
 
 @pytest.mark.usefixtures('db', 'character_user', 'character', 'no_csrf')
@@ -104,8 +87,8 @@ def test_owner_reupload(app, character_user, character):
 
     resp = app.post('/reupload/character', {
         'targetid': str(character),
-        'submitfile': webtest.Upload('wesley', _static('images/wesley-draw.png'), 'image/png'),
+        'submitfile': webtest.Upload('wesley', read_static('images/wesley-draw.png'), 'image/png'),
     }, headers={'Cookie': cookie}).follow()
 
     image_url = resp.html.find(id='detail-art').a['href']
-    assert _read_character_image(image_url).tobytes() == _read_static_image('images/wesley-draw.png').tobytes()
+    assert _read_character_image(image_url).tobytes() == read_static_image('images/wesley-draw.png').tobytes()

--- a/weasyl/test/web/test_submissions.py
+++ b/weasyl/test/web/test_submissions.py
@@ -1,0 +1,88 @@
+# encoding: utf-8
+from __future__ import absolute_import, division
+
+import hashlib
+from io import BytesIO
+
+import pytest
+import webtest
+
+from weasyl.test import db_utils
+from weasyl.test.web.common import read_static_image, read_storage_image
+
+
+_BASE_VISUAL_FORM = {
+    'submitfile': u'',
+    'thumbfile': u'',
+    'title': u'Test title',
+    'subtype': u'1030',
+    'folderid': u'',
+    'rating': u'10',
+    'content': u'Description',
+    'tags': u'foo bar ',
+}
+
+
+@pytest.fixture(name='submission_user')
+def _submission_user(db):
+    return db_utils.create_user(username='submission_test')
+
+
+def _create_visual(app, user, **kwargs):
+    cookie = db_utils.create_session(user)
+    form = dict(_BASE_VISUAL_FORM, **kwargs)
+    resp = app.post('/submit/visual', form, headers={'Cookie': cookie}).maybe_follow(headers={'Cookie': cookie})
+    submitid = int(resp.html.find('input', {'name': 'submitid'})['value'])
+
+    return submitid
+
+
+def _image_hash(image):
+    return hashlib.sha224(image.tobytes()).hexdigest()
+
+
+@pytest.mark.usefixtures('db', 'no_csrf')
+def test_visual_reupload_thumbnail_and_cover(app, submission_user):
+    # resized to be larger than COVER_SIZE so a cover is created
+    with BytesIO() as f:
+        read_static_image('images/wesley1.png').resize((2200, 200)).save(f, format='PNG')
+        wesley1_large = webtest.Upload('wesley1.png', f.getvalue(), 'image/png')
+
+    with BytesIO() as f:
+        read_static_image('images/wesley-jumpingtext.png').resize((2200, 100)).save(f, format='PNG')
+        wesley2_large = webtest.Upload('wesley-jumpingtext.png', f.getvalue(), 'image/png')
+
+    cookie = db_utils.create_session(submission_user)
+
+    # Create submission 1 with image 1
+    v1 = _create_visual(app, submission_user, submitfile=wesley1_large)
+
+    # Reupload submission 1 with image 2
+    app.post('/reupload/submission', {
+        'targetid': u'%i' % (v1,),
+        'submitfile': wesley2_large,
+    }, headers={'Cookie': cookie}).follow()
+
+    [thumb] = app.get('/~submissiontest').html.select('#user-thumbs img')
+    v1_new_thumbnail_url = thumb['src']
+    v1_new_cover_url = app.get('/~submissiontest/submissions/%i/test-title' % (v1,)).html.find(id='detail-art').img['src']
+
+    # Remove submission 1, so uploading a duplicate image is allowed
+    app.post('/remove/submission', {
+        'submitid': u'%i' % (v1,),
+    }, headers={'Cookie': cookie}).follow()
+
+    # Upload submission 2 with image 2
+    v2 = _create_visual(
+        app,
+        submission_user,
+        submitfile=wesley2_large,
+    )
+
+    [thumb] = app.get('/~submissiontest').html.select('#user-thumbs img')
+    v2_thumbnail_url = thumb['src']
+    v2_cover_url = app.get('/~submissiontest/submissions/%i/test-title' % (v2,)).html.find(id='detail-art').img['src']
+
+    # The reupload of submission 1 should look like submission 2
+    assert _image_hash(read_storage_image(v1_new_thumbnail_url)) == _image_hash(read_storage_image(v2_thumbnail_url))
+    assert _image_hash(read_storage_image(v2_cover_url)) == _image_hash(read_storage_image(v1_new_cover_url))


### PR DESCRIPTION
It’s a bit fragile – reuploading *after* uploading the second submission would reuse a cached cover from that upload and therefore not cover what I’m about to refactor – but it’s something.