### PR TITLE
Pillow 8

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -19,7 +19,7 @@ bcrypt==3.2.0
 dogpile.cache==0.9.2
 #lxml ...
 oauthlib==2.1.0
-Pillow==6.2.2
+Pillow==8.1.2
 psycopg2cffi==2.9.0
 #pyramid ...
 pytz==2020.4

--- a/libweasyl/setup.py
+++ b/libweasyl/setup.py
@@ -31,7 +31,7 @@ setup(
         'lxml==4.6.2',
         'misaka==1.0.3+weasyl.6',    # https://github.com/Weasyl/misaka
         'oauthlib==2.1.0',
-        'Pillow==6.2.2',
+        'Pillow==8.1.2',
         'psycopg2cffi==2.9.0',
         'pyramid~=2.0',
         'pytz==2020.4',

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -520,12 +520,19 @@ def reupload(userid, submitid, submitfile):
     if subcat == m.ART_SUBMISSION_CATEGORY:
         cover_media_item = submit_media_item.ensure_cover_image(im)
         orm.SubmissionMediaLink.make_or_replace_link(submitid, 'cover', cover_media_item)
-        generated_thumb = images.make_thumbnail(im)
-        generated_thumb_media_item = orm.MediaItem.fetch_or_create(
-            generated_thumb.to_buffer(format=images.image_file_type(generated_thumb)),
-            file_type=submit_file_type,
-            im=generated_thumb)
-        orm.SubmissionMediaLink.make_or_replace_link(submitid, 'thumbnail-generated', generated_thumb_media_item)
+
+        # Always create a 'generated' thumbnail from the source image.
+        with BytesIO(submitfile) as buf:
+            thumbnail_formats = images_new.get_thumbnail(buf)
+
+        thumb_generated, thumb_generated_file_type, thumb_generated_attributes = thumbnail_formats.compatible
+        thumb_generated_media_item = orm.MediaItem.fetch_or_create(
+            thumb_generated,
+            file_type=thumb_generated_file_type,
+            attributes=thumb_generated_attributes,
+        )
+
+        orm.SubmissionMediaLink.make_or_replace_link(submitid, 'thumbnail-generated', thumb_generated_media_item)
 
 
 def select_view(userid, submitid, rating, ignore=True, anyway=None):


### PR DESCRIPTION
- Upgrade Pillow from 6.2.2 to 8.1.2
- Use Pillow (images_new) for thumbnailing on reuploads, for consistency with the initial upload.