### PR TITLE
Use requests.exceptions.ConnectionError as the exception class

### DIFF
--- a/weasyl/spam_filtering.py
+++ b/weasyl/spam_filtering.py
@@ -2,6 +2,8 @@ import logging
 import os
 
 from akismet import Akismet, SpamStatus
+# Imported as RequestsConnectionError to not conflict with Python 3's built-in ConnectionError exception
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from weasyl import config
 from weasyl import define as d
@@ -79,7 +81,7 @@ def check(
     if FILTERING_ENABLED:
         try:
             return _akismet.check(**payload)
-        except ConnectionError:
+        except RequestsConnectionError:
             # Don't fail just because of a connection issue to the Akismet backend; but log that we failed.
             d.log_exc(level=logging.WARNING)
             return SpamStatus.Ham


### PR DESCRIPTION
The built-in ConnectionError class is only Python 3, and requests doesn't inherit from it (rather, the base error class inherits from IOError).

Fix arising from #654, where I had my IDE set to Python 3.5, and there's a built-in in Python 3.