### PR TITLE
Remove define.convert_inputdate in favor of using define.convert_unix…

### DIFF
--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -576,14 +576,14 @@ def convert_date(target=None):
     return result[1:] if result and result[0] == "0" else result
 
 
-def convert_iso_date(target=None):
+def convert_iso_date(target):
     """
-    Converts a unix timestamp to an ISO 8601 date (yyyy-mm-dd). If no target is passed,
+    Converts a Weasyl timestamp to an ISO 8601 date (yyyy-mm-dd). If no target is passed,
     the current date is returned.
 
     Note that the date is converted to localtime (via ``convert_to_localtime``).
 
-    :param target: The target unix timestamp to convert. Optional.
+    :param target: The target Weasyl timestamp to convert.
     :return: An ISO 8601 string representing the date of `target`, otherwise the current date formatted as YYYY-MM-DD.
     """
     date = convert_to_localtime(target)

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division
 
 import os
-import re
 import time
 import random
 import urllib

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -164,7 +164,7 @@ def _compile(template_name):
                 "CSRF": _get_csrf_input,
                 "USER_TYPE": user_type,
                 "DATE": convert_date,
-                "ISO_DATE": convert_iso_date,
+                "ISO8601_DATE": iso8601_date,
                 "TIME": _convert_time,
                 "LOCAL_ARROW": local_arrow,
                 "PRICE": text_price_amount,
@@ -576,17 +576,16 @@ def convert_date(target=None):
     return result[1:] if result and result[0] == "0" else result
 
 
-def convert_iso_date(target):
+def iso8601_date(target):
     """
-    Converts a Weasyl timestamp to an ISO 8601 date (yyyy-mm-dd). If no target is passed,
-    the current date is returned.
+    Converts a Weasyl timestamp to an ISO 8601 date (yyyy-mm-dd).
 
-    Note that the date is converted to localtime (via ``convert_to_localtime``).
+    NB: Target is offset by _UNIXTIME_OFFSET
 
     :param target: The target Weasyl timestamp to convert.
-    :return: An ISO 8601 string representing the date of `target`, otherwise the current date formatted as YYYY-MM-DD.
+    :return: An ISO 8601 string representing the date of `target`.
     """
-    date = convert_to_localtime(target)
+    date = datetime.datetime.utcfromtimestamp(target - _UNIXTIME_OFFSET)
     return arrow.get(date).format("YYYY-MM-DD")
 
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -773,7 +773,7 @@ def do_manage(my_userid, userid, username=None, full_name=None, catchphrase=None
         username (str): New username for user. Defaults to None.
         full_name (str): New full name for user. Defaults to None.
         catchphrase (str): New catchphrase for user. Defaults to None.
-        birthday (str): New birthday for user, in format for convert_inputdate. Defaults to None.
+        birthday (str): New birthday for user, in HTML5 date format (ISO 8601 yyyy-mm-dd). Defaults to None.
         gender (str): New gender for user. Defaults to None.
         country (str): New country for user. Defaults to None.
         remove_social (list): Items to remove from the user's social/contact links. Defaults to None.
@@ -825,30 +825,33 @@ def do_manage(my_userid, userid, username=None, full_name=None, catchphrase=None
         updates.append('- Catchphrase: %s' % (catchphrase,))
 
     # Birthday
-    if birthday is not None and d.convert_inputdate(birthday):
-        unixtime = d.convert_inputdate(birthday)
-        age = d.convert_age(unixtime)
+    if birthday is not None:
+        # HTML5 date format is yyyy-mm-dd
+        split = birthday.split("-")
+        if len(split) == 3 and d.convert_unixdate(day=split[2], month=split[1], year=split[0]):
+            unixtime = d.convert_unixdate(day=split[2], month=split[1], year=split[0])
+            age = d.convert_age(unixtime)
 
-        d.execute("UPDATE userinfo SET birthday = %i WHERE userid = %i", [unixtime, userid])
+            d.execute("UPDATE userinfo SET birthday = %i WHERE userid = %i", [unixtime, userid])
 
-        if age < ratings.EXPLICIT.minimum_age:
-            max_rating = ratings.GENERAL.code
-            rating_flag = ""
-        else:
-            max_rating = ratings.EXPLICIT.code
+            if age < ratings.EXPLICIT.minimum_age:
+                max_rating = ratings.GENERAL.code
+                rating_flag = ""
+            else:
+                max_rating = ratings.EXPLICIT.code
 
-        if d.get_rating(userid) > max_rating:
-            d.engine.execute(
-                """
-                UPDATE profile
-                SET config = REGEXP_REPLACE(config, '[ap]', '', 'g') || %(rating_flag)s
-                WHERE userid = %(user)s
-                """,
-                rating_flag=rating_flag,
-                user=userid,
-            )
-            d._get_all_config.invalidate(userid)
-        updates.append('- Birthday: %s' % (birthday,))
+            if d.get_rating(userid) > max_rating:
+                d.engine.execute(
+                    """
+                    UPDATE profile
+                    SET config = REGEXP_REPLACE(config, '[ap]', '', 'g') || %(rating_flag)s
+                    WHERE userid = %(user)s
+                    """,
+                    rating_flag=rating_flag,
+                    user=userid,
+                )
+                d._get_all_config.invalidate(userid)
+            updates.append('- Birthday: %s' % (birthday,))
 
     # Gender
     if gender is not None:

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -828,7 +828,7 @@ def do_manage(my_userid, userid, username=None, full_name=None, catchphrase=None
     if birthday is not None:
         # HTML5 date format is yyyy-mm-dd
         split = birthday.split("-")
-        if len(split) != 3 and d.convert_unixdate(day=split[2], month=split[1], year=split[0]) is None:
+        if len(split) != 3 or d.convert_unixdate(day=split[2], month=split[1], year=split[0]) is None:
             raise WeasylError("birthdayInvalid")
         unixtime = d.convert_unixdate(day=split[2], month=split[1], year=split[0])
         age = d.convert_age(unixtime)

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -828,7 +828,9 @@ def do_manage(my_userid, userid, username=None, full_name=None, catchphrase=None
     if birthday is not None:
         # HTML5 date format is yyyy-mm-dd
         split = birthday.split("-")
-        if len(split) == 3 and d.convert_unixdate(day=split[2], month=split[1], year=split[0]):
+        if len(split) != 3 and d.convert_unixdate(day=split[2], month=split[1], year=split[0]) is None:
+            raise WeasylError("birthdayInvalid")
+        else:
             unixtime = d.convert_unixdate(day=split[2], month=split[1], year=split[0])
             age = d.convert_age(unixtime)
 

--- a/weasyl/templates/admincontrol/manageuser.html
+++ b/weasyl/templates/admincontrol/manageuser.html
@@ -71,7 +71,7 @@ $:{TITLE("User Management", "Administrator Control Panel", "/admincontrol")}
 
     <span class="label">Date of Birth</span>
     <p><input type="checkbox" name="ch_birthday" />Update value</p>
-    <input type="text" class="input" name="birthday" value="${DATE(profile['birthday'])}" />
+    <input type="date" class="input" name="birthday" value="${ISO_DATE(profile['birthday'])}" />
 
     <span class="label">Gender</span>
     <p><input type="checkbox" name="ch_gender" />Update value</p>

--- a/weasyl/templates/admincontrol/manageuser.html
+++ b/weasyl/templates/admincontrol/manageuser.html
@@ -71,7 +71,7 @@ $:{TITLE("User Management", "Administrator Control Panel", "/admincontrol")}
 
     <span class="label">Date of Birth</span>
     <p><input type="checkbox" name="ch_birthday" />Update value</p>
-    <input type="date" class="input" name="birthday" value="${ISO_DATE(profile['birthday'])}" />
+    <input type="date" class="input" name="birthday" value="${ISO8601_DATE(profile['birthday'])}" />
 
     <span class="label">Gender</span>
     <p><input type="checkbox" name="ch_gender" />Update value</p>


### PR DESCRIPTION
…date directly

The function itself used convert_unixdate, so cut out the middleman. Closes #740. Also adds define.convert_iso_date and ISO_DATE (into the template renderer) to translate timestamps to YYYY-MM-DD (ISO 8601) format, which can be loaded into date input fields.

Intentionally ignores the force reset birthday paths, since that will be removed as part of MR #739.