### PR TITLE
Eliminate another round trip for profile.jsonb_settings

### DIFF
--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -681,7 +681,7 @@ def edit_preferences(userid, timezone=None,
     if jsonb_settings is not None:
         # update jsonb preferences
         updates['jsonb_settings'] = jsonb_settings.get_raw()
-        d._get_profile_settings.invalidate(userid)
+        d._get_all_config.invalidate(userid)
 
     d.engine.execute(
         tables.profile.update().where(tables.profile.c.userid == userid),


### PR DESCRIPTION
used on the viewer whenever thumbnails are displayed, for example.

Also fixes a bug: the guest `userid` is `0`, not `None`.