### PR TITLE
Remove dependency on storify from controllers/director.

### DIFF
--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -64,6 +64,6 @@ def directorcontrol_globaltagrestrictions_get_(request):
 @director_only
 @token_checked
 def directorcontrol_globaltagrestrictions_post_(request):
-    tags = searchtag.parse_restricted_tags(request.params.get("tags", ''))
+    tags = searchtag.parse_restricted_tags(request.params["tags"])
     searchtag.edit_global_tag_restrictions(request.userid, tags)
     raise HTTPSeeOther(location="/directorcontrol/globaltagrestrictions")

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -32,19 +32,23 @@ def directorcontrol_emailblacklist_get_(request):
 @token_checked
 @director_only
 def directorcontrol_emailblacklist_post_(request):
-    form = request.web_input(action=None, remove_selection=[], domain_name=None, reason=None)
+    action = request.params.get("action")
+    remove_selection = request.params.getall("remove_selection")
+    domain_name = request.params.get("domain_name")
+    reason = request.params.get("reason")
+
     # Remove entr(y|ies) from blacklist
-    if form.action == "remove":
+    if action == "remove":
         d.engine.execute("DELETE FROM emailblacklist WHERE id = ANY (%(selected_ids)s)",
-                         selected_ids=map(int, form.remove_selection))
+                         selected_ids=map(int, remove_selection))
 
     # Add any entries to blacklist, if any in form.domain_name; duplicate entries are silently discarded.
-    elif form.action == "add" and form.domain_name:
+    elif action == "add" and domain_name:
         d.engine.execute("""
             INSERT INTO emailblacklist (domain_name, reason, added_by)
                 SELECT UNNEST(%(domain_name)s), %(reason)s, %(added_by)s
             ON CONFLICT (domain_name) DO NOTHING
-        """, domain_name=form.domain_name.split(), reason=form.reason, added_by=request.userid)
+        """, domain_name=domain_name.split(), reason=reason, added_by=request.userid)
 
     raise HTTPSeeOther(location="/directorcontrol/emailblacklist")
 
@@ -60,6 +64,6 @@ def directorcontrol_globaltagrestrictions_get_(request):
 @director_only
 @token_checked
 def directorcontrol_globaltagrestrictions_post_(request):
-    tags = searchtag.parse_restricted_tags(request.params["tags"])
+    tags = searchtag.parse_restricted_tags(request.params.get("tags", ''))
     searchtag.edit_global_tag_restrictions(request.userid, tags)
     raise HTTPSeeOther(location="/directorcontrol/globaltagrestrictions")


### PR DESCRIPTION
Like it says on the tin. Removes ``web_input`` in favor of Pyramid-native parameter getting mechanisms for the director control panel's controller.