### PR TITLE
Restrict crossposting to source domains supported by Waxpost

### DIFF
--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -63,6 +63,9 @@ error_messages = {
         "The cover art file you uploaded exceeds the allowed filesize for this submission category."),
     "coverType": (
         "The cover art file you uploaded is not a valid filetype for this submission category."),
+    "crosspostInvalid": (
+        "The image you crossposted was from an unsupported source. "
+        "Please report this bug to the creator of the crossposting tool."),
     "duplicateSubmission": "You have already made a submission with this submission file.",
     "emailBlacklisted": (
         "The domain of the email you entered has been associated with a high volume of spam. "

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division
 
+import re
 import urlparse
 from io import BytesIO
 
@@ -114,12 +115,46 @@ def _create_submission(expected_type):
     return wrapper
 
 
+_ALLOWED_CROSSPOST_HOSTS = frozenset([
+    # DeviantArt
+    "wixmp.com",
+
+    # Fur Affinity
+    "furaffinity.net",
+    "facdn.net",
+
+    # Imgur
+    "imgur.com",
+
+    # Inkbunny
+    "ib.metapix.net",
+
+    # SoFurry
+    "sofurryfiles.com",
+])
+
+_ALLOWED_CROSSPOST_HOST = re.compile(
+    r"(?:\A|\.)"
+    + "(?:" + "|".join(map(re.escape, _ALLOWED_CROSSPOST_HOSTS)) + ")"
+    + r"\Z"
+)
+
+
+def _http_get_if_crosspostable(url):
+    parsed = urlparse.urlparse(url)
+
+    if parsed.scheme not in ("http", "https") or _ALLOWED_CROSSPOST_HOST.search(parsed.netloc) is None:
+        raise WeasylError("crosspostInvalid")
+
+    return d.http_get(url, timeout=5)
+
+
 @_create_submission(expected_type=1)
 def create_visual(userid, submission,
                   friends_only, tags, imageURL, thumbfile,
                   submitfile, critique, create_notifications):
     if imageURL:
-        resp = d.http_get(imageURL, timeout=5)
+        resp = _http_get_if_crosspostable(imageURL)
         submitfile = resp.content
 
     # Determine filesizes

--- a/weasyl/test/web/common.py
+++ b/weasyl/test/web/common.py
@@ -27,8 +27,12 @@ def read_asset_image(path):
     return Image.open(BytesIO(read_asset(path))).convert('RGBA')
 
 
+def get_storage_path(url):
+    return os.path.join(MACRO_STORAGE_ROOT, url[1:])
+
+
 def read_storage_image(image_url):
-    full_path = os.path.join(MACRO_STORAGE_ROOT, image_url[1:])
+    full_path = get_storage_path(image_url)
     return Image.open(full_path).convert('RGBA')
 
 

--- a/weasyl/test/web/test_submissions.py
+++ b/weasyl/test/web/test_submissions.py
@@ -2,14 +2,25 @@
 from __future__ import absolute_import, division
 
 import hashlib
+import re
+import threading
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from io import BytesIO
 
 import arrow
 import pytest
 import webtest
 
+from weasyl import submission
 from weasyl.test import db_utils
-from weasyl.test.web.common import BASE_VISUAL_FORM, create_visual, read_asset, read_asset_image, read_storage_image
+from weasyl.test.web.common import (
+    BASE_VISUAL_FORM,
+    create_visual,
+    get_storage_path,
+    read_asset,
+    read_asset_image,
+    read_storage_image,
+)
 
 
 def _image_hash(image):
@@ -108,3 +119,45 @@ def test_visual_reupload_thumbnail_and_cover(app, submission_user):
     # The reupload of submission 1 should look like submission 2
     assert _image_hash(read_storage_image(v1_new_thumbnail_url)) == _image_hash(read_storage_image(v2_thumbnail_url))
     assert _image_hash(read_storage_image(v2_cover_url)) == _image_hash(read_storage_image(v1_new_cover_url))
+
+
+class CrosspostHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'image/png')
+        self.end_headers()
+        self.wfile.write(read_asset('img/wesley1.png'))
+
+
+@pytest.mark.usefixtures('db', 'no_csrf')
+def test_crosspost(app, submission_user, monkeypatch):
+    monkeypatch.setattr(submission, '_ALLOWED_CROSSPOST_HOST', re.compile(r'\Alocalhost:[0-9]+\Z'))
+
+    crosspost_test_server = HTTPServer(('127.0.0.1', 0), CrosspostHandler)
+    image_url = 'http://localhost:%i/wesley1.png' % (crosspost_test_server.server_port,)
+
+    test_server_thread = threading.Thread(
+        target=crosspost_test_server.serve_forever,
+        kwargs={'poll_interval': 0.1},
+    )
+    test_server_thread.start()
+
+    # Crossposting from a supported source works
+    try:
+        v1 = create_visual(app, submission_user, imageURL=image_url)
+    finally:
+        crosspost_test_server.shutdown()
+        test_server_thread.join()
+
+    v1_image_url = app.get('/~submissiontest/submissions/%i/test-title' % (v1,)).html.find(id='detail-art').img['src']
+
+    assert open(get_storage_path(v1_image_url), 'rb').read() == read_asset('img/wesley1.png')
+
+    # Crossposting from an unsupported source doesn’t work
+    form = dict(
+        BASE_VISUAL_FORM,
+        imageURL='http://test.invalid/wesley1.png',
+    )
+    cookie = db_utils.create_session(submission_user)
+    resp = app.post('/submit/visual', form, headers={'Cookie': cookie}, status=422)
+    assert resp.html.find(id='error_content').p.text == 'The image you crossposted was from an unsupported source. Please report this bug to the creator of the crossposting tool.'


### PR DESCRIPTION
- Not filtering out targets on the Weasyl network is a recipe for disaster (even if nothing *should* privilege HTTP requests based on their source)

- The requests aren’t made through a proxy as is the case with outgoing mail, so this stops Weasyl servers’ private IP addresses (behind Cloudflare) from being revealed to just anyone.

List of sources in conveniently verifiable form at <https://github.com/Weasyl/waxpost-chrome/blob/cfe0ce252b60e4f0a2a3def94bec08f4c96abd5c/manifest.json#L14-L22>.