### PR TITLE
Make profile folder previews show most recent, obey blacklists

### DIFF
--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -107,7 +107,7 @@ def profile_(request):
         favorites,
         featured,
         # Folders preview
-        folder.select_preview(request.userid, otherid, rating, 3),
+        folder.select_preview(request.userid, otherid, rating),
         # Latest journal
         journal.select_latest(request.userid, rating, otherid=otherid),
         # Recent shouts


### PR DESCRIPTION
Instead of showing a random submission from a random selection of three non-empty folders, show the most recently updated folders with the corresponding most recent updates.

Fixes #725, and behaviour when all submissions in a folder are friends-only.

The query is slower, but hopefully not slow enough to cause problems in practice.