### PR TITLE
Load marked.js lazily

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -963,6 +963,28 @@
 
     var ATTEMPTED_BBCODE = /\[(\w+)\][\s\S]+\[\/\1\]/i;
 
+    var markedLoadState = 0;
+
+    function loadMarked() {
+        if (markedLoadState !== 0) {
+            return;
+        }
+
+        markedLoadState = 1;
+
+        var markedScript = document.createElement('script');
+
+        markedScript.onload = function () {
+            markedLoadState = 2;
+
+            forEach(document.getElementsByClassName('markdown'), updateMarkdownPreview);
+        };
+
+        markedScript.src = document.getElementById('scripts').getAttribute('data-marked-src');
+
+        document.body.appendChild(markedScript);
+    }
+
     function renderMarkdown(content, container) {
         var markdown = marked(content, markdownOptions);
         var fragment = document.createElement('div');
@@ -976,22 +998,37 @@
         }
     }
 
-    function addMarkdownPreview(input) {
-        var preview = document.createElement('div');
-        preview.className = 'markdown-preview formatted-content';
+    function updateMarkdownPreview(input) {
+        if (markedLoadState === 2) {
+            var preview = input.nextSibling.nextSibling;
 
-        function showPreview() {
             while (preview.childNodes.length) {
                 preview.removeChild(preview.firstChild);
             }
 
             renderMarkdown(input.value, preview);
+        } else {
+            loadMarked();
         }
+    }
 
-        input.addEventListener('input', showPreview, false);
+    function updateMarkdownPreviewListener() {
+        updateMarkdownPreview(this);
+    }
 
-        showPreview();
+    function addMarkdownPreview(input) {
+        var preview = document.createElement('div');
+        preview.className = 'markdown-preview formatted-content';
+
         input.parentNode.insertBefore(preview, input.nextSibling);
+
+        input.addEventListener('input', updateMarkdownPreviewListener, false);
+
+        if (input.value === '') {
+            input.addEventListener('focus', loadMarked, false);
+        } else {
+            updateMarkdownPreview(input);
+        }
     }
 
     function addMarkdownWarning(input) {
@@ -1161,8 +1198,8 @@
             var contentField = newFormContent.getElementsByClassName('form-content')[0];
 
             // Remove the original form’s non-functional Markdown preview and warning elements
-            contentField.parentNode.removeChild(contentField.nextElementSibling);
-            contentField.parentNode.removeChild(contentField.nextElementSibling);
+            contentField.parentNode.removeChild(contentField.nextSibling);
+            contentField.parentNode.removeChild(contentField.nextSibling);
 
             if (!children || children.nodeName !== 'UL') {
                 children = document.createElement('ul');
@@ -1271,7 +1308,15 @@
 
                     var commentBody = document.createElement('div');
                     commentBody.className = 'formatted-content';
-                    renderMarkdown(contentField.value, commentBody);
+
+                    if (markedLoadState === 2) {
+                        renderMarkdown(contentField.value, commentBody);
+                    } else {
+                        var pre = document.createElement('span');
+                        pre.style.whiteSpace = 'pre-wrap';
+                        pre.textContent = contentField.value;
+                        commentBody.appendChild(pre);
+                    }
 
                     commentContent.appendChild(commentActions);
                     commentContent.appendChild(commentByline);
@@ -1315,6 +1360,8 @@
                                     linkLink.textContent = 'Link';
                                     commentActions.appendChild(document.createTextNode(' '));
                                     commentActions.appendChild(linkLink);
+
+                                    commentBody.innerHTML = result.html;
 
                                     return;
                                 }

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -7,7 +7,7 @@ from pyramid.response import Response
 
 from libweasyl import ratings
 from libweasyl import staff
-from libweasyl.text import slug_for
+from libweasyl.text import markdown, slug_for
 
 from weasyl import (
     character, comment, define, folder, journal, macro, profile,
@@ -318,7 +318,10 @@ def submit_comment_(request):
                                content=form.content)
 
     if form.format == "json":
-        return {"id": commentid}
+        return {
+            "id": commentid,
+            "html": markdown(form.content),
+        }
 
     if define.get_int(form.submitid):
         raise HTTPSeeOther(location="/submission/%i#cid%i" % (define.get_int(form.submitid), commentid))

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -214,7 +214,6 @@ def _generate_http2_server_push_headers():
     js_preload = [
         '<' + item + '>; rel=preload; as=script' for item in [
             d.get_resource_path('js/jquery-2.2.4.min.js'),
-            d.get_resource_path('js/marked.js'),
             d.get_resource_path('js/scripts.js'),
         ]
     ]

--- a/weasyl/templates/common/page_end.html
+++ b/weasyl/templates/common/page_end.html
@@ -70,8 +70,7 @@ $def with (options=None)
 $if options and "typeahead" in options:
   <script src="${resource_path('js/typeahead.bundle.min.js')}"></script>
 
-<script src="${resource_path('js/marked.js')}"></script>
-<script src="${resource_path('js/scripts.js')}"></script>
+<script id="scripts" src="${resource_path('js/scripts.js')}" data-marked-src="${resource_path('js/marked.js')}"></script>
 
 <script src="${resource_path('js/yall.min.js')}"></script>
 <script>


### PR DESCRIPTION
so it doesn’t block scripts.js despite being unusable on most pages and unused on the rest when the user doesn’t type anything.

This can be further improved by splitting out defang (and splitting up scripts.js in general).