### PR TITLE
Set coverfile default value to empty string

### DIFF
--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -101,7 +101,7 @@ def submit_literary_get_(request):
 @login_required
 @token_checked
 def submit_literary_post_(request):
-    form = request.web_input(submitfile="", coverfile="boop", thumbfile="", title="",
+    form = request.web_input(submitfile="", coverfile="", thumbfile="", title="",
                              folderid="", subtype="", rating="", friends="", critique="",
                              content="", tags="", embedlink="")
 


### PR DESCRIPTION
Removes the default value of ``boop`` from ``coverfile`` in the ``submit_literary_post_`` route.

While this doesn't _break_ anything exactly, if, for example, someone with an intercepting proxy (or just deleting the element from the developer tools ... for whatever reason) decides to just not send the blank ``coverfile`` form parameter, the text "boop" would propagate down to Sanpera to try and be decoded. That is, the blank/empty ``coverfile`` normally received nullifies the default string received into the parameter as set in the function definition, and this only appears in non-standard conditions.

(When the ``<input>`` for ``coverfile`` is deleted)
```
2020-06-24T02:42:14+0000 [stderr#error] Traceback (most recent call last):
2020-06-24T02:42:14+0000 [stderr#error]   File "/vagrant/weasyl/image.py", line 28, in from_string
2020-06-24T02:42:14+0000 [stderr#error]     return Image.from_buffer(filedata)
2020-06-24T02:42:14+0000 [stderr#error]   File "sanpera/image.pyx", line 386, in sanpera.image.Image.from_buffer (sanpera/image.c:5718)
2020-06-24T02:42:14+0000 [stderr#error]   File "sanpera/exception.pyx", line 64, in sanpera.exception.MagickException.check (sanpera/exception.c:1392)
2020-06-24T02:42:14+0000 [stderr#error]   File "sanpera/exception.pyx", line 107, in sanpera.exception.check_magick_exception (sanpera/exception.c:1867)
2020-06-24T02:42:14+0000 [stderr#error] GenericMagickError: no decode delegate for this image format `' @ error/blob.c/BlobToImage/353   420   0
```
