### PR TITLE
Don’t fail Pillow thumbnailing for MPOs

### DIFF
--- a/libweasyl/libweasyl/images_new.py
+++ b/libweasyl/libweasyl/images_new.py
@@ -94,7 +94,7 @@ def get_thumbnail(image_file, bounds=None):
 
     thumbnail_attributes = {'width': image.width, 'height': image.height}
 
-    if image_format == 'JPEG':
+    if image_format in ('JPEG', 'MPO'):
         with BytesIO() as f:
             image.save(f, format='JPEG', quality=95, optimize=True, progressive=True, subsampling='4:2:2')
             compatible = (f.getvalue(), 'jpg', thumbnail_attributes)


### PR DESCRIPTION
ImageMagick identifies them as JPEGs, so the error message is confusing. Just produce a thumbnail from the first image in the sequence, like the old thumbnailing would have.

Tested with real MPOs, but I can’t find any existing small or redistributable MPOs, or a convenient way to create them.

Fixes WEASYL-160.