### PR TITLE
Add email for signing up while awaiting verification

### DIFF
--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -283,9 +283,12 @@ def create(form):
         #   let the already registered user know this via email (perhaps they forgot their username/password)
         query_username_login = d.engine.scalar("SELECT login_name FROM login WHERE email = %(email)s", email=email)
         query_username_logincreate = d.engine.scalar("SELECT login_name FROM logincreate WHERE email = %(email)s", email=email)
-        emailer.send(email, "Weasyl Account Creation - Account Already Exists", d.render(
-            "email/email_in_use_account_creation.html", [query_username_login or query_username_logincreate]))
-
+        if query_username_login:
+            emailer.send(email, "Weasyl Account Creation - Account Already Exists", d.render(
+                "email/email_in_use_account_creation.html", [query_username_login]))
+        else:
+            emailer.send(email, "Weasyl Account Creation - Account Already Exists", d.render(
+                "email/email_in_use_account_creation_in_progress.html", [token, query_username_logincreate]))
 
 def verify(token, ip_address=None):
     lo = d.meta.tables["login"]

--- a/weasyl/templates/email/email_in_use_account_creation_in_progress.html
+++ b/weasyl/templates/email/email_in_use_account_creation_in_progress.html
@@ -1,0 +1,12 @@
+$def with (token, username)
+Hello!
+
+You are receiving this message because someone attempted to create an account using this email address, which is already registered to the account named "${username}". This account still needs to be verified, but only one Weasyl account may be associated with an email address.
+
+If you are attempting to change your account name, please send an email from your registered email for your Weasyl account, ${username}, to ${M.MACRO_SUPPORT_ADDRESS} to request a username change.
+
+To verify the account under the username "${username}", you may go to https://www.weasyl.com/verify/account?token=${token}
+
+In the event that you forgot your password, you may reset it at https://www.weasyl.com/forgotpassword
+
+https://www.weasyl.com


### PR DESCRIPTION
This adds another template and calls it when the user attempts to sign
up again with another username, sending another email with the
verification link.

Addresses issue #76

I'm having issues making the dev environment so I wasn't able to test this. I'm trying to fix that and posted a few messages on Gitter, but there wasn't much changed.