### PR TITLE
Remove unused and mostly unimplemented content-item settings

### DIFF
--- a/etc/SETTINGS.txt
+++ b/etc/SETTINGS.txt
@@ -98,9 +98,6 @@ h  Hidden
 f  Friends-only
 m  Members-only
 
-t  Tag-locked
-c  Comment-locked
-
 ------------------
 folder.settings ()
 ------------------
@@ -115,14 +112,6 @@ h  Hidden
 f  Friends-only
 q  Critique
 
-p  Pool
-o  Collaboration
-
-t  Tag-locked
-c  Comment-locked
-a  Admin-locked
-
-e  Encored
 u  Thumbnail required
 v  Embedded content
 
@@ -147,9 +136,6 @@ character.settings ()
 
 h  Hidden
 f  Friends-only
-
-t  Tag-locked
-c  Comment-locked
 
 -----------------------
 charfeature.settings ()

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -241,8 +241,6 @@ character = Table(
     Column('settings', CharSettingsColumn({
         'h': 'hidden',
         'f': 'friends-only',
-        't': 'tag-locked',
-        'c': 'comment-locked',
     }, length=20), nullable=False, server_default=''),
     Column('page_views', Integer(), nullable=False, server_default='0'),
     default_fkey(['userid'], ['login.userid'], name='character_userid_fkey'),
@@ -281,8 +279,6 @@ journal = Table(
     Column('settings', CharSettingsColumn({
         'h': 'hidden',
         'f': 'friends-only',
-        't': 'tag-locked',
-        'c': 'comment-locked',
     }, length=20), nullable=False, server_default=''),
     Column('page_views', Integer(), nullable=False, server_default='0'),
     Column('submitter_ip_address', String(length=45), nullable=True),
@@ -740,12 +736,6 @@ submission = Table(
         'h': 'hidden',
         'f': 'friends-only',
         'q': 'critique',
-        'p': 'pool',
-        'o': 'collaboration',
-        't': 'tag-locked',
-        'c': 'comment-locked',
-        'a': 'admin-locked',
-        'e': 'encored',
         'u': 'thumbnail-required',
     }, {
         'embed-type': {

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -28,7 +28,6 @@ unexpected = (
 
 error_messages = {
     "addressInvalid": "Your IP address does not match the location from which this request was made.",
-    "AdminLocked": "This content has been locked from any editing by an admin.",
     "ArtistTags": "You cannot remove tags that have been added by the artist.",
     "birthdayInsufficient": (
         "Your date of birth indicates that you are not allowed to set your content rating settings to the "

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -934,8 +934,6 @@ def edit(userid, submission, embedlink=None, friends_only=False, critique=False)
 
     if not query or "h" in query[2]:
         raise WeasylError("Unexpected")
-    elif "a" in query[2] and userid not in staff.MODS:
-        raise WeasylError("AdminLocked")
     elif userid != query[0] and userid not in staff.MODS:
         raise WeasylError("InsufficientPermissions")
     elif not submission.title:


### PR DESCRIPTION
Encores, pools, collaborations, locking. All verified to not be present in the production database, and I didn’t find them anywhere else in the code, although they’re hard to look for because settings columns are terrible.