### PR TITLE
Convert frienduser and watchuser table timestamps

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
+++ b/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
@@ -8,7 +8,7 @@ Create Date: 2020-02-26 18:18:58.505000
 
 # revision identifiers, used by Alembic.
 revision = 'e0320dc462db'
-down_revision = 'cc2f96b0ba35'
+down_revision = '652d9ba475f0'
 
 from alembic import op   # lgtm[py/unused-import]
 import sqlalchemy as sa  # lgtm[py/unused-import]

--- a/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
+++ b/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
@@ -1,0 +1,52 @@
+"""convert frienduser timestamps to DateTime
+
+Revision ID: e0320dc462db
+Revises: 1d8412df7346
+Create Date: 2020-02-26 18:18:58.505000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e0320dc462db'
+down_revision = 'cc2f96b0ba35'
+
+from alembic import op   # lgtm[py/unused-import]
+import sqlalchemy as sa  # lgtm[py/unused-import]
+
+
+def upgrade():
+    op.alter_column('watchuser', 'unixtime', server_default=None)
+    op.alter_column('watchuser', 'unixtime',
+               existing_type=sa.INTEGER(),
+               server_default=sa.func.now(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False,
+               postgresql_using="timestamp with time zone 'epoch' + (unixtime-18000) * interval '1 second';",
+               new_column_name='created_at')
+    op.alter_column('frienduser', 'unixtime', server_default=None)
+    op.alter_column('frienduser', 'unixtime',
+               existing_type=sa.INTEGER(),
+               server_default=sa.func.now(),
+               type_=sa.DateTime(timezone=True),
+               existing_nullable=False,
+               postgresql_using="timestamp with time zone 'epoch' + (unixtime-18000) * interval '1 second';",
+               new_column_name='created_at')
+
+
+def downgrade():
+    op.alter_column('watchuser', 'created_at', server_default=None)
+    op.alter_column('watchuser', 'created_at',
+                    existing_type=sa.DateTime(timezone=True),
+                    type_=sa.INTEGER(),
+                    existing_nullable=False,
+                    server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),
+                    postgresql_using="extract(epoch from created_at)+18000;",
+                    new_column_name='unixtime')
+    op.alter_column('frienduser', 'created_at', server_default=None)
+    op.alter_column('frienduser', 'created_at',
+                    existing_type=sa.DateTime(timezone=True),
+                    type_=sa.INTEGER(),
+                    existing_nullable=False,
+                    server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),
+                    postgresql_using="extract(epoch from created_at)+18000;",
+                    new_column_name='unixtime')

--- a/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
+++ b/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
@@ -12,6 +12,7 @@ down_revision = 'cc2f96b0ba35'
 
 from alembic import op   # lgtm[py/unused-import]
 import sqlalchemy as sa  # lgtm[py/unused-import]
+from sqlalchemy.dialects.postgresql import TIMESTAMP
 
 
 def upgrade():
@@ -19,7 +20,7 @@ def upgrade():
     op.alter_column('watchuser', 'unixtime',
                existing_type=sa.INTEGER(),
                server_default=sa.func.now(),
-               type_=sa.DateTime(timezone=True),
+               type_=TIMESTAMP(timezone=True),
                existing_nullable=False,
                postgresql_using="to_timestamp(unixtime + 18000)",
                new_column_name='created_at')
@@ -27,7 +28,7 @@ def upgrade():
     op.alter_column('frienduser', 'unixtime',
                existing_type=sa.INTEGER(),
                server_default=sa.func.now(),
-               type_=sa.DateTime(timezone=True),
+               type_=TIMESTAMP(timezone=True),
                existing_nullable=False,
                postgresql_using="to_timestamp(unixtime + 18000)",
                new_column_name='created_at')
@@ -36,7 +37,7 @@ def upgrade():
 def downgrade():
     op.alter_column('watchuser', 'created_at', server_default=None)
     op.alter_column('watchuser', 'created_at',
-                    existing_type=sa.DateTime(timezone=True),
+                    existing_type=TIMESTAMP(timezone=True),
                     type_=sa.INTEGER(),
                     existing_nullable=False,
                     server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),
@@ -44,7 +45,7 @@ def downgrade():
                     new_column_name='unixtime')
     op.alter_column('frienduser', 'created_at', server_default=None)
     op.alter_column('frienduser', 'created_at',
-                    existing_type=sa.DateTime(timezone=True),
+                    existing_type=TIMESTAMP(timezone=True),
                     type_=sa.INTEGER(),
                     existing_nullable=False,
                     server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),

--- a/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
+++ b/libweasyl/libweasyl/alembic/versions/e0320dc462db_convert_frienduser_timestamps_to_.py
@@ -21,7 +21,7 @@ def upgrade():
                server_default=sa.func.now(),
                type_=sa.DateTime(timezone=True),
                existing_nullable=False,
-               postgresql_using="timestamp with time zone 'epoch' + (unixtime-18000) * interval '1 second';",
+               postgresql_using="to_timestamp(unixtime + 18000)",
                new_column_name='created_at')
     op.alter_column('frienduser', 'unixtime', server_default=None)
     op.alter_column('frienduser', 'unixtime',
@@ -29,7 +29,7 @@ def upgrade():
                server_default=sa.func.now(),
                type_=sa.DateTime(timezone=True),
                existing_nullable=False,
-               postgresql_using="timestamp with time zone 'epoch' + (unixtime-18000) * interval '1 second';",
+               postgresql_using="to_timestamp(unixtime + 18000)",
                new_column_name='created_at')
 
 
@@ -40,7 +40,7 @@ def downgrade():
                     type_=sa.INTEGER(),
                     existing_nullable=False,
                     server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),
-                    postgresql_using="extract(epoch from created_at)+18000;",
+                    postgresql_using="extract(epoch from created_at) - 18000",
                     new_column_name='unixtime')
     op.alter_column('frienduser', 'created_at', server_default=None)
     op.alter_column('frienduser', 'created_at',
@@ -48,5 +48,5 @@ def downgrade():
                     type_=sa.INTEGER(),
                     existing_nullable=False,
                     server_default=sa.text(u"(date_part('epoch'::text, now()) - (18000)::double precision)"),
-                    postgresql_using="extract(epoch from created_at)+18000;",
+                    postgresql_using="extract(epoch from created_at) - 18000",
                     new_column_name='unixtime')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -219,7 +219,7 @@ frienduser = Table(
     Column('settings', CharSettingsColumn({
         'p': 'pending',
     }, length=20), nullable=False, server_default='p'),
-    Column('created_at', DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column('created_at', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
     default_fkey(['otherid'], ['login.userid'], name='frienduser_otherid_fkey'),
     default_fkey(['userid'], ['login.userid'], name='frienduser_userid_fkey'),
 )
@@ -934,7 +934,7 @@ watchuser = Table(
     Column('userid', Integer(), primary_key=True, nullable=False),
     Column('otherid', Integer(), primary_key=True, nullable=False),
     Column('settings', String(length=20), nullable=False),
-    Column('created_at', DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column('created_at', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
     default_fkey(['otherid'], ['login.userid'], name='watchuser_otherid_fkey'),
     default_fkey(['userid'], ['login.userid'], name='watchuser_userid_fkey'),
 )

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -219,8 +219,7 @@ frienduser = Table(
     Column('settings', CharSettingsColumn({
         'p': 'pending',
     }, length=20), nullable=False, server_default='p'),
-    Column('unixtime', WeasylTimestampColumn(), nullable=False,
-           server_default=text(u"(date_part('epoch'::text, now()) - (18000)::double precision)")),
+    Column('created_at', DateTime(timezone=True), nullable=False, server_default=func.now()),
     default_fkey(['otherid'], ['login.userid'], name='frienduser_otherid_fkey'),
     default_fkey(['userid'], ['login.userid'], name='frienduser_userid_fkey'),
 )
@@ -935,8 +934,7 @@ watchuser = Table(
     Column('userid', Integer(), primary_key=True, nullable=False),
     Column('otherid', Integer(), primary_key=True, nullable=False),
     Column('settings', String(length=20), nullable=False),
-    Column('unixtime', Integer(), nullable=False,
-           server_default=text(u"(date_part('epoch'::text, now()) - (18000)::double precision)")),
+    Column('created_at', DateTime(timezone=True), nullable=False, server_default=func.now()),
     default_fkey(['otherid'], ['login.userid'], name='watchuser_otherid_fkey'),
     default_fkey(['userid'], ['login.userid'], name='watchuser_userid_fkey'),
 )


### PR DESCRIPTION
Converts frienduser and watchuser tables to use DateTime(timezone=True) instead of WeasylTimeColumn. 

Helps out with #68 