### PR TITLE
Fix shout deletion being misattributed, and clean up related code

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/77c5bbd1fa3d_remove_unused_stored_comment_indent.py
+++ b/libweasyl/libweasyl/alembic/versions/77c5bbd1fa3d_remove_unused_stored_comment_indent.py
@@ -1,0 +1,26 @@
+"""Remove unused stored comment indent
+
+Revision ID: 77c5bbd1fa3d
+Revises: c5074772185a
+Create Date: 2020-04-03 06:12:36.855188
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '77c5bbd1fa3d'
+down_revision = 'c5074772185a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('charcomment', 'indent')
+    op.drop_column('comments', 'indent')
+    op.drop_column('journalcomment', 'indent')
+
+
+def downgrade():
+    op.add_column('journalcomment', sa.Column('indent', sa.INTEGER(), server_default=sa.text(u'0'), autoincrement=False, nullable=False))
+    op.add_column('comments', sa.Column('indent', sa.INTEGER(), server_default=sa.text(u'0'), autoincrement=False, nullable=False))
+    op.add_column('charcomment', sa.Column('indent', sa.INTEGER(), server_default=sa.text(u'0'), autoincrement=False, nullable=False))

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -54,7 +54,6 @@ charcomment = Table(
     Column('parentid', Integer(), nullable=False, server_default='0'),
     Column('content', String(length=10000), nullable=False),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('indent', Integer(), nullable=False, server_default='0'),
     Column('settings', String(length=20), nullable=False, server_default=''),
     Column('hidden_by', Integer(), nullable=True),
     default_fkey(['targetid'], ['character.charid'], name='charcomment_targetid_fkey'),
@@ -87,7 +86,6 @@ comments = Table(
     Column('parentid', Integer(), nullable=True),
     Column('content', Text(), nullable=False),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('indent', Integer(), nullable=False, server_default='0'),
     Column('settings', CharSettingsColumn({
         'h': 'hidden',
         's': 'staff-note',
@@ -310,7 +308,6 @@ journalcomment = Table(
     Column('parentid', Integer(), nullable=False, server_default='0'),
     Column('content', String(length=10000), nullable=False),
     Column('unixtime', WeasylTimestampColumn(), nullable=False),
-    Column('indent', Integer(), nullable=False, server_default='0'),
     Column('settings', String(length=20), nullable=False, server_default=''),
     Column('hidden_by', Integer(), nullable=True),
     default_fkey(['targetid'], ['journal.journalid'], name='journalcomment_targetid_fkey'),

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -284,12 +284,13 @@ def submit_shout_(request):
     if not define.is_vouched_for(request.userid):
         raise WeasylError("vouchRequired")
 
-    c = orm.Comment()
-    c.parentid = define.get_int(form.parentid)
-    c.userid = define.get_int(form.userid or form.staffnotes)
-    c.content = form.content
-
-    commentid = shout.insert(request.userid, c, staffnotes=form.staffnotes)
+    commentid = shout.insert(
+        request.userid,
+        target_user=define.get_int(form.userid or form.staffnotes),
+        parentid=define.get_int(form.parentid),
+        content=form.content,
+        staffnotes=bool(form.staffnotes),
+    )
 
     if form.format == "json":
         return {"id": commentid}

--- a/weasyl/shout.py
+++ b/weasyl/shout.py
@@ -56,18 +56,18 @@ def count(ownerid, staffnotes=False):
     return ret
 
 
-def insert(userid, shout, staffnotes=False):
+def insert(userid, target_user, parentid, content, staffnotes):
     # Check invalid content
-    if not shout.content:
+    if not content:
         raise WeasylError("commentInvalid")
-    elif not shout.userid or not d.is_vouched_for(shout.userid):
+    elif not target_user or not d.is_vouched_for(target_user):
         raise WeasylError("Unexpected")
 
     # Determine parent userid
-    if shout.parentid:
+    if parentid:
         parentuserid = d.engine.scalar(
             "SELECT userid FROM comments WHERE commentid = %(parent)s",
-            parent=shout.parentid,
+            parent=parentid,
         )
 
         if parentuserid is None:
@@ -77,19 +77,19 @@ def insert(userid, shout, staffnotes=False):
 
     # Check permissions
     if userid not in staff.MODS:
-        if ignoreuser.check(shout.userid, userid):
+        if ignoreuser.check(target_user, userid):
             raise WeasylError("pageOwnerIgnoredYou")
-        elif ignoreuser.check(userid, shout.userid):
+        elif ignoreuser.check(userid, target_user):
             raise WeasylError("youIgnoredPageOwner")
         elif ignoreuser.check(parentuserid, userid):
             raise WeasylError("replyRecipientIgnoredYou")
         elif ignoreuser.check(userid, parentuserid):
             raise WeasylError("youIgnoredReplyRecipient")
 
-        _, is_banned, _ = d.get_login_settings(shout.userid)
-        profile_config = d.get_config(shout.userid)
+        _, is_banned, _ = d.get_login_settings(target_user)
+        profile_config = d.get_config(target_user)
 
-        if is_banned or "w" in profile_config or "x" in profile_config and not frienduser.check(userid, shout.userid):
+        if is_banned or "w" in profile_config or "x" in profile_config and not frienduser.check(userid, target_user):
             raise WeasylError("insufficientActionPermissions")
 
     # Create comment
@@ -98,16 +98,16 @@ def insert(userid, shout, staffnotes=False):
     db = d.connect()
     commentid = db.scalar(
         co.insert()
-        .values(userid=userid, target_user=shout.userid, parentid=shout.parentid or None, content=shout.content,
+        .values(userid=userid, target_user=target_user, parentid=parentid or None, content=content,
                 unixtime=arrow.utcnow(), settings=settings)
         .returning(co.c.commentid))
 
     # Create notification
-    if shout.parentid and userid != parentuserid:
+    if parentid and userid != parentuserid:
         if not staffnotes or parentuserid in staff.MODS:
-            welcome.shoutreply_insert(userid, commentid, parentuserid, shout.parentid, staffnotes)
-    elif not staffnotes and shout.userid and userid != shout.userid:
-        welcome.shout_insert(userid, commentid, otherid=shout.userid)
+            welcome.shoutreply_insert(userid, commentid, parentuserid, parentid, staffnotes)
+    elif not staffnotes and target_user and userid != target_user:
+        welcome.shout_insert(userid, commentid, otherid=target_user)
 
     d.metric('increment', 'shouts')
 

--- a/weasyl/shout.py
+++ b/weasyl/shout.py
@@ -18,8 +18,7 @@ def select(userid, ownerid, limit=None, staffnotes=False):
     statement = ["""
         SELECT
             sh.commentid, sh.parentid, sh.userid, pr.username,
-            sh.content, sh.unixtime, sh.settings, sh.indent,
-            sh.hidden_by
+            sh.content, sh.unixtime, sh.settings, sh.hidden_by
         FROM comments sh
             INNER JOIN profile pr USING (userid)
         WHERE sh.target_user = %i

--- a/weasyl/test/test_comment.py
+++ b/weasyl/test/test_comment.py
@@ -8,7 +8,6 @@ from libweasyl.models import site
 
 from weasyl import define as d
 from weasyl import comment
-from weasyl import orm
 from weasyl import shout
 from weasyl.error import WeasylError
 from weasyl.test import db_utils
@@ -118,8 +117,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
 
     def test_add_and_remove_shout(self):
         # commenter1 posts a shout on owner's page
-        c1 = shout.insert(self.commenter1, orm.Comment(userid=self.owner,
-                                                       content="hello"))
+        c1 = shout.insert(self.commenter1, target_user=self.owner, parentid=None, content="hello", staffnotes=False)
         self.assertEqual(1, self.count_notifications(self.owner))
 
         shouts = shout.select(0, self.owner)
@@ -127,8 +125,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
         self.assertTrue(shouts[0].viewitems() >= {"content": "hello"}.viewitems())
 
         # commenter2 posts a reply to c1
-        c2 = shout.insert(self.commenter2, orm.Comment(userid=self.owner,
-                                                       content="reply", parentid=c1))
+        c2 = shout.insert(self.commenter2, target_user=self.owner, parentid=c1, content="reply", staffnotes=False)
         self.assertEqual(1, self.count_notifications(self.commenter1))
 
         shouts = shout.select(0, self.owner)
@@ -136,8 +133,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
         self.assertTrue(shouts[1].viewitems() >= {"content": "reply"}.viewitems())
 
         # owner posts a reply to c2
-        c3 = shout.insert(self.owner, orm.Comment(userid=self.owner,
-                                                  content="reply 2", parentid=c2))
+        c3 = shout.insert(self.owner, target_user=self.owner, parentid=c2, content="reply 2", staffnotes=False)
         self.assertEqual(1, self.count_notifications(self.commenter2))
 
         shouts = shout.select(0, self.owner)
@@ -145,8 +141,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
         self.assertTrue(shouts[2].viewitems() >= {"content": "reply 2"}.viewitems())
 
         # commenter1 responds to owner
-        shout.insert(self.commenter1, orm.Comment(userid=self.owner,
-                                                  content="reply 3", parentid=c3))
+        shout.insert(self.commenter1, target_user=self.owner, parentid=c3, content="reply 3", staffnotes=False)
         self.assertEqual(2, self.count_notifications(self.owner))
 
         shouts = shout.select(0, self.owner)
@@ -154,8 +149,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
         self.assertTrue(shouts[3].viewitems() >= {"content": "reply 3"}.viewitems())
 
         # commenter1 posts a new root shout
-        shout.insert(self.commenter1, orm.Comment(userid=self.owner,
-                                                  content="root 2"))
+        shout.insert(self.commenter1, target_user=self.owner, parentid=None, content="root 2", staffnotes=False)
         self.assertEqual(3, self.count_notifications(self.owner))
 
         shouts = shout.select(0, self.owner)
@@ -164,8 +158,7 @@ class CheckNotificationsTestCase(unittest.TestCase):
         self.assertTrue(shouts[4].viewitems() >= {"content": "reply 3"}.viewitems())
 
         # commenter2 posts another reply to c1
-        shout.insert(self.commenter2, orm.Comment(userid=self.owner,
-                                                  content="reply 4", parentid=c1))
+        shout.insert(self.commenter2, target_user=self.owner, parentid=c1, content="reply 4", staffnotes=False)
         self.assertEqual(2, self.count_notifications(self.commenter1))
 
         shouts = shout.select(0, self.owner)


### PR DESCRIPTION
Right now, hidden top-level shouts always show up as having been hidden by nobody, and any other level is (almost always) “[hidden by moderator]”. This happens because the indent level is being used as the `hidden_by` user id.

This set of changes fixes that, and also removes stored `indent`s altogether, since the field has been calculated entirely by `weasyl.comment.thread()` for some time now. The migration should be applied after switching over the workers.