### PR TITLE
Docker fixes

### DIFF
--- a/README-docker.md
+++ b/README-docker.md
@@ -101,7 +101,7 @@ containers/run \
 ## Nginx
 
 ```shell
-mkdir -p weasyl-web
+mkdir -p weasyl-web storage/static
 docker cp weasyl-web:/weasyl/build weasyl-web/
 containers/run-nginx
 ```

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -9,11 +9,11 @@ run_periodic_tasks = false
 profile_responses = false
 
 [sqlalchemy]
-# url = postgresql+psycopg2cffi://weasyl@weasyl-database/weasyl
-url = postgresql+psycopg2cffi:///weasyl
+url = postgresql+psycopg2cffi://weasyl@weasyl-database/weasyl
+# url = postgresql+psycopg2cffi:///weasyl
 
 [memcached]
-# servers = weasyl-memcached
+servers = weasyl-memcached
 
 [sentry]
 # dsn = twisted+http://...

--- a/containers/run
+++ b/containers/run
@@ -3,7 +3,7 @@ set -eu
 exec docker run --rm -it \
     `#--runtime=runsc` \
     --security-opt=no-new-privileges \
-    --user="$UID:$(id -g)" \
+    --user="$(id -u):$(id -g)" \
     --read-only \
     --init \
     --tmpfs=/tmp \

--- a/containers/run-nginx
+++ b/containers/run-nginx
@@ -9,8 +9,8 @@ containers/run \
     "$(containers/mount containers/nginx.conf /etc/nginx/nginx.conf)" \
     "$(containers/mount weasyl-web/build /weasyl/build)" \
     "$(containers/mount storage/static /weasyl/static)" \
-    --tmpfs=/var/cache/nginx:uid="$UID" \
-    --tmpfs=/run:uid="$UID" \
+    --tmpfs=/var/cache/nginx:uid="$(id -u)" \
+    --tmpfs=/run:uid="$(id -u)" \
     --publish=127.0.0.1:80:8080/tcp \
     nginx:mainline-alpine
 docker stop weasyl-nginx


### PR DESCRIPTION
Looking back to #885, a few lingering issues that are resolved (and eliminates the troubleshooting section entirely, and avoids re-symlinking ``sh`` to ``bash`` (which may or may not cause further issues, since Ubuntu might not expect it)):

- Adds ``storage/static`` as a created directory. (The nginx step would otherwise complain about this not existing.)
- Uncomments lines in ``site.config.txt.example``, permitting the template file to be used as-is without manually uncommenting the lines.
- Since Ubuntu is symlinking `/bin/sh` to `dash`, when on Ubuntu as a host invocations of the Docker scripts fails (`containers/run: 3: UID: parameter not set`). Converts usages of `$UID` to `$(id -u)`.

This was created by running through `README-docker.md` top-to-bottom, to ensure everything works as expected.