### PR TITLE
Fix README-docker.md to permit execution of tests

### DIFF
--- a/README-docker.md
+++ b/README-docker.md
@@ -84,7 +84,7 @@ containers/run \
 
 ```shell
 DOCKER_BUILDKIT=1 docker build --target=test -t weasyl-test --build-arg "version=$(git rev-parse --short HEAD)" .
-mkdir .pytest_cache
+mkdir -p .pytest_cache
 containers/run \
     --network=wzlnet \
     --name=weasyl-test \

--- a/README-docker.md
+++ b/README-docker.md
@@ -83,7 +83,8 @@ containers/run \
 ### Test
 
 ```shell
-DOCKER_BUILDKIT=1 docker build --target=test -t weasyl-test .
+DOCKER_BUILDKIT=1 docker build --target=test -t weasyl-test --build-arg "version=$(git rev-parse --short HEAD)" .
+mkdir .pytest_cache
 containers/run \
     --network=wzlnet \
     --name=weasyl-test \


### PR DESCRIPTION
Build of test container fails without ``--build-arg`` included; launch of ``weasyl-test`` container fails without ``.pytest_cache`` directory existing.