### PR TITLE
Reference constraint file for weasyl to fix libweasyl builds.

### DIFF
--- a/libweasyl/Makefile
+++ b/libweasyl/Makefile
@@ -31,7 +31,7 @@ all: .stamp-ve .stamp-egg-info alembic.ini
 
 # Installs libweasyl package in development mode
 .stamp-egg-info: setup.py .stamp-ve
-	$(VE)/bin/pip install $(USE_WHEEL) -e '.[development]'
+	$(VE)/bin/pip install $(USE_WHEEL) -e '.[development]' -c ../etc/requirements.txt
 	touch $@
 
 # Creates alembic config


### PR DESCRIPTION
Attempting to install libweasyl would fail otherwise. Gitter reference/discussion: https://gitter.im/Weasyl/weasyl?at=5e3ce917433e1d40399e8220

(I got tired of manually adding the constraint file to each branch checkout. So let's fix it once and for all.)