### PR TITLE
Switch to smtplib to send mail

### DIFF
--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -20,6 +20,9 @@ url = postgresql+psycopg2cffi:///weasyl
 [sentry]
 # dsn = twisted+http://...
 
+[smtp]
+host = localhost
+
 [recaptcha-lo.weasyl.com]
 public_key = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 private_key = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -25,14 +25,13 @@ def normalize_address(address):
     return "%s@%s" % (local, domain.lower())
 
 
-def append(mailto, mailfrom, subject, content, displayto=None):
+def append(mailto, mailfrom, subject, content):
     """Send an e-mail.
 
     `mailto` must be a list of e-mail addresses to send this e-mail to. If
     `mailfrom` is None, the system email will be designated as the sender.
     Otherwise, `mailfrom` must be a single e-mail address. The 'To' header of the
-    e-mail will be a comma-separated list of the `mailto` addresses unless
-    `displayto` is not None (in which case it will be set to `displayto`.)
+    e-mail will be a comma-separated list of the `mailto` addresses.
     """
 
     if not mailfrom:
@@ -53,10 +52,7 @@ def append(mailto, mailfrom, subject, content, displayto=None):
         subject = "None"
 
     message = email.mime.text.MIMEText(content.strip())
-    if displayto is not None:
-        message["To"] = displayto
-    else:
-        message["To"] = ', '.join(mailto)
+    message["To"] = ', '.join(mailto)
     message["From"] = mailfrom
     message["Subject"] = subject
 

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -25,26 +25,18 @@ def normalize_address(address):
     return "%s@%s" % (local, domain.lower())
 
 
-def append(mailto, mailfrom, subject, content):
+def append(mailto, subject, content):
     """Send an e-mail.
 
-    `mailto` must be a list of e-mail addresses to send this e-mail to. If
-    `mailfrom` is None, the system email will be designated as the sender.
-    Otherwise, `mailfrom` must be a single e-mail address. The 'To' header of the
+    `mailto` must be a list of e-mail addresses to send this e-mail to. The
+    system email will be designated as the sender. The 'To' header of the
     e-mail will be a comma-separated list of the `mailto` addresses.
     """
-
-    if not mailfrom:
-        mailfrom = macro.MACRO_EMAIL_ADDRESS
-
-    mailfrom = normalize_address(mailfrom)
     subject = subject.strip()
     content = content.strip()
 
     if not mailto:
         raise error.WeasylError("mailtoInvalid")
-    elif not mailfrom:
-        raise error.WeasylError("mailfromInvalid")
     elif not content:
         raise error.WeasylError("contentInvalid")
 
@@ -53,7 +45,7 @@ def append(mailto, mailfrom, subject, content):
 
     message = email.mime.text.MIMEText(content.strip())
     message["To"] = ', '.join(mailto)
-    message["From"] = mailfrom
+    message["From"] = macro.MACRO_EMAIL_ADDRESS
     message["Subject"] = subject
 
     sendmail_args = ['sendmail'] + list(mailto)

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import email.mime.text
 
-from weasyl import define, error, macro
+from weasyl import define, macro
 
 
 EMAIL_ADDRESS = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
@@ -28,16 +28,15 @@ def normalize_address(address):
 def append(mailto, subject, content):
     """Send an e-mail.
 
-    `mailto` must be a list of e-mail addresses to send this e-mail to. The
-    system email will be designated as the sender. The 'To' header of the
-    e-mail will be a comma-separated list of the `mailto` addresses.
+    `mailto` must be a normalized e-mail address to send this e-mail to. The
+    system email will be designated as the sender.
     """
     message = email.mime.text.MIMEText(content.strip())
-    message["To"] = ', '.join(mailto)
+    message["To"] = mailto
     message["From"] = macro.MACRO_EMAIL_ADDRESS
     message["Subject"] = subject
 
-    sendmail_args = ['sendmail'] + list(mailto)
+    sendmail_args = ['sendmail', '-t']
     proc = subprocess.Popen(sendmail_args, stdin=subprocess.PIPE)
     proc.communicate(message.as_string())
     if proc.returncode:

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -32,17 +32,6 @@ def append(mailto, subject, content):
     system email will be designated as the sender. The 'To' header of the
     e-mail will be a comma-separated list of the `mailto` addresses.
     """
-    subject = subject.strip()
-    content = content.strip()
-
-    if not mailto:
-        raise error.WeasylError("mailtoInvalid")
-    elif not content:
-        raise error.WeasylError("contentInvalid")
-
-    if not subject:
-        subject = "None"
-
     message = email.mime.text.MIMEText(content.strip())
     message["To"] = ', '.join(mailto)
     message["From"] = macro.MACRO_EMAIL_ADDRESS

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -7,7 +7,7 @@ import email.mime.text
 from weasyl import define, macro
 
 
-EMAIL_ADDRESS = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+EMAIL_ADDRESS = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+\Z")
 
 
 def normalize_address(address):

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -235,7 +235,7 @@ def create(form):
         })
 
         # Queue verification email
-        emailer.append([email], None, "Weasyl Account Creation", d.render(
+        emailer.append([email], "Weasyl Account Creation", d.render(
             "email/verify_account.html", [token, sysname]))
         d.metric('increment', 'createdusers')
     else:
@@ -258,7 +258,7 @@ def create(form):
         #   let the already registered user know this via email (perhaps they forgot their username/password)
         query_username_login = d.engine.scalar("SELECT login_name FROM login WHERE email = %(email)s", email=email)
         query_username_logincreate = d.engine.scalar("SELECT login_name FROM logincreate WHERE email = %(email)s", email=email)
-        emailer.append([email], None, "Weasyl Account Creation - Account Already Exists", d.render(
+        emailer.append([email], "Weasyl Account Creation - Account Already Exists", d.render(
             "email/email_in_use_account_creation.html", [query_username_login or query_username_logincreate]))
 
 

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -234,8 +234,8 @@ def create(form):
             "unixtime": arrow.now(),
         })
 
-        # Queue verification email
-        emailer.append(email, "Weasyl Account Creation", d.render(
+        # Send verification email
+        emailer.send(email, "Weasyl Account Creation", d.render(
             "email/verify_account.html", [token, sysname]))
         d.metric('increment', 'createdusers')
     else:
@@ -258,7 +258,7 @@ def create(form):
         #   let the already registered user know this via email (perhaps they forgot their username/password)
         query_username_login = d.engine.scalar("SELECT login_name FROM login WHERE email = %(email)s", email=email)
         query_username_logincreate = d.engine.scalar("SELECT login_name FROM logincreate WHERE email = %(email)s", email=email)
-        emailer.append(email, "Weasyl Account Creation - Account Already Exists", d.render(
+        emailer.send(email, "Weasyl Account Creation - Account Already Exists", d.render(
             "email/email_in_use_account_creation.html", [query_username_login or query_username_logincreate]))
 
 

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -235,7 +235,7 @@ def create(form):
         })
 
         # Queue verification email
-        emailer.append([email], "Weasyl Account Creation", d.render(
+        emailer.append(email, "Weasyl Account Creation", d.render(
             "email/verify_account.html", [token, sysname]))
         d.metric('increment', 'createdusers')
     else:
@@ -258,7 +258,7 @@ def create(form):
         #   let the already registered user know this via email (perhaps they forgot their username/password)
         query_username_login = d.engine.scalar("SELECT login_name FROM login WHERE email = %(email)s", email=email)
         query_username_logincreate = d.engine.scalar("SELECT login_name FROM logincreate WHERE email = %(email)s", email=email)
-        emailer.append([email], "Weasyl Account Creation - Account Already Exists", d.render(
+        emailer.append(email, "Weasyl Account Creation - Account Already Exists", d.render(
             "email/email_in_use_account_creation.html", [query_username_login or query_username_logincreate]))
 
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -590,13 +590,13 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
             """, userid=userid, newemail=newemail, token=token)
 
             # Send out the email containing the verification token.
-            emailer.append([newemail], "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
+            emailer.append(newemail, "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
         else:
             # The target email exists: let the target know this
             query_username = d.engine.scalar("""
                 SELECT login_name FROM login WHERE email = %(email)s
             """, email=newemail)
-            emailer.append([newemail], "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
+            emailer.append(newemail, "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
                 "email/email_in_use_email_change.html", [query_username])
             )
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -590,13 +590,13 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
             """, userid=userid, newemail=newemail, token=token)
 
             # Send out the email containing the verification token.
-            emailer.append(newemail, "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
+            emailer.send(newemail, "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
         else:
             # The target email exists: let the target know this
             query_username = d.engine.scalar("""
                 SELECT login_name FROM login WHERE email = %(email)s
             """, email=newemail)
-            emailer.append(newemail, "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
+            emailer.send(newemail, "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
                 "email/email_in_use_email_change.html", [query_username])
             )
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -590,13 +590,13 @@ def edit_email_password(userid, username, password, newemail, newemailcheck,
             """, userid=userid, newemail=newemail, token=token)
 
             # Send out the email containing the verification token.
-            emailer.append([newemail], None, "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
+            emailer.append([newemail], "Weasyl Email Change Confirmation", d.render("email/verify_emailchange.html", [token, d.get_display_name(userid)]))
         else:
             # The target email exists: let the target know this
             query_username = d.engine.scalar("""
                 SELECT login_name FROM login WHERE email = %(email)s
             """, email=newemail)
-            emailer.append([newemail], None, "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
+            emailer.append([newemail], "Weasyl Account Information - Duplicate Email on Accounts Rejected", d.render(
                 "email/email_in_use_email_change.html", [query_username])
             )
 

--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -39,7 +39,7 @@ def request(form):
         """, id=user_id, token=token, time=now, address=address)
 
         # Generate and send an email to the user containing a password reset link
-        emailer.append(email, "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
+        emailer.send(email, "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
 
 
 def prepare(token):

--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -39,7 +39,7 @@ def request(form):
         """, id=user_id, token=token, time=now, address=address)
 
         # Generate and send an email to the user containing a password reset link
-        emailer.append([email], None, "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
+        emailer.append([email], "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
 
 
 def prepare(token):

--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -39,7 +39,7 @@ def request(form):
         """, id=user_id, token=token, time=now, address=address)
 
         # Generate and send an email to the user containing a password reset link
-        emailer.append([email], "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
+        emailer.append(email, "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
 
 
 def prepare(token):

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -103,7 +103,7 @@ def lower_bcrypt_rounds(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def drop_email(monkeypatch):
-    def drop_append(mailto, mailfrom, subject, content, displayto=None):
+    def drop_append(mailto, mailfrom, subject, content):
         pass
 
     monkeypatch.setattr(emailer, 'append', drop_append)

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -103,7 +103,7 @@ def lower_bcrypt_rounds(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def drop_email(monkeypatch):
-    def drop_append(mailto, mailfrom, subject, content):
+    def drop_append(mailto, subject, content):
         pass
 
     monkeypatch.setattr(emailer, 'append', drop_append)

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -103,10 +103,10 @@ def lower_bcrypt_rounds(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def drop_email(monkeypatch):
-    def drop_append(mailto, subject, content):
+    def drop_send(mailto, subject, content):
         pass
 
-    monkeypatch.setattr(emailer, 'append', drop_append)
+    monkeypatch.setattr(emailer, 'send', drop_send)
 
 
 @pytest.fixture


### PR DESCRIPTION
Allows not having a local MTA or similar, convenient for containers. Should work without configuration changes in production, since the VMs have SMTP on localhost.

Fixes #700.