### PR TITLE
Remove obsolete profile config for tag blocking type

### DIFF
--- a/etc/SETTINGS.txt
+++ b/etc/SETTINGS.txt
@@ -38,7 +38,6 @@ profile.config (lkscftjone)
 
 b  Show birthday in profile
 
-l  Use only tag blocklist
 a  View max rating mature
 p  View max rating explicit
 

--- a/libweasyl/libweasyl/alembic/versions/981bd4df447e_remove_obsolete_tag_blocking_type_.py
+++ b/libweasyl/libweasyl/alembic/versions/981bd4df447e_remove_obsolete_tag_blocking_type_.py
@@ -1,0 +1,21 @@
+"""Remove obsolete tag blocking type profile config
+
+Revision ID: 981bd4df447e
+Revises: 371d1872b404
+Create Date: 2021-03-11 04:20:44.425416
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '981bd4df447e'
+down_revision = '371d1872b404'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("UPDATE profile SET config = replace(config, 'l', '') WHERE config ~ 'l'")
+
+
+def downgrade():
+    pass

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -464,8 +464,6 @@ profile = Table(
         'b': 'show-birthday',
         '2': '12-hour-time',
 
-        'l': 'use-only-tag-blacklist',
-
         'g': 'tagging-disabled',
         'd': 'premium',
 

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -66,7 +66,6 @@ Config = create_configuration([
     BoolOption("hidefavbar", "u"),
     ConfigOption("shouts", {"anyone": "", "friends_only": "x", "staff_only": "w"}),
     ConfigOption("notes", {"anyone": "", "friends_only": "z", "staff_only": "y"}),
-    BoolOption("filter", "l"),
     BoolOption("follow_s", "s"),
     BoolOption("follow_c", "c"),
     BoolOption("follow_f", "f"),

--- a/weasyl/test/test_search.py
+++ b/weasyl/test/test_search.py
@@ -156,7 +156,7 @@ def test_search_pagination(db):
     (u"Marth", 1),
 ])
 def test_user_search(db, term, n_results):
-    config = CharSettings({'use-only-tag-blacklist'}, {}, {})
+    config = CharSettings({}, {}, {})
     db_utils.create_user("Sam Peacock", username="sammy", config=config)
     db_utils.create_user("LionCub", username="spammer2800", config=config)
     db_utils.create_user("Samantha Wildlife", username="godall", config=config)
@@ -172,7 +172,7 @@ def test_user_search(db, term, n_results):
 
 
 def test_user_search_ordering(db):
-    config = CharSettings({'use-only-tag-blacklist'}, {}, {})
+    config = CharSettings({}, {}, {})
     db_utils.create_user("user_aa", username="useraa", config=config)
     db_utils.create_user("user_ba", username="userba", config=config)
     db_utils.create_user("user_Ab", username="userab", config=config)


### PR DESCRIPTION
`l` indicated use of a tag blocklist, which is the only kind now. ~64k profiles have this applied.

```
=> SELECT round(max(userid), -4) AS max FROM profile;
┌────────┐
│  max   │
├────────┤
│ 190000 │
└────────┘

=> SELECT round(max(userid), -4) AS max FROM profile WHERE config ~ 'l';
┌───────┐
│  max  │
├───────┤
│ 80000 │
└───────┘
```