### PR TITLE
Time request handling parts with monotonic `clock.perf_counter`

### DIFF
--- a/weasyl/cache.py
+++ b/weasyl/cache.py
@@ -8,9 +8,9 @@ from pyramid.threadlocal import get_current_request
 def _increments(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        start = time.time()
+        start = time.perf_counter()
         result = func(self, *args, **kwargs)
-        end = time.time()
+        end = time.perf_counter()
 
         request = get_current_request()
         if hasattr(request, 'memcached_times'):

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -50,11 +50,11 @@ def db_timer_tween_factory(handler, registry):
     A tween that records timing information in the headers of a response.
     """
     def db_timer_tween(request):
-        started_at = time.time()
+        started_at = time.perf_counter()
         request.sql_times = []
         request.memcached_times = []
         resp = handler(request)
-        ended_at = time.time()
+        ended_at = time.perf_counter()
         time_in_sql = sum(request.sql_times)
         time_in_memcached = sum(request.memcached_times)
         time_in_python = ended_at - started_at - time_in_sql - time_in_memcached
@@ -497,12 +497,12 @@ class InputWrapMiddleware(object):
 
 @event.listens_for(Engine, 'before_cursor_execute')
 def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    context._query_start_time = time.time()
+    context._query_start_time = time.perf_counter()
 
 
 @event.listens_for(Engine, 'after_cursor_execute')
 def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    total = time.time() - context._query_start_time
+    total = time.perf_counter() - context._query_start_time
     request = get_current_request()  # TODO: There should be a better way to save this.
     if hasattr(request, 'sql_times'):
         request.sql_times.append(total)


### PR DESCRIPTION
Python 3!

In addition to being monotonic, operations on its return values are more precise, because zero is closer in time – but that effect is a decimal place or two past what we even display.