### PR TITLE
Remove thumbnail-legacy links

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/652d9ba475f0_remove_thumbnail_legacy_links.py
+++ b/libweasyl/libweasyl/alembic/versions/652d9ba475f0_remove_thumbnail_legacy_links.py
@@ -1,0 +1,21 @@
+"""Remove thumbnail-legacy links
+
+Revision ID: 652d9ba475f0
+Revises: cc2f96b0ba35
+Create Date: 2020-03-01 23:17:41.685935
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '652d9ba475f0'
+down_revision = 'cc2f96b0ba35'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("DELETE FROM submission_media_links WHERE link_type = 'thumbnail-legacy'")
+
+
+def downgrade():
+    pass

--- a/weasyl/api.py
+++ b/weasyl/api.py
@@ -41,9 +41,7 @@ def tidy_media(item):
 
 
 def tidy_all_media(d):
-    # We suppress thumbnail-legacy currently.
-    hidden_keys = ['thumbnail-legacy']
-    ret = {k: map(tidy_media, v) for k, v in d.iteritems() if k not in hidden_keys}
+    ret = {k: map(tidy_media, v) for k, v in d.iteritems()}
     thumbnail_value = ret.get('thumbnail-custom') or ret.get('thumbnail-generated')
     if thumbnail_value:
         ret['thumbnail'] = thumbnail_value

--- a/weasyl/media.py
+++ b/weasyl/media.py
@@ -71,7 +71,7 @@ def format_media_link(media, link):
             login_name, link.submitid, media.sha256, login_name,
             slug_for(link.submission.title), media.file_type)
         return define.cdnify_url(formatted_url)
-    elif link.link_type in ['cover', 'thumbnail-custom', 'thumbnail-legacy',
+    elif link.link_type in ['cover', 'thumbnail-custom',
                             'thumbnail-generated', 'thumbnail-generated-webp',
                             'avatar', 'banner']:
         return define.cdnify_url(media.display_url)


### PR DESCRIPTION
They existed for the temporary thumbnail migration tool, which has been removed.