### PR TITLE
Remove measurement of time a request spends queued

### DIFF
--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -51,19 +51,13 @@ def db_timer_tween_factory(handler, registry):
     """
     def db_timer_tween(request):
         started_at = time.time()
-        queued_at = request.environ.get('HTTP_X_REQUEST_STARTED_AT')
-        if queued_at is None:
-            return handler(request)
-
         request.sql_times = []
         request.memcached_times = []
-        time_queued = started_at - float(queued_at)
         resp = handler(request)
         ended_at = time.time()
         time_in_sql = sum(request.sql_times)
         time_in_memcached = sum(request.memcached_times)
         time_in_python = ended_at - started_at - time_in_sql - time_in_memcached
-        resp.headers['X-Queued-Time-Spent'] = '%0.1fms' % (time_queued * 1000,)
         resp.headers['X-SQL-Time-Spent'] = '%0.1fms' % (time_in_sql * 1000,)
         resp.headers['X-Memcached-Time-Spent'] = '%0.1fms' % (time_in_memcached * 1000,)
         resp.headers['X-Python-Time-Spent'] = '%0.1fms' % (time_in_python * 1000,)

--- a/weasyl/polecat.py
+++ b/weasyl/polecat.py
@@ -16,12 +16,6 @@ class WeasylSite(Site):
     def log(self, request):
         "Do nothing; we don't need request logging."
 
-    def getResourceFor(self, request):
-        resource = Site.getResourceFor(self, request)
-        now = time.time()
-        request.requestHeaders.addRawHeader('X-Request-Started-At', '%0.8f' % now)
-        return resource
-
 
 class PeriodicTasksService(Service):
     def __init__(self, clock, taskFunction, interval=60):


### PR DESCRIPTION
because since Twisted 16.3.0, requests never spend time queued. See the relevant deprecation notices at https://twistedmatrix.com/documents/21.2.0/api/twisted.web.http.Request.html (“in 16.3 this method was changed to become a no-op, as Request objects are now never queued”) and https://twistedmatrix.com/trac/ticket/8320.

This should be followed up with the removal of `(queued: $sent_http_x_queued_time_spent)` from the Nginx timing log configuration.

- [ ] update Nginx timing log configuration (@charmander)