### PR TITLE
Post Python 3 Cleanup: Remove __future__ imports

### DIFF
--- a/libweasyl/libweasyl/alembic/env.py
+++ b/libweasyl/libweasyl/alembic/env.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig

--- a/libweasyl/libweasyl/constants.py
+++ b/libweasyl/libweasyl/constants.py
@@ -6,8 +6,6 @@ useful to have these values centralized instead of scattered throughout
 libweasyl.
 """
 
-from __future__ import unicode_literals
-
 import enum
 
 

--- a/libweasyl/libweasyl/defang.py
+++ b/libweasyl/libweasyl/defang.py
@@ -4,8 +4,6 @@ HTML defanging.
 :py:func:`.defang` is the primary export of this module.
 """
 
-from __future__ import unicode_literals
-
 import re
 from urllib.parse import urlparse
 

--- a/libweasyl/libweasyl/flash.py
+++ b/libweasyl/libweasyl/flash.py
@@ -1,5 +1,3 @@
-from __future__ import division, unicode_literals
-
 import itertools
 import lzma
 import struct

--- a/libweasyl/libweasyl/images.py
+++ b/libweasyl/libweasyl/images.py
@@ -6,8 +6,6 @@ This module defines functions which work on sanpera_ ``Image`` objects.
 .. _sanpera: https://pypi.python.org/pypi/sanpera
 """
 
-from __future__ import division
-
 from sanpera.image import Image
 from sanpera import geometry
 

--- a/libweasyl/libweasyl/images_new.py
+++ b/libweasyl/libweasyl/images_new.py
@@ -5,8 +5,6 @@ Image manipulation with Pillow.
 """
 # TODO: rename when Sanpera libweasyl.libweasyl.images is no longer used
 
-from __future__ import absolute_import
-
 from collections import namedtuple
 from io import BytesIO
 

--- a/libweasyl/libweasyl/models/content.py
+++ b/libweasyl/libweasyl/models/content.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 from pyramid.decorator import reify
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship

--- a/libweasyl/libweasyl/models/helpers.py
+++ b/libweasyl/libweasyl/models/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import contextlib
 
 import json

--- a/libweasyl/libweasyl/models/media.py
+++ b/libweasyl/libweasyl/models/media.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import collections
 import hashlib
 from io import BytesIO

--- a/libweasyl/libweasyl/test/test_files.py
+++ b/libweasyl/libweasyl/test/test_files.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 
 import pytest

--- a/libweasyl/libweasyl/test/test_flash.py
+++ b/libweasyl/libweasyl/test/test_flash.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import base64
 from io import BytesIO
 

--- a/libweasyl/libweasyl/test/test_html.py
+++ b/libweasyl/libweasyl/test/test_html.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import json
 
 from libweasyl import html

--- a/libweasyl/libweasyl/test/test_media.py
+++ b/libweasyl/libweasyl/test/test_media.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import pytest
 
 from libweasyl.test.common import datadir

--- a/libweasyl/libweasyl/test/test_text.py
+++ b/libweasyl/libweasyl/test/test_text.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 from lxml.etree import LIBXML_VERSION
 import pytest
 

--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
-
 import re
 
 from lxml import etree, html

--- a/weasyl/api.py
+++ b/weasyl/api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl.models.meta import Base
 from libweasyl.models.api import APIToken
 from libweasyl import security

--- a/weasyl/avatar.py
+++ b/weasyl/avatar.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from sanpera import geometry
 
 from libweasyl import images

--- a/weasyl/banner.py
+++ b/weasyl/banner.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import media, orm
 
 

--- a/weasyl/blocktag.py
+++ b/weasyl/blocktag.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl import ratings
 from libweasyl.cache import region
 

--- a/weasyl/cache.py
+++ b/weasyl/cache.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import functools
 import time
 

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 import re
 

--- a/weasyl/collection.py
+++ b/weasyl/collection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import blocktag
 from weasyl import define as d
 from weasyl import ignoreuser

--- a/weasyl/comment.py
+++ b/weasyl/comment.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 import arrow
 
 from libweasyl import staff

--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division
-
 import logging
 import re
 from collections import namedtuple

--- a/weasyl/config.py
+++ b/weasyl/config.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from configparser import ConfigParser, NoOptionError, NoSectionError
 
 from weasyl import macro

--- a/weasyl/configuration_builder.py
+++ b/weasyl/configuration_builder.py
@@ -1,8 +1,5 @@
 # TODO(kailys): Doc and create examples
 
-from __future__ import absolute_import
-
-
 class ConfigOption(object):
     "A class representing options for ``Config``."
 

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.response import Response
 

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPForbidden
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.httpexceptions import HTTPUnprocessableEntity

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from urllib.parse import urljoin
 
 from pyramid.httpexceptions import HTTPSeeOther

--- a/weasyl/controllers/decorators.py
+++ b/weasyl/controllers/decorators.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.response import Response
 
 from libweasyl import staff

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid import httpexceptions
 from pyramid.response import Response
 

--- a/weasyl/controllers/director.py
+++ b/weasyl/controllers/director.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.response import Response
 

--- a/weasyl/controllers/events.py
+++ b/weasyl/controllers/events.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPMovedPermanently
 
 

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import itertools
 
 from pyramid.response import Response

--- a/weasyl/controllers/info.py
+++ b/weasyl/controllers/info.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.response import Response
 
 from libweasyl import staff

--- a/weasyl/controllers/interaction.py
+++ b/weasyl/controllers/interaction.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.response import Response
 

--- a/weasyl/controllers/marketplace.py
+++ b/weasyl/controllers/marketplace.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.response import Response
 
 from weasyl import define, media, commishinfo

--- a/weasyl/controllers/messages.py
+++ b/weasyl/controllers/messages.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import itertools
 
 from pyramid.httpexceptions import HTTPSeeOther

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from __future__ import absolute_import
-
 import arrow
 
 from pyramid.httpexceptions import HTTPSeeOther

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid import httpexceptions
 from pyramid.response import Response
 

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import namedtuple
 
 from weasyl.controllers import (

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 
 from pyramid.httpexceptions import HTTPSeeOther

--- a/weasyl/controllers/two_factor_auth.py
+++ b/weasyl/controllers/two_factor_auth.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import arrow
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPSeeOther

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from urllib.parse import urlparse
 
 import arrow

--- a/weasyl/controllers/weasyl_collections.py
+++ b/weasyl/controllers/weasyl_collections.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.httpexceptions import HTTPSeeOther
 from pyramid.response import Response
 

--- a/weasyl/cron.py
+++ b/weasyl/cron.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 from twisted.python import log
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import os
 import time
 import random

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 from email.mime.text import MIMEText
 from smtplib import SMTP

--- a/weasyl/embed.py
+++ b/weasyl/embed.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 import string
 from urllib.parse import urlsplit

--- a/weasyl/error.py
+++ b/weasyl/error.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from sqlalchemy.exc import DBAPIError as PostgresError
 
 from libweasyl.exceptions import WeasylError as _WeasylError

--- a/weasyl/errorcode.py
+++ b/weasyl/errorcode.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 userid = "This user doesn't seem to be in our database."
 submitid = "This submission doesn't seem to be in our database."
 charid = "This character doesn't seem to be in our database."

--- a/weasyl/favorite.py
+++ b/weasyl/favorite.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import collection
 from weasyl import define as d
 from weasyl import frienduser

--- a/weasyl/files.py
+++ b/weasyl/files.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import glob
 import errno

--- a/weasyl/folder.py
+++ b/weasyl/folder.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from collections import defaultdict
 
 import sqlalchemy as sa

--- a/weasyl/followuser.py
+++ b/weasyl/followuser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl import ratings
 
 from weasyl import define as d

--- a/weasyl/frienduser.py
+++ b/weasyl/frienduser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import define as d
 from weasyl import ignoreuser
 from weasyl import media

--- a/weasyl/http.py
+++ b/weasyl/http.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 
 def get_headers(wsgi_env):
     """

--- a/weasyl/ignoreuser.py
+++ b/weasyl/ignoreuser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl import staff
 from libweasyl.cache import region
 

--- a/weasyl/image.py
+++ b/weasyl/image.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import logging
 import os
 

--- a/weasyl/index.py
+++ b/weasyl/index.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 import itertools
 import operator

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 
 from libweasyl import ratings

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 from io import open
 

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 
 from libweasyl import ratings

--- a/weasyl/media.py
+++ b/weasyl/media.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl import images
 from libweasyl import media as libweasylmedia
 from libweasyl.text import slug_for

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from itertools import chain
 
 from weasyl import character

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, print_function
-
 import os
 import re
 import sys

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import collections
 import datetime
 

--- a/weasyl/note.py
+++ b/weasyl/note.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 
 from libweasyl import staff

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import json
 from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
 from pyramid.response import Response

--- a/weasyl/orm.py
+++ b/weasyl/orm.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from libweasyl.models.api import OAuthBearerToken, OAuthConsumer, APIToken
 from libweasyl.models.content import Character, Comment, Journal, Submission
 from libweasyl.models.media import (

--- a/weasyl/pagination.py
+++ b/weasyl/pagination.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 
 class PaginatedResult(object):
     # We expect select_list to have at least the following keyword arguments:

--- a/weasyl/polecat.py
+++ b/weasyl/polecat.py
@@ -3,8 +3,6 @@
 Just bear with me here.
 """
 
-from __future__ import absolute_import, division
-
 import time
 
 from twisted.application.service import Service

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytz
 import sqlalchemy as sa
 

--- a/weasyl/report.py
+++ b/weasyl/report.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import aliased, contains_eager, joinedload

--- a/weasyl/resetpassword.py
+++ b/weasyl/resetpassword.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from __future__ import absolute_import
-
 import hashlib
 import string
 from collections import namedtuple

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from __future__ import absolute_import
-
 import re
 
 from libweasyl.ratings import GENERAL, MATURE, EXPLICIT

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 import sqlalchemy as sa
 

--- a/weasyl/shout.py
+++ b/weasyl/shout.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 
 from libweasyl import staff

--- a/weasyl/siteupdate.py
+++ b/weasyl/siteupdate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 
 from libweasyl import staff

--- a/weasyl/staff_config.py
+++ b/weasyl/staff_config.py
@@ -2,8 +2,6 @@
 Retrieve a dictionary of Weasyl staff.
 """
 
-from __future__ import absolute_import
-
 import ast
 
 from weasyl import macro

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division
-
 import re
 from io import BytesIO
 from urllib.parse import urlparse

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -1,8 +1,6 @@
 # pytest configuration for weasyl db test fixture.
 # The filename conftest.py is magical, do not change.
 
-from __future__ import absolute_import
-
 import errno
 import json
 import os

--- a/weasyl/test/db_utils.py
+++ b/weasyl/test/db_utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import itertools
 
 import arrow

--- a/weasyl/test/login/test_authenticate_bcrypt.py
+++ b/weasyl/test/login/test_authenticate_bcrypt.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 import pytest
 import json
 

--- a/weasyl/test/login/test_create.py
+++ b/weasyl/test/login/test_create.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import arrow
 

--- a/weasyl/test/login/test_get_account_verification_token.py
+++ b/weasyl/test/login/test_get_account_verification_token.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import arrow
 

--- a/weasyl/test/login/test_password_secure.py
+++ b/weasyl/test/login/test_password_secure.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import login
 
 

--- a/weasyl/test/login/test_signin.py
+++ b/weasyl/test/login/test_signin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from datetime import datetime
 import pytz
 import pytest

--- a/weasyl/test/login/test_verify.py
+++ b/weasyl/test/login/test_verify.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 import arrow
 

--- a/weasyl/test/resetpassword/conftest.py
+++ b/weasyl/test/resetpassword/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import re
 
 import pytest

--- a/weasyl/test/resetpassword/test_force.py
+++ b/weasyl/test/resetpassword/test_force.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl import resetpassword, login

--- a/weasyl/test/resetpassword/test_prepare.py
+++ b/weasyl/test/resetpassword/test_prepare.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import hashlib
 
 import pytest

--- a/weasyl/test/resetpassword/test_request.py
+++ b/weasyl/test/resetpassword/test_request.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl import resetpassword

--- a/weasyl/test/resetpassword/test_reset.py
+++ b/weasyl/test/resetpassword/test_reset.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import bcrypt
 

--- a/weasyl/test/searchtag/test_associate.py
+++ b/weasyl/test/searchtag/test_associate.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from libweasyl import staff

--- a/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from libweasyl import staff

--- a/weasyl/test/searchtag/test_edit_user_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_edit_user_tag_restrictions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from weasyl import searchtag

--- a/weasyl/test/searchtag/test_get_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_get_tag_restrictions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from libweasyl import staff

--- a/weasyl/test/searchtag/test_parse_restricted_tags.py
+++ b/weasyl/test/searchtag/test_parse_restricted_tags.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from weasyl import searchtag
 
 

--- a/weasyl/test/test_api.py
+++ b/weasyl/test/test_api.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_character.py
+++ b/weasyl/test/test_character.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_collection.py
+++ b/weasyl/test/test_collection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_comment.py
+++ b/weasyl/test/test_comment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import unittest
 

--- a/weasyl/test/test_configuration_builder.py
+++ b/weasyl/test/test_configuration_builder.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 from weasyl.configuration_builder import (
     BoolOption, ConfigOption, DuplicateCode, InvalidValue, create_configuration)

--- a/weasyl/test/test_define.py
+++ b/weasyl/test/test_define.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 from pyramid.threadlocal import get_current_request
 import pytest
 

--- a/weasyl/test/test_favorite.py
+++ b/weasyl/test/test_favorite.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_folders.py
+++ b/weasyl/test/test_folders.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_followuser.py
+++ b/weasyl/test/test_followuser.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 from unittest import mock
 

--- a/weasyl/test/test_http.py
+++ b/weasyl/test/test_http.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl import http

--- a/weasyl/test/test_journal.py
+++ b/weasyl/test/test_journal.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import pytest
 

--- a/weasyl/test/test_marketplace.py
+++ b/weasyl/test/test_marketplace.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import datetime
 
 import arrow

--- a/weasyl/test/test_media.py
+++ b/weasyl/test/test_media.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import contextlib
 
 import pytest

--- a/weasyl/test/test_pagination.py
+++ b/weasyl/test/test_pagination.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import unittest
 import weasyl.pagination as pagination
 

--- a/weasyl/test/test_profile.py
+++ b/weasyl/test/test_profile.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 import pytest
 import unittest

--- a/weasyl/test/test_search.py
+++ b/weasyl/test/test_search.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from unittest import mock
 
 import pytest

--- a/weasyl/test/test_submission.py
+++ b/weasyl/test/test_submission.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import datetime
 import unittest
 import pytest

--- a/weasyl/test/test_two_factor_auth.py
+++ b/weasyl/test/test_two_factor_auth.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import re
 from urllib.parse import quote as urlquote
 

--- a/weasyl/test/useralias/test_select.py
+++ b/weasyl/test/useralias/test_select.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl.test import db_utils

--- a/weasyl/test/useralias/test_set.py
+++ b/weasyl/test/useralias/test_set.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from libweasyl.models.helpers import CharSettings

--- a/weasyl/test/utils.py
+++ b/weasyl/test/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 
 class Bag(object):
     """

--- a/weasyl/test/web/common.py
+++ b/weasyl/test/web/common.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division
-
 import os
 from io import BytesIO
 

--- a/weasyl/test/web/conftest.py
+++ b/weasyl/test/web/conftest.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division
-
 import pytest
 
 from weasyl.test import db_utils

--- a/weasyl/test/web/test_api.py
+++ b/weasyl/test/web/test_api.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division
-
 import pytest
 import webtest
 

--- a/weasyl/test/web/test_blacklist.py
+++ b/weasyl/test/web/test_blacklist.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 import pytest
 
 from libweasyl import ratings

--- a/weasyl/test/web/test_characters.py
+++ b/weasyl/test/web/test_characters.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import
-
 import os
 import pytest
 import webtest

--- a/weasyl/test/web/test_folders.py
+++ b/weasyl/test/web/test_folders.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl.test import db_utils

--- a/weasyl/test/web/test_journals.py
+++ b/weasyl/test/web/test_journals.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from __future__ import absolute_import
-
 import arrow
 import pytest
 

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pyotp
 import pytest
 

--- a/weasyl/test/web/test_notes.py
+++ b/weasyl/test/web/test_notes.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from weasyl import define as d

--- a/weasyl/test/web/test_site_updates.py
+++ b/weasyl/test/web/test_site_updates.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import pytest
 
 from libweasyl import staff

--- a/weasyl/test/web/test_submissions.py
+++ b/weasyl/test/web/test_submissions.py
@@ -1,6 +1,4 @@
 # encoding: utf-8
-from __future__ import absolute_import, division
-
 import hashlib
 import re
 import threading

--- a/weasyl/thumbnail.py
+++ b/weasyl/thumbnail.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 from sanpera import geometry
 

--- a/weasyl/two_factor_auth.py
+++ b/weasyl/two_factor_auth.py
@@ -1,8 +1,6 @@
 """
 Module for handling 2FA-related functions.
 """
-from __future__ import absolute_import, unicode_literals
-
 import re
 import string
 from urllib.parse import quote as urlquote

--- a/weasyl/useralias.py
+++ b/weasyl/useralias.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from weasyl import define as d
 from weasyl import login
 from weasyl.error import WeasylError

--- a/weasyl/welcome.py
+++ b/weasyl/welcome.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import arrow
 import sqlalchemy as sa
 

--- a/weasyl/wsgi.py
+++ b/weasyl/wsgi.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from pyramid.config import Configurator
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.response import Response


### PR DESCRIPTION
The future is now, so let's remove ``__future__`` imports! 🎉

(Note: I think I cut this branch from ``upstream/master`` prior to the forced update removing c005258700509ce7444863a8cc5d82a8e4e3c4e5 (which would have set 8.1.2 as the version in use) -- I am not sure how to remedy this and remove that commit from this branch, but I did synchronize the ``Pillow`` versions with ``6.2.2``, as is currently on ``master``)