### PR TITLE
Fill in submission.favorites for submissions that haven’t been favorited since its introduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ENV WEASYL_STORAGE_ROOT=testing/storage
 ENV PATH="/weasyl/.venv/bin:${PATH}"
 COPY pytest.ini ./
 COPY assets assets
-CMD pytest -x libweasyl.test && pytest -x weasyl.test
+CMD pytest -x libweasyl.test libweasyl.models.test && pytest -x weasyl.test
 
 FROM package
 ENV WEASYL_APP_ROOT=/weasyl

--- a/libweasyl/libweasyl/alembic/versions/5a6d74c75fa6_fill_in_favorite_count_for_submissions.py
+++ b/libweasyl/libweasyl/alembic/versions/5a6d74c75fa6_fill_in_favorite_count_for_submissions.py
@@ -1,0 +1,40 @@
+"""Fill in favorite count for submissions
+
+Revision ID: 5a6d74c75fa6
+Revises: 4b6fd0d48a2b
+Create Date: 2020-02-25 09:11:34.348670
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5a6d74c75fa6'
+down_revision = '4b6fd0d48a2b'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute(
+        "UPDATE submission"
+        " SET favorites = f.count"
+        " FROM (SELECT targetid, count(*) FROM favorite WHERE type = 's' GROUP BY targetid) f"
+        " WHERE f.targetid = submission.submitid"
+        " AND submission.favorites IS NULL"
+    )
+
+    op.execute(
+        "UPDATE submission"
+        " SET favorites = 0"
+        " WHERE favorites IS NULL"
+    )
+
+    op.alter_column('submission', 'favorites',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('submission', 'favorites',
+               existing_type=sa.INTEGER(),
+               nullable=True)

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -764,7 +764,7 @@ submission = Table(
         },
     }), nullable=False, server_default=''),
     Column('page_views', Integer(), nullable=False, server_default='0'),
-    Column('favorites', Integer()),
+    Column('favorites', Integer(), nullable=False),
     Column('sorttime', WeasylTimestampColumn(), nullable=False),
     Column('submitter_ip_address', String(length=45), nullable=True),
     Column('submitter_user_agent_id', Integer(), nullable=True),

--- a/libweasyl/libweasyl/test/common.py
+++ b/libweasyl/libweasyl/test/common.py
@@ -87,7 +87,7 @@ def make_submission(db):
     owner = make_user(db)
     sub = content.Submission(
         owner=owner, title='', content='', subtype=1, rating=ratings.GENERAL,
-        unixtime=arrow.get(0), sorttime=arrow.get(0), settings=None)
+        unixtime=arrow.get(0), sorttime=arrow.get(0), settings=None, favorites=0)
     db.add(sub)
     db.flush()
     return sub

--- a/libweasyl/libweasyl/test/common.py
+++ b/libweasyl/libweasyl/test/common.py
@@ -74,28 +74,7 @@ def make_user(db):
     return user
 
 
-def make_friendship(db, user1, user2):
-    """
-    Create a friendship between two users.
-
-    The Friendship object created is added to the session.
-    """
-    db.add(users.Friendship(userid=user1.userid, otherid=user2.userid))
-    db.flush()
-
-
-def make_password(db, user, hashsum='$2a$13$pr8cpRxMMbiYfyuEnJ9Cl./QiO9yK7A/H/f9.CQ2DTGyIFgwDHCIa'):
-    """
-    Add a password to a user.
-
-    The default password is 'password'. The AuthBCrypt object created is added
-    to the session.
-    """
-    db.add(users.AuthBCrypt(user=user, hashsum=hashsum))
-    db.flush()
-
-
-def make_submission(db, settings=()):
+def make_submission(db):
     """
     Create a new submission.
 
@@ -109,8 +88,6 @@ def make_submission(db, settings=()):
     sub = content.Submission(
         owner=owner, title='', content='', subtype=1, rating=ratings.GENERAL,
         unixtime=arrow.get(0), sorttime=arrow.get(0), settings=None)
-    if settings:
-        sub.settings.mutable_settings.update(settings)
     db.add(sub)
     db.flush()
     return sub

--- a/weasyl/favorite.py
+++ b/weasyl/favorite.py
@@ -210,18 +210,8 @@ def insert(userid, submitid=None, charid=None, journalid=None):
 
         if submitid:
             db.execute(
-                """
-                UPDATE submission SET
-                    favorites = (
-                        CASE
-                            WHEN favorites IS NULL THEN
-                                (SELECT count(*) FROM favorite WHERE type = 's' AND targetid = %(target)s)
-                            ELSE
-                                favorites + 1
-                        END
-                    )
-                    WHERE submitid = %(target)s
-                """,
+                "UPDATE submission SET favorites = favorites + 1"
+                " WHERE submitid = %(target)s",
                 target=submitid,
             )
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -312,9 +312,8 @@ def _select_statistics(userid):
         SELECT
             (SELECT page_views FROM profile WHERE userid = %(user)s),
             (SELECT COUNT(*) FROM favorite WHERE userid = %(user)s),
-            (SELECT
-                (SELECT COUNT(*) FROM favorite fa JOIN submission su ON fa.targetid = su.submitid
-                    WHERE su.userid = %(user)s AND fa.type = 's') +
+            (
+                (SELECT sum(favorites) FROM submission WHERE userid = %(user)s) +
                 (SELECT COUNT(*) FROM favorite fa JOIN character ch ON fa.targetid = ch.charid
                     WHERE ch.userid = %(user)s AND fa.type = 'f') +
                 (SELECT COUNT(*) FROM favorite fa JOIN journal jo ON fa.targetid = jo.journalid

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -596,13 +596,6 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
     tags, artist_tags = searchtag.select_with_artist_tags(submitid)
     settings = d.get_profile_settings(query[0])
 
-    fave_count = query[11]
-
-    if fave_count is None:
-        fave_count = d.engine.scalar(
-            "SELECT COUNT(*) FROM favorite WHERE (targetid, type) = (%(target)s, 's')",
-            target=submitid)
-
     if query[12] is None:
         sub_media = media.get_submission_media(submitid)
     else:
@@ -621,7 +614,7 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
         "settings": query[8],
         "page_views": (
             query[9] + 1 if d.common_view_content(userid, 0 if anyway == "true" else submitid, "submit") else query[9]),
-        "fave_count": fave_count,
+        "fave_count": query[11],
 
 
         "mine": userid == query[0],


### PR DESCRIPTION
and apply code simplifications accordingly.

You know, I’m still not sure whether this is guaranteed to produce consistent results with concurrent queries, but it’s easy to detect and correct after the migration has run if not.