### PR TITLE
Remove active users

### DIFF
--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import arrow
 from twisted.python import log
 
-from weasyl.define import active_users, engine, get_time
+from weasyl.define import engine, get_time
 from weasyl import index, submission
 
 
@@ -28,12 +28,6 @@ def run_periodic_tasks():
         if now.minute % 2 == 0:
             index.recent_submissions.refresh()
             log.msg('refreshed recent submissions')
-
-        # Recache the active user counts
-        # Every 5 minutes
-        if now.minute % 5 == 0:
-            active_users.refresh()
-            log.msg('refreshed active user counts')
 
         # Recalculate recently popular submissions
         # Every 10 minutes

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -734,36 +734,8 @@ def common_page_start(userid, options=None, **extended_options):
     return [data]
 
 
-def _active_users(seconds):
-    usercount_url_template = config_read_setting('url_template', section='usercount')
-    if not usercount_url_template:
-        return
-    try:
-        resp = http_get(usercount_url_template % (seconds,))
-    except WeasylError:
-        return
-    if resp.status_code != 200:
-        return
-    return resp.json()['users']
-
-
-@region.cache_on_arguments(expiration_time=600)
-@record_timing
-def active_users():
-    active_users = []
-    for span, seconds in [('hour', 60 * 60), ('day', 60 * 60 * 24)]:
-        users = _active_users(seconds)
-        if users:
-            active_users.append((span, users))
-
-    return '; '.join(
-        '%d users active in the last %s' % (users, span)
-        for span, users in active_users)
-
-
 def common_page_end(userid, page, options=None):
-    active_users_string = active_users()
-    data = render("common/page_end.html", (options, active_users_string))
+    data = render("common/page_end.html", (options,))
     page.append(data)
     return "".join(page)
 

--- a/weasyl/templates/common/page_end.html
+++ b/weasyl/templates/common/page_end.html
@@ -1,4 +1,4 @@
-$def with (options=None, active_users_string='')
+$def with (options=None)
   <footer><div id="footer">
 
     <nav><div id="footer-nav" class="clear">
@@ -57,9 +57,6 @@ $def with (options=None, active_users_string='')
     <img id="footer-wesley" src="${resource_path('img/wesley1.png')}" alt="" />
 
     <p id="footer-info">
-      $if active_users_string:
-        ${active_users_string}.
-        <br>
       <a href="https://github.com/Weasyl/weasyl/commit/${SHA}">${SHA}</a> &middot; Copyright &copy; 2012–${arrow.now().year} Weasyl LLC<br>
       <a href="https://github.com/Weasyl/weasyl">Weasyl is an open source project</a>
     </p>


### PR DESCRIPTION
It’s adding a Memcached round trip for something that’s not even functional right now. (When/if we bring it back, it should probably only count registered users.)