### PR TITLE
Update link format for some of the most common sources of old-style submission links

### DIFF
--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -24,7 +24,7 @@ def submission_(request):
 
     if not request.userid:
         # Only generate the Twitter/OGP meta headers if not authenticated (the UA viewing is likely automated).
-        twit_card = submission.twitter_card(submitid)
+        twit_card = submission.twitter_card(request, submitid)
         if define.user_is_twitterbot():
             extras['twitter_card'] = twit_card
         # The "og:" prefix is specified in page_start.html, and og:image is required by the OGP spec, so something must be in there.
@@ -67,6 +67,7 @@ def submission_(request):
 
     page = define.common_page_start(request.userid, **extras)
     page.append(define.render('detail/submission.html', [
+        request,
         # Myself
         profile.select_myself(request.userid),
         # Submission detail

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -79,6 +79,7 @@ def profile_(request):
     statistics, show_statistics = profile.select_statistics(otherid)
 
     page.append(define.render('user/profile.html', [
+        request,
         # Profile information
         userprofile,
         # User information

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -701,7 +701,7 @@ def select_view_api(userid, submitid, anyway=False, increment_views=False):
     }
 
 
-def twitter_card(submitid):
+def twitter_card(request, submitid):
     query = d.engine.execute("""
         SELECT
             su.title, su.settings, su.content, su.subtype, su.userid, pr.username, pr.full_name, pr.config, ul.link_value, su.rating
@@ -728,7 +728,13 @@ def twitter_card(submitid):
 
     ret = {
         'url': d.absolutify_url(
-            '/submission/%s/%s' % (submitid, text.slug_for(title))),
+            request.route_path(
+                'submission_detail_profile',
+                name=d.get_sysname(username),
+                submitid=submitid,
+                slug=text.slug_for(title),
+            )
+        ),
     }
 
     if twitter:

--- a/weasyl/templates/detail/submission.html
+++ b/weasyl/templates/detail/submission.html
@@ -1,4 +1,4 @@
-$def with (myself, query, subtypes, violations)
+$def with (request, myself, query, subtypes, violations)
 $code:
   def _CAT(x):
     if x // 1000 == 1:   return "Visual"
@@ -113,9 +113,16 @@ $code:
       $ older = query['folder_more']['older']
       $if older:
         $for e, i in enumerate(older, start=1):
-          $ thumb = THUMB(i)
-          $ id = 'id="folder-nav-prev"' if e == len(older) else ''
-          <a class="nav-link older" $:{id} href="/submission/${i['submitid']}/${SLUG(i['title'])}">
+          $code:
+            thumb = THUMB(i)
+            id = 'id="folder-nav-prev"' if e == len(older) else ''
+            link = request.route_path(
+              'submission_detail_profile',
+              name=LOGIN(i['username']),
+              submitid=i['submitid'],
+              slug=SLUG(i['title']),
+            )
+          <a class="nav-link older" $:{id} href="${link}">
             <span class="text">&#171; Older</span>
             $if i['rating'] == R.MATURE.code:
               <span class="rating mature">The following submission is rated Mature:</span>
@@ -126,9 +133,16 @@ $code:
 
       $if query['folder_more']['newer']:
         $for e, i in enumerate(query['folder_more']['newer']):
-          $ thumb = THUMB(i)
-          $ id = 'id="folder-nav-next"' if e == 0 else ''
-          <a class="nav-link newer" $:{id} href="/submission/${i['submitid']}/${SLUG(i['title'])}">
+          $code:
+            thumb = THUMB(i)
+            id = 'id="folder-nav-next"' if e == 0 else ''
+            link = request.route_path(
+              'submission_detail_profile',
+              name=LOGIN(i['username']),
+              submitid=i['submitid'],
+              slug=SLUG(i['title']),
+            )
+          <a class="nav-link newer" $:{id} href="${link}">
             $if i['rating'] == R.MATURE.code:
               <span class="rating mature">The following submission is rated Mature:</span>
             $elif i['rating'] == R.EXPLICIT.code:

--- a/weasyl/templates/user/profile.html
+++ b/weasyl/templates/user/profile.html
@@ -1,4 +1,4 @@
-$def with (profile, userinfo, social_sites, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends)
+$def with (request, profile, userinfo, social_sites, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <section><div id="user-header" class="stage clear">
@@ -46,9 +46,16 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
       $ cover = featured['sub_media']['cover'][0]
       <div id="user-featured">
         $if featured['contype'] in (10, 15):
-          <h3>${blurb}: <a class="color-c" href="/submission/${featured['submitid']}/${SLUG(featured['title'])}">${featured['title']}</a></h3>
+          $code:
+            featured_link = request.route_path(
+              'submission_detail_profile',
+              name=LOGIN(featured['username']),
+              submitid=featured['submitid'],
+              slug=SLUG(featured['title']),
+            )
+          <h3>${blurb}: <a class="color-c" href="${featured_link}">${featured['title']}</a></h3>
           <div id="uf-image">
-            <a href="/submission/${featured['submitid']}/${SLUG(featured['title'])}"><img src="${cover['display_url']}" alt="${blurb} image: ${featured['title']}" /></a>
+            <a href="${featured_link}"><img src="${cover['display_url']}" alt="${blurb} image: ${featured['title']}" /></a>
         $elif featured['contype'] == 20:
           <h3>Most Recent: <a class="color-c" href="/character/${featured['charid']}/${SLUG(featured['title'])}">${featured['title']}</a></h3>
           <div id="uf-image">

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -30,6 +30,7 @@ from weasyl import (
     middleware,
     spam_filtering,
 )
+from weasyl.controllers.routes import setup_routes_and_views
 from weasyl.wsgi import wsgi_app
 
 
@@ -90,7 +91,7 @@ def setup_request_environment(request):
     pyramid_request.web_input = middleware.web_input_request_method
     pyramid_request.environ['HTTP_X_FORWARDED_FOR'] = '127.0.0.1'
     pyramid_request.client_addr = '127.0.0.1'
-    pyramid.testing.setUp(request=pyramid_request)
+    setup_routes_and_views(pyramid.testing.setUp(request=pyramid_request))
 
     def tear_down():
         pyramid_request.pg_connection.close()

--- a/weasyl/test/test_submission.py
+++ b/weasyl/test/test_submission.py
@@ -5,6 +5,7 @@ import unittest
 import pytest
 
 import arrow
+from pyramid.threadlocal import get_current_request
 
 from libweasyl.models.helpers import CharSettings
 from libweasyl import ratings
@@ -41,9 +42,10 @@ class SelectListTestCase(unittest.TestCase):
         sub2 = db_utils.create_submission(user, rating=ratings.MATURE.code)
         sub3 = db_utils.create_submission(user, rating=ratings.EXPLICIT.code)
 
-        card1 = submission.twitter_card(sub1)
-        card2 = submission.twitter_card(sub2)
-        card3 = submission.twitter_card(sub3)
+        request = get_current_request()
+        card1 = submission.twitter_card(request, sub1)
+        card2 = submission.twitter_card(request, sub2)
+        card3 = submission.twitter_card(request, sub3)
 
         self.assertNotEqual('This image is rated 18+ and only viewable on weasyl.com', card1['description'])
         self.assertEqual('This image is rated 18+ and only viewable on weasyl.com', card2['description'])


### PR DESCRIPTION
- In-folder navigation on submissions
- Featured/latest submissions on profile pages
- Twitter cards/OGP metadata

This is a performance improvement, since it avoids a redirect that’s already done the full work of `submission.select_view`.