### PR TITLE
Fix password reset requests with uppercase in local part

### DIFF
--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -47,7 +47,7 @@ def _find_reset_target(db, email):
     matches = db.execute(
         "SELECT userid, email, username FROM login"
         " INNER JOIN profile USING (userid)"
-        ' WHERE lower(email COLLATE "C") = %(email)s',
+        ' WHERE lower(email COLLATE "C") = lower(%(email)s COLLATE "C")',
         email=email,
     ).fetchall()
 

--- a/weasyl/test/resetpassword/test_request.py
+++ b/weasyl/test/resetpassword/test_request.py
@@ -28,3 +28,19 @@ def test_verify_success_if_valid_information_provided(captured_tokens):
         "email": email_addr,
         "username": username,
     }
+
+
+@pytest.mark.usefixtures('db')
+def test_case_insensitive_local_part(captured_tokens):
+    email_addr = "Test@weasyl.com"
+    username = "test"
+    user_id = db_utils.create_user(username=username, email_addr=email_addr.swapcase())
+    resetpassword.request(email=email_addr)
+
+    pw_reset_token = captured_tokens[email_addr]
+    assert 25 == len(pw_reset_token)
+    assert dict(resetpassword.prepare(pw_reset_token)) == {
+        "userid": user_id,
+        "email": email_addr.swapcase(),
+        "username": username,
+    }


### PR DESCRIPTION
The input was normalized with `emailer.normalize_address()`, but not lowercased.