### PR TITLE
Correct non-sanitized input leading to raised errors

### DIFF
--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -27,11 +27,11 @@ def search_(request):
 
     page = define.common_page_start(request.userid, title="Browse and search")
 
+    if form.find and form.find not in ("submit", "char", "journal", "user"):
+        form.find = "submit"
+
     if form.q:
         find = form.find
-
-        if find not in ("submit", "char", "journal", "user"):
-            find = "submit"
 
         q = form.q.strip()
         search_query = search.Query.parse(q, find)
@@ -41,10 +41,10 @@ def search_(request):
             "find": search_query.find,
             "within": form.within,
             "rated": set('gap') & set(form.rated),
-            "cat": int(form.cat) if form.cat else None,
-            "subcat": int(form.subcat) if form.subcat else None,
-            "backid": int(form.backid) if form.backid else None,
-            "nextid": int(form.nextid) if form.nextid else None,
+            "cat": define.get_int(form.cat) if form.cat else None,
+            "subcat": define.get_int(form.subcat) if form.subcat else None,
+            "backid": define.get_int(form.backid) if form.backid else None,
+            "nextid": define.get_int(form.nextid) if form.nextid else None,
         }
 
         if search_query.find == "user":
@@ -82,7 +82,7 @@ def search_(request):
 
         meta = {
             "find": form.find,
-            "cat": int(form.cat) if form.cat else None,
+            "cat": define.get_int(form.cat) if form.cat else None,
         }
 
         page.append(define.render("etc/search.html", [


### PR DESCRIPTION
The errors (e.g., ``KeyError``/``ValueError``) seem to be caused by what appears like either manual or automated SQL-injection checks. Resolves the following Sentry IDs (I think this is all of them for the changed lines!): WEASYL-110, WEASYL-11C, WEASYL-114, WEASYL-10Z, WEASYL-15S, WEASYL-134, WEASYL-136, WEASYL-133, WEASYL-173, WEASYL-135, WEASYL-18Z, WEASYL-190, WEASYL-191, and WEASYL-193.

Not quite [Little Bobby Tables](https://xkcd.com/327/) territory, but this level of noise is avoided easily enough (force ``find`` to a known good value if it is set as a query parameter, and ``d.get_int()`` on incoming numeric values).