### PR TITLE
Improve password reset

### DIFF
--- a/assets/js/zxcvbn-check.js
+++ b/assets/js/zxcvbn-check.js
@@ -1,8 +1,6 @@
 (function () {
     "use strict";
 
-    var word = /[a-zA-Z0-9]+/g;
-
     var strengthMessages = [
         "Crackable password",
         "Over easy password",
@@ -27,6 +25,9 @@
                     .split(",")
                     .filter(Boolean)
                     .map(document.getElementById, document);
+            var personalData =
+                (passwordStrength.getAttribute("data-personal-data") || "")
+                    .match(/[a-zA-Z0-9]+/g) || [];
 
             function check() {
                 if (!passwordField.value) {
@@ -35,16 +36,20 @@
                     return;
                 }
 
-                var personalStrings = personalFields.reduce(function (strings, field) {
-                    var value = field.value;
-                    var match;
+                var personalStrings =
+                    personalFields
+                        .reduce(function (strings, field) {
+                            var value = field.value;
+                            var word = /[a-zA-Z0-9]+/g;
+                            var match;
 
-                    while ((match = word.exec(value))) {
-                        strings.push(match[0]);
-                    }
+                            while ((match = word.exec(value))) {
+                                strings.push(match[0]);
+                            }
 
-                    return strings;
-                }, []);
+                            return strings;
+                        }, [])
+                        .concat(personalData);
 
                 var result = zxcvbn(passwordField.value, personalStrings);
 

--- a/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
+++ b/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
@@ -15,6 +15,14 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 def upgrade():
+    op.create_index(
+        'ind_login_lower_email',
+        'login',
+        [
+            sa.text('(lower(email COLLATE "C"))'),
+        ],
+        unique=False,
+    )
     op.drop_table('forgotpassword')
     op.create_table('forgotpassword',
     sa.Column('token_sha256', postgresql.BYTEA(), nullable=False),
@@ -36,6 +44,8 @@ def upgrade():
 
 
 def downgrade():
+    op.drop_index('ind_login_lower_email', table_name='login')
+
     op.drop_table('forgotpassword')
     op.create_table('forgotpassword',
     sa.Column('set_time', sa.INTEGER(), autoincrement=False, nullable=False),

--- a/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
+++ b/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
@@ -1,0 +1,51 @@
+"""Improve password reset
+
+Revision ID: c5074772185a
+Revises: 3accc3d526ba
+Create Date: 2020-03-28 03:11:19.300735
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c5074772185a'
+down_revision = '3accc3d526ba'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.drop_table('forgotpassword')
+    op.create_table('forgotpassword',
+    sa.Column('token_sha256', postgresql.BYTEA(), nullable=False),
+    sa.Column('email', sa.String(length=254), nullable=False),
+    sa.Column('created_at', postgresql.TIMESTAMP(timezone=True), server_default=sa.text(u'now()'), nullable=False),
+    sa.PrimaryKeyConstraint('token_sha256')
+    )
+    op.create_index('ind_forgotpassword_created_at', 'forgotpassword', ['created_at'], unique=False)
+    op.create_table('user_events',
+    sa.Column('eventid', sa.Integer(), nullable=False),
+    sa.Column('userid', sa.Integer(), nullable=False),
+    sa.Column('event', sa.String(length=100), nullable=False),
+    sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.Column('occurred', postgresql.TIMESTAMP(timezone=True), server_default=sa.text(u'now()'), nullable=False),
+    sa.ForeignKeyConstraint(['userid'], ['login.userid'], ),
+    sa.PrimaryKeyConstraint('eventid')
+    )
+    op.create_index('ind_user_events_userid_eventid', 'user_events', ['userid', 'eventid'], unique=False)
+
+
+def downgrade():
+    op.drop_table('forgotpassword')
+    op.create_table('forgotpassword',
+    sa.Column('set_time', sa.INTEGER(), autoincrement=False, nullable=False),
+    sa.Column('address', sa.TEXT(), autoincrement=False, nullable=False),
+    sa.Column('link_time', sa.INTEGER(), server_default=sa.text(u'0'), autoincrement=False, nullable=False),
+    sa.Column('userid', sa.INTEGER(), autoincrement=False, nullable=False),
+    sa.Column('token', sa.VARCHAR(length=100), autoincrement=False, nullable=False),
+    sa.ForeignKeyConstraint(['userid'], [u'login.userid'], name=u'forgotpassword_userid_fkey', onupdate=u'CASCADE', ondelete=u'CASCADE'),
+    sa.UniqueConstraint('userid', name=u'forgotpassword_userid_key')
+    )
+    op.drop_index('ind_user_events_userid_eventid', table_name='user_events')
+    op.drop_table('user_events')
+    op.drop_index('ind_forgotpassword_created_at', table_name='forgotpassword')

--- a/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
+++ b/libweasyl/libweasyl/alembic/versions/c5074772185a_improve_password_reset.py
@@ -46,6 +46,7 @@ def upgrade():
 def downgrade():
     op.drop_index('ind_login_lower_email', table_name='login')
 
+    op.drop_index('ind_forgotpassword_created_at', table_name='forgotpassword')
     op.drop_table('forgotpassword')
     op.create_table('forgotpassword',
     sa.Column('set_time', sa.INTEGER(), autoincrement=False, nullable=False),
@@ -58,4 +59,3 @@ def downgrade():
     )
     op.drop_index('ind_user_events_userid_eventid', table_name='user_events')
     op.drop_table('user_events')
-    op.drop_index('ind_forgotpassword_created_at', table_name='forgotpassword')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -203,13 +203,12 @@ Index('ind_folder_userid', folder.c.userid)
 
 forgotpassword = Table(
     'forgotpassword', metadata,
-    Column('userid', Integer(), unique=True, nullable=False),
-    Column('token', String(length=100), primary_key=True, nullable=False),
-    Column('set_time', Integer(), nullable=False),
-    Column('link_time', Integer(), nullable=False, server_default='0'),
-    Column('address', Text(), nullable=False),
-    default_fkey(['userid'], ['login.userid'], name='forgotpassword_userid_fkey'),
+    Column('token_sha256', BYTEA(), primary_key=True, nullable=False),
+    Column('email', String(length=254), nullable=False),
+    Column('created_at', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
 )
+
+Index('ind_forgotpassword_created_at', forgotpassword.c.created_at)
 
 
 frienduser = Table(
@@ -336,6 +335,7 @@ login = Table(
 )
 
 Index('ind_login_login_name', login.c.login_name)
+Index('ind_login_lower_email', func.lower(login.c.login_name.collate('C')))
 
 
 twofa_recovery_codes = Table(
@@ -684,6 +684,17 @@ user_agents = Table(
     Column('user_agent_id', Integer(), primary_key=True, nullable=False),
     Column('user_agent', String(length=1024), nullable=False, unique=True),
 )
+
+user_events = Table(
+    'user_events', metadata,
+    Column('eventid', Integer(), primary_key=True, nullable=False),
+    Column('userid', Integer(), ForeignKey('login.userid'), nullable=False),
+    Column('event', String(length=100), nullable=False),
+    Column('data', JSONB(), nullable=False),
+    Column('occurred', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+)
+
+Index('ind_user_events_userid_eventid', user_events.c.userid, user_events.c.eventid)
 
 
 siteupdate = Table(

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -279,7 +279,7 @@ def forgetpassword_post_(request):
 
 @guest_required
 def resetpassword_get_(request):
-    token = request.GET['token']
+    token = request.GET.get('token', "")
     reset_target = resetpassword.prepare(token=token)
 
     if reset_target is None:

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -270,37 +270,46 @@ def forgotpassword_get_(request):
 @guest_required
 @token_checked
 def forgetpassword_post_(request):
-    form = request.web_input(email="")
-
-    resetpassword.request(form)
+    resetpassword.request(email=request.POST['email'])
     return Response(define.errorpage(
         request.userid,
-        "**Success!** Provided the supplied email matches a user account in our  "
-        "records, information on how to reset your password has been sent to your "
-        "email address.",
+        "**Success!** Information on how to reset your password has been sent to your email address.",
         [["Return to the Home Page", "/"]]))
 
 
 @guest_required
 def resetpassword_get_(request):
-    form = request.web_input(token="")
+    token = request.GET['token']
+    reset_target = resetpassword.prepare(token=token)
 
-    if not resetpassword.prepare(form.token):
+    if reset_target is None:
         return Response(define.errorpage(
             request.userid,
             "This link does not appear to be valid. If you followed this link from your email, it may have expired."))
 
-    return Response(define.webpage(request.userid, "etc/resetpassword.html", [form.token], title="Reset Forgotten Password"))
+    if isinstance(reset_target, resetpassword.Unregistered):
+        return Response(define.errorpage(
+            request.userid,
+            "The e-mail address **%s** is not associated with a Weasyl account." % (reset_target.email,),
+            [["Sign Up", "/signup"], ["Return to the Home Page", "/"]]))
+
+    return Response(define.webpage(request.userid, "etc/resetpassword.html", [token, reset_target], title="Reset Forgotten Password"))
 
 
 @guest_required
 def resetpassword_post_(request):
-    form = request.web_input(token="", username="", email="", day="", month="", year="", password="", passcheck="")
+    expect_userid = int(request.POST['userid'])
 
-    resetpassword.reset(form)
+    resetpassword.reset(
+        token=request.POST['token'],
+        password=request.POST['password'],
+        passcheck=request.POST['passcheck'],
+        expect_userid=expect_userid,
+        address=request.client_addr,
+    )
 
-    # Invalidate all other user sessions for this user.
-    profile.invalidate_other_sessions(request.userid)
+    # Invalidate user sessions for this user.
+    profile.invalidate_other_sessions(expect_userid)
 
     return Response(define.errorpage(
         request.userid,

--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -3,16 +3,13 @@ from __future__ import absolute_import
 import arrow
 from twisted.python import log
 
-from weasyl.define import engine, get_time
+from weasyl.define import engine
 from weasyl import index, submission
 
 
 def run_periodic_tasks():
     # An arrow object representing the current UTC time
     now = arrow.utcnow()
-
-    # An integer representing the current unixtime (with an offset applied sourced from libweasyl.legacy)
-    time_now = get_time()
 
     db = engine.connect()
     with db.begin():
@@ -43,10 +40,6 @@ def run_periodic_tasks():
 
         # Daily at 0:00
         if now.hour == 0 and now.minute == 0:
-            # Delete password resets older than one day
-            db.execute("DELETE FROM forgotpassword WHERE set_time < %(expiry)s", expiry=time_now - 86400)
-            log.msg('cleared old forgotten password requests')
-
             # Delete email reset requests older than two days
             db.execute("""
                 DELETE FROM emailverify

--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -2,120 +2,150 @@
 
 from __future__ import absolute_import
 
+import hashlib
+import string
+from collections import namedtuple
+
 from libweasyl import security
 from weasyl import define as d
 from weasyl import emailer
 from weasyl.error import WeasylError
 
 
-# form
-#   email
+Unregistered = namedtuple('Unregistered', ['email'])
 
-def request(form):
-    token = security.generate_key(100)
-    email = emailer.normalize_address(form.email)
 
-    # Determine the user associated with `username`; if the user is not found,
-    # raise an exception
-    user_id = d.engine.scalar("""
-        SELECT userid FROM login WHERE email = %(email)s
-    """, email=email)
+def _hash_token(token):
+    return hashlib.sha256(token.encode("ascii")).digest()
 
-    # If `user_id` exists, then the supplied email was valid; if not valid, do nothing, raising
-    #   no errors for plausible deniability of email existence
-    if user_id:
-        # Insert a record into the forgotpassword table for the user,
-        # or update an existing one
-        now = d.get_time()
-        address = d.get_address()
 
-        d.engine.execute("""
-            INSERT INTO forgotpassword (userid, token, set_time, address)
-            VALUES (%(id)s, %(token)s, %(time)s, %(address)s)
-            ON CONFLICT (userid) DO UPDATE SET
-                token = %(token)s,
-                set_time = %(time)s,
-                address = %(address)s
-        """, id=user_id, token=token, time=now, address=address)
+def request(email):
+    token = security.generate_key(25, key_characters=string.digits + string.ascii_lowercase)
+    token_sha256 = _hash_token(token)
+    email = emailer.normalize_address(email)
 
-        # Generate and send an email to the user containing a password reset link
-        emailer.send(email, "Weasyl Password Recovery", d.render("email/reset_password.html", [token]))
+    if email is None:
+        raise WeasylError("emailInvalid")
+
+    d.engine.execute(
+        "INSERT INTO forgotpassword (email, token_sha256)"
+        " VALUES (%(email)s, %(token_sha256)s)",
+        email=email, token_sha256=bytearray(token_sha256))
+
+    # Generate and send an email to the user containing a password reset link
+    emailer.send(email, "Weasyl Account Recovery", d.render("email/reset_password.html", [token]))
+
+
+def _find_reset_target(db, email):
+    """
+    Get information about the user whose password can be reset by access to the
+    provided normalized e-mail address, or None if there is no such user.
+
+    Matches the address case-insensitively, with priority given to a
+    case-sensitive match if there are multiple matches.
+    """
+    matches = db.execute(
+        "SELECT userid, email, username FROM login"
+        " INNER JOIN profile USING (userid)"
+        ' WHERE lower(email COLLATE "C") = %(email)s',
+        email=email,
+    ).fetchall()
+
+    for match in matches:
+        if match.email == email:
+            return match
+
+    # XXX: we sent an e-mail to the address in its entered form, but are
+    # resetting the password of an account with a different case.
+    #
+    # that’s a vulnerability for a case-sensitive mail provider, but there’s
+    # not much else we can do while remaining user-friendly, and being
+    # case-sensitive as a mail provider is already exposing users to that kind
+    # of risk all over.
+    return matches[0] if matches else None
 
 
 def prepare(token):
-    # Remove records from the forgotpassword table which have been active for
-    # more than one hour, regardless of whether or not the user has clicked the
-    # associated link provided to them in the password reset request email, or
-    # which have been visited but have not been removed by the password reset
-    # script within five minutes of being visited
+    token_sha256 = _hash_token(token)
+
     d.engine.execute(
-        "DELETE FROM forgotpassword WHERE set_time < %(set_cutoff)s OR link_time > 0 AND link_time < %(link_cutoff)s",
-        set_cutoff=d.get_time() - 3600,
-        link_cutoff=d.get_time() - 300,
+        "DELETE FROM forgotpassword"
+        " WHERE created_at < now() - INTERVAL '1 hour'"
     )
 
-    # Set the unixtime record for which the link associated with `token` was
-    # visited by the user
-    result = d.engine.execute(
-        "UPDATE forgotpassword SET link_time = %(now)s WHERE token = %(token)s",
-        now=d.get_time(),
-        token=token,
+    email = d.engine.scalar(
+        "SELECT email FROM forgotpassword WHERE token_sha256 = %(token_sha256)s",
+        token_sha256=bytearray(token_sha256),
     )
 
-    return result.rowcount == 1
+    if email is None:
+        # token expired, or never existed.
+        return None
+
+    reset_target = _find_reset_target(d.engine, email=email)
+
+    if reset_target is None:
+        # a password reset was requested for an e-mail address not belonging to an account.
+        return Unregistered(email=email)
+
+    return reset_target
 
 
-# form
-#   username    passcheck    month
-#   email       token        year
-#   password    day
-
-def reset(form):
+def reset(token, password, passcheck, expect_userid, address):
     from weasyl import login
 
-    # Raise an exception if `password` does not enter `passcheck` (indicating
-    # that the user mistyped one of the fields) or if `password` does not meet
-    # the system's password security requirements
-    if form.password != form.passcheck:
+    token_sha256 = _hash_token(token)
+
+    if password != passcheck:
         raise WeasylError("passwordMismatch")
-    elif not login.password_secure(form.password):
+    elif not login.password_secure(password):
         raise WeasylError("passwordInsecure")
 
-    # Select the user information and record data from the forgotpassword table
-    # pertaining to `token`, requiring that the link associated with the record
-    # be visited no more than five minutes prior; if the forgotpassword record is
-    # not found or does not meet this requirement, raise an exception
-    query = d.engine.execute("""
-        SELECT lo.userid, lo.login_name, lo.email, fp.link_time, fp.address
-        FROM login lo
-            INNER JOIN userinfo ui USING (userid)
-            INNER JOIN forgotpassword fp USING (userid)
-        WHERE fp.token = %(token)s AND fp.link_time > %(cutoff)s
-    """, token=form.token, cutoff=d.get_time() - 300).first()
+    with d.engine.begin() as db:
+        email = db.scalar(
+            "DELETE FROM forgotpassword"
+            " WHERE token_sha256 = %(token_sha256)s AND created_at >= now() - INTERVAL '1 hour'"
+            " RETURNING email",
+            token_sha256=bytearray(token_sha256),
+        )
 
-    if not query:
-        raise WeasylError("forgotpasswordRecordMissing")
+        if email is None:
+            # token expired, or never existed.
+            raise WeasylError("forgotpasswordRecordMissing")
 
-    USERID, USERNAME, EMAIL, LINKTIME, ADDRESS = query
+        match = _find_reset_target(db, email=email)
 
-    # Check `username` and `email` against known correct values and raise an
-    # exception if there is a mismatch
-    if emailer.normalize_address(form.email) != emailer.normalize_address(EMAIL):
-        raise WeasylError("emailIncorrect")
-    elif d.get_sysname(form.username) != USERNAME:
-        raise WeasylError("usernameIncorrect")
-    elif d.get_address() != ADDRESS:
-        raise WeasylError("addressInvalid")
+        if match is None:
+            # account changed e-mail addresses.
+            raise WeasylError("forgotpasswordRecordMissing")
 
-    # Update the authbcrypt table with a new password hash
-    d.engine.execute(
-        'INSERT INTO authbcrypt (userid, hashsum) VALUES (%(user)s, %(hash)s) '
-        'ON CONFLICT (userid) DO UPDATE SET hashsum = %(hash)s',
-        user=USERID, hash=login.passhash(form.password))
+        if match.userid != expect_userid:
+            # e-mail address changed accounts. possible, but very unusual.
+            #
+            # this is to make sure to never change the password of an account
+            # different from the one promised on the form, not a security thing
+            # – `expect_userid` is a hidden field of the form.
+            raise WeasylError("forgotpasswordRecordMissing")
 
-    d.engine.execute(
-        "DELETE FROM forgotpassword WHERE token = %(token)s",
-        token=form.token)
+        # Update the authbcrypt table with a new password hash
+        result = db.execute(
+            "UPDATE authbcrypt SET hashsum = %(hash)s WHERE userid = %(user)s",
+            user=match.userid,
+            hash=login.passhash(password),
+        )
+
+        if result.rowcount != 1:
+            raise WeasylError("Unexpected")
+
+        db.execute(
+            d.meta.tables["user_events"].insert({
+                "userid": match.userid,
+                "event": "password-reset",
+                "data": {
+                    "address": address,
+                }
+            })
+        )
 
 
 # form

--- a/weasyl/templates/email/reset_password.html
+++ b/weasyl/templates/email/reset_password.html
@@ -7,4 +7,6 @@ https://www.weasyl.com/resetpassword?token=${token}
 
 If you did not request this service, no action is required on your behalf; you may safely ignore this email and no changes will be made to your account.
 
+The link will expire after one hour.
+
 https://www.weasyl.com

--- a/weasyl/templates/etc/forgotpassword.html
+++ b/weasyl/templates/etc/forgotpassword.html
@@ -6,10 +6,10 @@ $:{RENDER("common/stage_title.html", ["Reset Forgotten Password"])}
     $:{CSRF()}
 
     <label for="fp-email">Email Address</label>
-    <input type="text" class="input" id="fp-email" name="email" required="required" style="margin-bottom: 1em" />
+    <input type="email" class="input" id="fp-email" name="email" required maxlength="254" style="margin-bottom: 1em" />
 
     <button type="submit" class="button positive" style="float: right;">Continue</button>
-    <a href="/index" class="button">Return Home</a>
+    <a href="/" class="button">Return Home</a>
   </form>
 
 </div>

--- a/weasyl/templates/etc/resetpassword.html
+++ b/weasyl/templates/etc/resetpassword.html
@@ -1,36 +1,33 @@
-$def with (token)
+$def with (token, reset_target)
 $:{RENDER("common/stage_title.html", ["Reset Forgotten Password"])}
 
 <div id="resetpassword-content" class="content">
 
     <form class="form skinny clear" name="resetpassword" action="/resetpassword" method="post">
       <input type="hidden" name="token" value="${token}" />
+      <input type="hidden" name="userid" value="${reset_target.userid}" />
 
-      <label for="reset-user">Username</label>
-      <input type="text" class="input" id="reset-user" name="username" autofocus="autofocus" required="required" />
-
-      <label for="reset-email">Email Address</label>
-      <input type="email" class="input" id="reset-email" name="email" placeholder="john@doe.com" required="required" />
+      <p>Resetting password for user <strong><a href="/~${LOGIN(reset_target.username)}">${reset_target.username}</a></strong>.</p>
 
       <div class="form-2up clear">
         <div class="form-2up-1">
           <label for="password">New Password</label>
-          <input type="password" class="input" id="password" name="password" maxlength="72" required />
+          <input type="password" class="input" id="password" name="password" minlength="10" maxlength="72" required />
           <p class="color-lighter" style="padding-top: 0.5em;"><i>Passwords must be a minimum of 10 characters.</i></p>
         </div>
         <div class="form-2up-2">
           <label for="passcheck" class="color-lighter">Confirm Password</label>
-          <input type="password" class="input last-input" id="passcheck" name="passcheck" maxlength="72" required />
+          <input type="password" class="input last-input" id="passcheck" name="passcheck" minlength="10" maxlength="72" required />
         </div>
       </div>
 
-      <div id="password-strength" class="password-strength password-strength-empty" data-password-input="password" data-personal-inputs="reset-user,reset-email"></div>
+      <div id="password-strength" class="password-strength password-strength-empty" data-password-input="password" data-personal-data="${reset_target.username};${reset_target.email}"></div>
 
       <script src="${resource_path('js/zxcvbn.js')}" async></script>
       <script src="${resource_path('js/zxcvbn-check.js')}" async></script>
 
       <button class="button positive" style="float: right;">Continue</button>
-      <a href="/index" class="button">Return Home</a>
+      <a href="/" class="button">Return Home</a>
 
     </form>
 

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -18,6 +18,8 @@ from weasyl import sessions
 _user_index = itertools.count()
 TEST_DATABASE = "weasyl_test"
 
+_DEFAULT_PASSWORD = "$2b$04$IIdgY7gIpBckJI.YZQ3nHOo.Gh5j2lLhoTEPnWJplnfdpIOSoHYcu"
+
 
 def add_entity(entity):
     db = d.connect()
@@ -63,9 +65,8 @@ def create_user(full_name="", birthday=arrow.get(586162800), config=None,
         d.engine.execute("UPDATE login SET voucher = userid WHERE userid = %(id)s",
                          id=user.userid)
     # Set a password for this user
-    if password is not None:
-        d.engine.execute("INSERT INTO authbcrypt VALUES (%(id)s, %(bcrypthash)s)",
-                         id=user.userid, bcrypthash=login.passhash(password))
+    d.engine.execute("INSERT INTO authbcrypt VALUES (%(id)s, %(bcrypthash)s)",
+                     id=user.userid, bcrypthash=_DEFAULT_PASSWORD if password is None else login.passhash(password))
     # Set an email address for this user
     if email_addr is not None:
         d.engine.execute("UPDATE login SET email = %(email)s WHERE userid = %(id)s",

--- a/weasyl/test/resetpassword/conftest.py
+++ b/weasyl/test/resetpassword/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+
+import re
+
+import pytest
+
+from weasyl import emailer
+
+
+@pytest.fixture
+def captured_tokens(monkeypatch):
+    result = {}
+
+    def capture_token(mailto, subject, content):
+        token = re.search(r"\?token=(.*)", content).group(1)
+        result[mailto] = token
+
+    monkeypatch.setattr(emailer, "send", capture_token)
+
+    return result

--- a/weasyl/test/resetpassword/test_prepare.py
+++ b/weasyl/test/resetpassword/test_prepare.py
@@ -1,87 +1,69 @@
 from __future__ import absolute_import
 
+import hashlib
+
 import pytest
-import arrow
 
 from weasyl import resetpassword
 from weasyl import define as d
 from weasyl.test import db_utils
-from weasyl.test.utils import Bag
 
 
 @pytest.mark.usefixtures('db')
-def test_false_returned_if_token_does_not_exist():
+def test_none_returned_if_token_does_not_exist():
     token = "testtokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentest000000"
-    assert not resetpassword.prepare(token)
+    assert resetpassword.prepare(token) is None
 
 
 @pytest.mark.usefixtures('db')
-def test_true_returned_if_token_exists():
-    user_id = db_utils.create_user(username='checktoken0002')
-    token = "testtokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentest000001"
+def test_user_info_returned_if_token_exists():
+    email_addr = "test@weasyl.com"
+    username = "checktoken0002"
+    user_id = db_utils.create_user(username=username, email_addr=email_addr)
+    token = "testtokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentest000008"
     d.engine.execute(d.meta.tables["forgotpassword"].insert(), {
         "userid": user_id,
-        "token": token,
-        "set_time": d.get_time(),
-        "link_time": 0,
-        "address": d.get_address(),
+        "token_sha256": hashlib.sha256(token.encode("ascii")).digest(),
+        "email": email_addr,
     })
-    assert resetpassword.prepare(token)
+    assert dict(resetpassword.prepare(token)) == {
+        "userid": user_id,
+        "email": email_addr,
+        "username": username,
+    }
 
 
 @pytest.mark.usefixtures('db')
-def test_stale_records_get_deleted_when_function_is_called():
-    token_store = []
-    for i in range(20):
-        user_name = "testPrepare%d" % (i,)
-        email_addr = "test%d@weasyl.com" % (i,)
-        user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
-        form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                               month=arrow.now().month, year=arrow.now().year)
-        resetpassword.request(form_for_request)
-        pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-        token_store.append(pw_reset_token)
-    # Set 5 tokens to be two hours old (0,5) (7200)
-    for i in range(0, 5):
-        d.engine.execute("UPDATE forgotpassword SET set_time = %(time)s WHERE token = %(token)s",
-                         time=d.get_time() - 7200, token=token_store[i])
-    # Set 5 tokens to be 30 minutes old (5,10) (1800)
-    for i in range(5, 10):
-        d.engine.execute("UPDATE forgotpassword SET set_time = %(time)s WHERE token = %(token)s",
-                         time=d.get_time() - 1800, token=token_store[i])
-    # Set 5 tokens to be 10 minutes old for the last visit time (10,15) (600)
-    for i in range(10, 15):
-        d.engine.execute("UPDATE forgotpassword SET link_time = %(time)s WHERE token = %(token)s",
-                         time=d.get_time() - 600, token=token_store[i])
-    # Set 5 tokens to be 2 minutes old for the last visit time (10,15) (120)
-    for i in range(15, 20):
-        d.engine.execute("UPDATE forgotpassword SET link_time = %(time)s WHERE token = %(token)s",
-                         time=d.get_time() - 120, token=token_store[i])
-    # This range should be invalid (set_time > 3600)
-    for i in range(0, 5):
-        assert not resetpassword.prepare(token_store[i])
-    # This range should still be valid (set_time < 3600)
-    for i in range(5, 10):
-        assert resetpassword.prepare(token_store[i])
-    # This range should be invalid (link_time > 300)
-    for i in range(10, 15):
-        assert not resetpassword.prepare(token_store[i])
-    # This range should still be valid (link_time < 300)
-    for i in range(15, 20):
-        assert resetpassword.prepare(token_store[i])
-
-
-@pytest.mark.usefixtures('db')
-def test_link_time_field_is_updated_when_valid_token_supplied_to_function():
-    user_name = "test"
+def test_unregistered():
     email_addr = "test@weasyl.com"
-    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
-    form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                           month=arrow.now().month, year=arrow.now().year)
-    resetpassword.request(form_for_request)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    link_time = d.engine.scalar("SELECT link_time FROM forgotpassword WHERE token = %(token)s", token=pw_reset_token)
-    assert link_time == 0
-    resetpassword.prepare(pw_reset_token)
-    link_time = d.engine.scalar("SELECT link_time FROM forgotpassword WHERE token = %(token)s", token=pw_reset_token)
-    assert link_time >= d.get_time() - 10
+    user_id = db_utils.create_user(username='checktoken0002')
+    token = "testtokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentesttokentest000008"
+    d.engine.execute(d.meta.tables["forgotpassword"].insert(), {
+        "userid": user_id,
+        "token_sha256": hashlib.sha256(token.encode("ascii")).digest(),
+        "email": email_addr,
+    })
+    assert resetpassword.prepare(token) == resetpassword.Unregistered(email=email_addr)
+
+
+@pytest.mark.usefixtures('db')
+def test_stale_records_get_deleted_when_function_is_called(captured_tokens):
+    email_addrs = list(map("test{}@weasyl.com".format, range(10)))
+
+    for email_addr in email_addrs:
+        db_utils.create_user(email_addr=email_addr)
+        resetpassword.request(email=email_addr)
+    # Set 5 tokens to be two hours old (0,5)
+    for i in range(0, 5):
+        d.engine.execute("UPDATE forgotpassword SET created_at = now() - INTERVAL '2 hours' WHERE email = %(email)s",
+                         email=email_addrs[i])
+    # Set 5 tokens to be 30 minutes old (5,10)
+    for i in range(5, 10):
+        d.engine.execute("UPDATE forgotpassword SET created_at = now() - INTERVAL '30 minutes' WHERE email = %(email)s",
+                         email=email_addrs[i])
+    # This range should be invalid (created_at > 3600)
+    for i in range(0, 5):
+        assert not resetpassword.prepare(captured_tokens[email_addrs[i]])
+    # This range should still be valid (created_at < 3600)
+    for i in range(5, 10):
+        assert resetpassword.prepare(captured_tokens[email_addrs[i]])

--- a/weasyl/test/resetpassword/test_request.py
+++ b/weasyl/test/resetpassword/test_request.py
@@ -5,39 +5,26 @@ import pytest
 from weasyl import resetpassword
 from weasyl import define as d
 from weasyl.test import db_utils
-from weasyl.test.utils import Bag
 
 
 @pytest.mark.usefixtures('db')
-def test_user_must_exist_for_a_forgotten_password_request_to_be_made():
-    email_addr = "test@weasyl.com"
-    form = Bag(email=email_addr)
-    resetpassword.request(form)
-    record_count = d.engine.scalar("""
-        SELECT COUNT(*) FROM forgotpassword
-    """)
-    assert record_count == 0
+def test_forgotten_password_request_always_made():
+    resetpassword.request(email="test@weasyl.com")
+    record_count = d.engine.scalar("SELECT count(*) FROM forgotpassword")
+    assert record_count == 1
 
 
 @pytest.mark.usefixtures('db')
-def test_email_must_match_email_stored_in_DB():
+def test_verify_success_if_valid_information_provided(captured_tokens):
     email_addr = "test@weasyl.com"
-    user_id = db_utils.create_user(email_addr=email_addr)
-    email_addr = "invalid-email@weasyl.com"
-    form = Bag(email=email_addr)
-    resetpassword.request(form)
-    query = d.engine.scalar("""
-        SELECT userid FROM forgotpassword WHERE userid = %(userid)s
-    """, userid=user_id)
-    assert not query
+    username = "test"
+    user_id = db_utils.create_user(username=username, email_addr=email_addr)
+    resetpassword.request(email=email_addr)
 
-
-@pytest.mark.usefixtures('db')
-def test_verify_success_if_valid_information_provided():
-    email_addr = "test@weasyl.com"
-    user_id = db_utils.create_user(email_addr=email_addr)
-    form = Bag(email=email_addr)
-    resetpassword.request(form)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    assert 100 == len(pw_reset_token)
-    assert resetpassword.prepare(pw_reset_token)
+    pw_reset_token = captured_tokens[email_addr]
+    assert 25 == len(pw_reset_token)
+    assert dict(resetpassword.prepare(pw_reset_token)) == {
+        "userid": user_id,
+        "email": email_addr,
+        "username": username,
+    }

--- a/weasyl/test/resetpassword/test_reset.py
+++ b/weasyl/test/resetpassword/test_reset.py
@@ -2,154 +2,97 @@ from __future__ import absolute_import
 
 import pytest
 import bcrypt
-import arrow
 
 from weasyl import resetpassword, login
 from weasyl import define as d
 from weasyl.error import WeasylError
 from weasyl.test import db_utils
-from weasyl.test.utils import Bag
 
 
 user_name = "test"
 email_addr = "test@weasyl.com"
-token = "a" * 100
+token = "a" * 25
 
 
 @pytest.mark.usefixtures('db')
 def test_passwordMismatch_WeasylError_if_supplied_passwords_dont_match():
-    db_utils.create_user(email_addr=email_addr, username=user_name)
-    form = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-               month=arrow.now().month, year=arrow.now().year, token=token,
-               password='qwe', passcheck='asd')
+    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
     with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form)
+        resetpassword.reset(
+            token=token,
+            password='qwe',
+            passcheck='asd',
+            expect_userid=user_id,
+            address=None,
+        )
     assert 'passwordMismatch' == err.value.value
 
 
 @pytest.mark.usefixtures('db')
 def test_passwordInsecure_WeasylError_if_password_length_insufficient():
-    db_utils.create_user(email_addr=email_addr, username=user_name)
+    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
     password = ''
-    form = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-               month=arrow.now().month, year=arrow.now().year, token=token,
-               password=password, passcheck=password)
     # Considered insecure...
     for i in range(0, login._PASSWORD):
         with pytest.raises(WeasylError) as err:
-            resetpassword.reset(form)
+            resetpassword.reset(
+                token=token,
+                password=password,
+                passcheck=password,
+                expect_userid=user_id,
+                address=None,
+            )
         assert 'passwordInsecure' == err.value.value
         password += 'a'
-        form.password = password
-        form.passcheck = password
     # Considered secure...
     password += 'a'
-    form.password = password
-    form.passcheck = password
     # Success at WeasylError/forgotpasswordRecordMissing; we didn't make one yet
     with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form)
+        resetpassword.reset(
+            token=token,
+            password=password,
+            passcheck=password,
+            expect_userid=user_id,
+            address=None,
+        )
     assert 'forgotpasswordRecordMissing' == err.value.value
 
 
 @pytest.mark.usefixtures('db')
 def test_forgotpasswordRecordMissing_WeasylError_if_reset_record_not_found():
-    db_utils.create_user(email_addr=email_addr, username=user_name)
+    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
     password = '01234567890123'
-    form = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-               month=arrow.now().month, year=arrow.now().year, token=token,
-               password=password, passcheck=password)
     # Technically we did this in the above test, but for completeness, target it alone
     with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form)
+        resetpassword.reset(
+            token=token,
+            password=password,
+            passcheck=password,
+            expect_userid=user_id,
+            address=None,
+        )
     assert 'forgotpasswordRecordMissing' == err.value.value
 
 
 @pytest.mark.usefixtures('db')
-def test_emailIncorrect_WeasylError_if_email_address_doesnt_match_stored_email():
-    # Two parts: Set forgot password record; attempt reset with incorrect email
-    #  Requirement: Get token set from request()
-    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
-    password = '01234567890123'
-    form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                           month=arrow.now().month, year=arrow.now().year)
-    resetpassword.request(form_for_request)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    # Force update link_time (required)
-    resetpassword.prepare(pw_reset_token)
-    email_addr_mismatch = "invalid-email@weasyl.com"
-    form_for_reset = Bag(email=email_addr_mismatch, username=user_name, day=arrow.now().day,
-                         month=arrow.now().month, year=arrow.now().year, token=pw_reset_token,
-                         password=password, passcheck=password)
-    with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form_for_reset)
-    assert 'emailIncorrect' == err.value.value
-
-
-@pytest.mark.usefixtures('db')
-def test_emailIncorrect_WeasylError_if_username_doesnt_match_stored_username():
-    # Two parts: Set forgot password record; attempt reset with incorrect username
-    #  Requirement: Get token set from request()
-    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
-    password = '01234567890123'
-    form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                           month=arrow.now().month, year=arrow.now().year)
-    resetpassword.request(form_for_request)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    # Force update link_time (required)
-    resetpassword.prepare(pw_reset_token)
-    user_name_mismatch = "nottheaccountname123"
-    form_for_reset = Bag(email=email_addr, username=user_name_mismatch, day=arrow.now().day,
-                         month=arrow.now().month, year=arrow.now().year, token=pw_reset_token,
-                         password=password, passcheck=password)
-    with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form_for_reset)
-    assert 'usernameIncorrect' == err.value.value
-
-
-@pytest.mark.usefixtures('db')
-def test_password_reset_fails_if_attempted_from_different_ip_address():
-    # Two parts: Set forgot password record; attempt reset with incorrect IP Address in forgotpassword table vs. requesting IP
-    #  Requirement: Get token set from request()
-    user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
-    password = '01234567890123'
-    form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                           month=arrow.now().month, year=arrow.now().year)
-    resetpassword.request(form_for_request)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    # Change IP detected when request was made (required for test)
-    d.engine.execute("UPDATE forgotpassword SET address = %(addr)s WHERE token = %(token)s",
-                     addr="127.42.42.42", token=pw_reset_token)
-    # Force update link_time (required)
-    resetpassword.prepare(pw_reset_token)
-    form_for_reset = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                         month=arrow.now().month, year=arrow.now().year, token=pw_reset_token,
-                         password=password, passcheck=password)
-    with pytest.raises(WeasylError) as err:
-        resetpassword.reset(form_for_reset)
-    assert 'addressInvalid' == err.value.value
-
-
-@pytest.mark.usefixtures('db')
-def test_verify_success_if_correct_information_supplied():
+def test_verify_success_if_correct_information_supplied(captured_tokens):
     # Subtests:
     #  a) Verify 'authbcrypt' table has new hash
     #  b) Verify 'forgotpassword' row is removed.
     #  > Requirement: Get token set from request()
     user_id = db_utils.create_user(email_addr=email_addr, username=user_name)
     password = '01234567890123'
-    form_for_request = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-                           month=arrow.now().month, year=arrow.now().year)
-    resetpassword.request(form_for_request)
-    pw_reset_token = d.engine.scalar("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    # Force update link_time (required)
-    resetpassword.prepare(pw_reset_token)
-    form = Bag(email=email_addr, username=user_name, day=arrow.now().day,
-               month=arrow.now().month, year=arrow.now().year, token=pw_reset_token,
-               password=password, passcheck=password)
-    resetpassword.reset(form)
+    resetpassword.request(email=email_addr)
+    pw_reset_token = captured_tokens[email_addr]
+    resetpassword.reset(
+        token=pw_reset_token,
+        password=password,
+        passcheck=password,
+        expect_userid=user_id,
+        address=None,
+    )
     # 'forgotpassword' row should not exist after a successful reset
-    row_does_not_exist = d.engine.execute("SELECT token FROM forgotpassword WHERE userid = %(id)s", id=user_id)
-    assert row_does_not_exist.first() is None
+    record_count = d.engine.scalar("SELECT count(*) FROM forgotpassword")
+    assert record_count == 0
     bcrypt_hash = d.engine.scalar("SELECT hashsum FROM authbcrypt WHERE userid = %(id)s", id=user_id)
     assert bcrypt.checkpw(password.encode('utf-8'), bcrypt_hash.encode('utf-8'))


### PR DESCRIPTION
Fixes #698.

- always send an e-mail so people aren’t left guessing as to whether something is eventually coming (and so various behaviours are independent of whether an account with the given e-mail address exists on the site)

- look up e-mail case-insensitively (but prefer case-sensitive for backwards compatibility – there are 700+ e-mail addresses with multiple associated accounts because registration is case-sensitive! registration being `<input type="email">` but password reset being `<input type="text">` might have made this even more visible than usual on mobile.)

- look up e-mail at reset time so that a password reset request sent to an account’s previous address doesn’t work (even though the window was only one hour)

- drop 5-minute timer that starts on visiting the link, because it doesn’t do much for security and could be incredibly frustrating

- allow requesting a reset and performing the reset on different IP addresses, because people’s IP addresses can change and they can use multiple devices

- don’t require people to reenter their username and e-mail address, to make use of the password reset less annoying

- further to the previous, *show* the username so the feature can also act as a forgotten username lookup

- sidestep any potential side channel attacks on the token (and questions of whether keeping the tokens in the database is a risk) by hashing tokens and therefore not knowing them

- reduce the length and complexity of tokens, just in case someone needs to retype one

- log password resets

An important future improvement is to make this at least as resistant to abuse as the signup page, so we should start by applying the CAPTCHA to it as soon as the server is able to reach Google to validate them again.

One new risk this introduces is that someone with access to the mailbox will be able to view the owner’s Weasyl username undetected by them, but I think it’s acceptable.

Letting a user skip the login screen after changing their password would probably be helpful, but with 2FA and status checks having to be moved around to accomplish that, it seems best to leave that for later.