### PR TITLE
Update nginx client_max_body_size to 55m

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,7 +87,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        client_max_body_size 30m;
+        client_max_body_size 55m;
         client_body_buffer_size 128k;
         proxy_connect_timeout 10;
         proxy_send_timeout 30;

--- a/containers/nginx.conf
+++ b/containers/nginx.conf
@@ -32,7 +32,7 @@ http {
         root /weasyl/build;
 
         location / {
-            client_max_body_size 30m;
+            client_max_body_size 55m;
 
             proxy_pass http://weasyl-web:8880;
             proxy_redirect off;


### PR DESCRIPTION
Required by #822 (which raised visual submission limit to 50MiB)