### PR TITLE
Markdown cleanup

### DIFF
--- a/libweasyl/libweasyl/test/test_text.py
+++ b/libweasyl/libweasyl/test/test_text.py
@@ -96,6 +96,7 @@ def test_markdown_user_linking_with_underscore():
 
 def test_markdown_image_replacement():
     assert markdown('![example](http://example)') == '<p><a href="http://example" rel="nofollow">example</a></p>'
+    assert markdown('<img alt="broken">') == '<p><a href="">broken</a></p>'
 
 
 def test_forum_whitelist():

--- a/libweasyl/libweasyl/test/test_text.py
+++ b/libweasyl/libweasyl/test/test_text.py
@@ -16,7 +16,9 @@ user_linking_markdown_tests = [
      '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"></a>'
      '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"></a>'),
     ('<!~spam>', '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"> <span>spam</span></a>'),
+    ('![user image with alt text](user:example)', '<a href="/~example" class="user-icon"><img src="/~example/avatar"> <span>user image with alt text</span></a>'),
     ('<user:spam>', '<a href="/~spam">spam</a>'),
+    ('[link](user:spam)', '<a href="/~spam">link</a>'),
     ('<fa:spam>', '<a href="https://www.furaffinity.net/user/spam" rel="nofollow">spam</a>'),
     ('<da:spam>', '<a href="https://www.deviantart.com/spam" rel="nofollow">spam</a>'),
     ('<ib:spam>', '<a href="https://inkbunny.net/spam" rel="nofollow">spam</a>'),

--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -230,43 +230,39 @@ def _markdown_fragment(target):
             if image.tag != "img":
                 continue
 
-            src = image.get("src")
+            src = image.get("src", "")
 
-            if src:
-                t, _, user = src.partition(":")
+            t, _, user = src.partition(":")
 
-                if t != "user":
-                    i = list(parent).index(image)
-                    link = etree.Element(u"a")
-                    link.tail = image.tail
-                    src = image.get("src")
-
-                    if src:
-                        link.set(u"href", src)
-                        link.text = image.attrib.get("alt", src)
-
-                    parent[i] = link
-
-                    continue
-
-                image.set(u"src", u"/~{user}/avatar".format(user=get_sysname(user)))
-
+            if t != "user":
+                i = list(parent).index(image)
                 link = etree.Element(u"a")
-                link.set(u"href", u"/~{user}".format(user=get_sysname(user)))
-                link.set(u"class", u"user-icon")
-                parent.insert(list(parent).index(image), link)
-                parent.remove(image)
-                link.append(image)
                 link.tail = image.tail
+                link.set(u"href", src)
+                link.text = image.attrib.get("alt", src)
 
-                if "alt" in image.attrib and image.attrib["alt"]:
-                    image.tail = u" "
-                    label = etree.SubElement(link, u"span")
-                    label.text = image.attrib["alt"]
-                    del image.attrib["alt"]
-                else:
-                    image.tail = None
-                    image.set(u"alt", user)
+                parent[i] = link
+
+                continue
+
+            image.set(u"src", u"/~{user}/avatar".format(user=get_sysname(user)))
+
+            link = etree.Element(u"a")
+            link.set(u"href", u"/~{user}".format(user=get_sysname(user)))
+            link.set(u"class", u"user-icon")
+            parent.insert(list(parent).index(image), link)
+            parent.remove(image)
+            link.append(image)
+            link.tail = image.tail
+
+            if "alt" in image.attrib and image.attrib["alt"]:
+                image.tail = u" "
+                label = etree.SubElement(link, u"span")
+                label.text = image.attrib["alt"]
+                del image.attrib["alt"]
+            else:
+                image.tail = None
+                image.set(u"alt", user)
 
     add_user_links(fragment, None, True)
 


### PR DESCRIPTION
- Adds more tests, bringing up measured line/branch coverage on libweasyl.text to 100% (the “uncovered” `continue` and the associated partial coverage on the `elif` seems to be some kind of coverage bug)
- Simplifies and fixes `<img>` removal

I recommend looking at the diff with whitespace changes ignored.