### PR TITLE
Remove inter-media links

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/259bc2d8e46c_remove_inter_media_links.py
+++ b/libweasyl/libweasyl/alembic/versions/259bc2d8e46c_remove_inter_media_links.py
@@ -1,0 +1,36 @@
+"""Remove inter-media links
+
+Revision ID: 259bc2d8e46c
+Revises: 67e810c14252
+Create Date: 2021-06-26 18:09:59.780429
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '259bc2d8e46c'
+down_revision = '67e810c14252'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_index('ind_media_media_links_described_with_id', table_name='media_media_links')
+    op.drop_index('ind_media_media_links_describee_id', table_name='media_media_links')
+    op.drop_index('ind_media_media_links_submitid', table_name='media_media_links')
+    op.drop_table('media_media_links')
+
+
+def downgrade():
+    op.create_table('media_media_links',
+    sa.Column('linkid', sa.INTEGER(), autoincrement=True, nullable=False),
+    sa.Column('described_with_id', sa.INTEGER(), autoincrement=False, nullable=False),
+    sa.Column('describee_id', sa.INTEGER(), autoincrement=False, nullable=False),
+    sa.Column('link_type', sa.VARCHAR(length=32), autoincrement=False, nullable=False),
+    sa.ForeignKeyConstraint(['described_with_id'], ['media.mediaid'], name='media_media_links_described_with_id_fkey', onupdate='CASCADE', ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['describee_id'], ['media.mediaid'], name='media_media_links_describee_id_fkey', onupdate='CASCADE', ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('linkid', name='media_media_links_pkey')
+    )
+    op.create_index('ind_media_media_links_submitid', 'media_media_links', ['describee_id'], unique=False)
+    op.create_index('ind_media_media_links_describee_id', 'media_media_links', ['describee_id'], unique=False)
+    op.create_index('ind_media_media_links_described_with_id', 'media_media_links', ['described_with_id'], unique=False)

--- a/libweasyl/libweasyl/models/content.py
+++ b/libweasyl/libweasyl/models/content.py
@@ -53,9 +53,6 @@ class Submission(Base):
     @reify
     def cover_media(self):
         ret = self.media.get('cover')
-        # TODO: this should be unnecessary
-        if not ret and self.submission_media:
-            ret = self.submission_media['described'].get('cover')
         if ret:
             return ret[0]
         return None

--- a/libweasyl/libweasyl/models/media.py
+++ b/libweasyl/libweasyl/models/media.py
@@ -1,4 +1,3 @@
-import collections
 import hashlib
 from io import BytesIO
 import os
@@ -140,11 +139,11 @@ class _LinkMixin(object):
         for load in cls._load:
             q = q.options(joinedload(load))
 
-        buckets = collections.defaultdict(lambda: collections.defaultdict(list))
+        buckets = {identity: {} for identity in identities}
         for link in q.all():
             media_data = link.media_item.serialize(link=link)
-            buckets[getattr(link, cls._identity)][link.link_type].append(media_data)
-        return [dict(buckets[identity]) for identity in identities]
+            buckets[getattr(link, cls._identity)].setdefault(link.link_type, []).append(media_data)
+        return list(buckets.values())
 
     @classmethod
     def register_cache(cls, func):

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -367,21 +367,6 @@ media = Table(
 Index('ind_media_sha256', media.c.sha256)
 
 
-media_media_links = Table(
-    'media_media_links', metadata,
-    Column('linkid', Integer(), primary_key=True, nullable=False),
-    Column('described_with_id', Integer(), nullable=False),
-    Column('describee_id', Integer(), nullable=False),
-    Column('link_type', String(length=32), nullable=False),
-    default_fkey(['describee_id'], ['media.mediaid'], name='media_media_links_describee_id_fkey'),
-    default_fkey(['described_with_id'], ['media.mediaid'], name='media_media_links_described_with_id_fkey'),
-)
-
-Index('ind_media_media_links_describee_id', media_media_links.c.describee_id)
-Index('ind_media_media_links_submitid', media_media_links.c.describee_id)
-Index('ind_media_media_links_described_with_id', media_media_links.c.described_with_id, unique=False)
-
-
 message = Table(
     'message', metadata,
     Column('noteid', Integer(), primary_key=True, nullable=False),

--- a/libweasyl/libweasyl/models/test/test_media.py
+++ b/libweasyl/libweasyl/models/test/test_media.py
@@ -1,14 +1,13 @@
 import pytest
 
 from libweasyl.models import media
-from libweasyl.test.common import media_item, make_user, make_submission, make_media
+from libweasyl.test.common import media_item, make_user, make_submission
 
 
 link_types_names = 'cls', 'linked_attr', 'link_attr', 'media_attr', 'generator'
 link_types = [
     (media.UserMediaLink, 'userid', 'userid', 'mediaid', make_user),
     (media.SubmissionMediaLink, 'submitid', 'submitid', 'mediaid', make_submission),
-    (media.MediaMediaLink, 'mediaid', 'describee_id', 'described_with_id', make_media),
 ]
 
 
@@ -72,16 +71,3 @@ def test_clearing_media_links(db, cls, linked_attr, link_attr, media_attr, gener
     cls.make_or_replace_link(getattr(linked, linked_attr), 'test', item)
     cls.clear_link(getattr(linked, linked_attr), 'test')
     assert cls.query.count() == 0
-
-
-def test_self_media_links(db):
-    """
-    Media items can be linked to themselves.
-    """
-    item = media_item(db, '1200x6566.png')
-    media.MediaMediaLink.make_or_replace_link(item.mediaid, 'test', item)
-    [link] = media.MediaMediaLink.query.all()
-    assert link.link_type == 'test'
-    assert link.described_with_id == item.mediaid
-    assert link.describee_id == item.mediaid
-    assert link.media_item is link.describee

--- a/libweasyl/libweasyl/test/common.py
+++ b/libweasyl/libweasyl/test/common.py
@@ -91,15 +91,3 @@ def make_submission(db):
     db.add(sub)
     db.flush()
     return sub
-
-
-def make_media(db):
-    """
-    Create a new media item.
-
-    The file used for the media item is fixed: the data file '2x233.gif'.
-
-    Returns:
-        A MediaItem.
-    """
-    return media_item(db, '2x233.gif')

--- a/weasyl-apidocs/source/index.rst
+++ b/weasyl-apidocs/source/index.rst
@@ -265,14 +265,6 @@ Slightly different keys are returned for the
       "media": {
          "submission": [
             {
-               "links": {
-                  "cover": [
-                     {
-                        "mediaid": 1009285,
-                        "url": "https://www.weasyl.com/static/media/41/eb/c1/41ebc1c2940be928532785dfbf35c37622664d2fbb8114c3b063df969562fc51.png"
-                     }
-                  ]
-               },
                "mediaid": 1009285,
                "url": "https://www.weasyl.com/~fiz/submissions/2031/41ebc1c2940be928532785dfbf35c37622664d2fbb8114c3b063df969562fc51/fiz-a-wesley.png"
             }
@@ -376,14 +368,6 @@ A basic character object resembles::
       "media": {
          "submission": [
             {
-               "links": {
-                     "cover": [
-                        {
-                           "mediaid": null,
-                           "url": "https://cdn.weasyl.com/static/character/94/4d/a7/e0/a0/7a/wesley-63670.cover.png"
-                        }
-                     ]
-               },
                "mediaid": null,
                "url": "https://cdn.weasyl.com/static/character/94/4d/a7/e0/a0/7a/wesley-63670.submit.2000.png"
             }
@@ -544,11 +528,6 @@ file stored by Weasyl. The *url* is one possible URL where the file can be
 downloaded. There can be multiple possible *url*\ s for a given *mediaid*. A
 *mediaid* can also be ``null`` to indicate the *url* is already unambiguous.
 
-A media file object may also have another key: *links*. The *links* key is
-itself a media key, and allows media files to be linked to other media files.
-Currently, the only kind of link is ``"cover"``, which links a media file to
-its :term:`cover image`.
-
 For submissions, the possible descriptive names are ``"submission"`` for the
 original file uploaded by the user, ``"cover"`` for the submission's
 :term:`cover image`, and ``"thumbnail"`` for the submission's thumbnail. The
@@ -564,14 +543,6 @@ Here is an example of the media for a visual submission::
   {
     "submission": [
       {
-        "links": {
-          "cover": [
-            {
-              "mediaid": 1651999,
-              "url": "https://www.weasyl.com/static/media/..."
-            }
-          ]
-        },
         "mediaid": 1651999,
         "url": "https://www.weasyl.com/static/media/..."
       }
@@ -584,14 +555,6 @@ Here is an example of the media for a visual submission::
     ],
     "cover": [
       {
-        "links": {
-          "cover": [
-            {
-              "mediaid": 1651999,
-              "url": "https://www.weasyl.com/static/media/..."
-            }
-          ]
-        },
         "mediaid": 1651999,
         "url": "https://www.weasyl.com/static/media/..."
       }

--- a/weasyl/api.py
+++ b/weasyl/api.py
@@ -29,13 +29,10 @@ def delete_api_keys(userid, keys):
 
 
 def tidy_media(item):
-    ret = {
+    return {
         'url': d.absolutify_url(item['display_url']),
         'mediaid': item.get('mediaid'),
     }
-    if item.get('described'):
-        ret['links'] = tidy_all_media(item['described'])
-    return ret
 
 
 def tidy_all_media(d):

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -425,21 +425,11 @@ def fake_media_items(charid, userid, login, settings):
     return {
         "submission": [{
             "display_url": submission_url,
-            "described": {
-                "cover": [{
-                    "display_url": cover_url,
-                }],
-            },
         }],
         "thumbnail-generated": [{
             "display_url": thumbnail_url,
         }],
         "cover": [{
             "display_url": cover_url,
-            "described": {
-                "submission": [{
-                    "display_url": submission_url,
-                }],
-            },
         }],
     }

--- a/weasyl/orm.py
+++ b/weasyl/orm.py
@@ -1,7 +1,7 @@
 from libweasyl.models.api import OAuthBearerToken, OAuthConsumer, APIToken
 from libweasyl.models.content import Character, Comment, Journal, Submission
 from libweasyl.models.media import (
-    MediaItem, SubmissionMediaLink, UserMediaLink, MediaMediaLink)
+    MediaItem, SubmissionMediaLink, UserMediaLink)
 from libweasyl.models.users import Follow, Login, Profile, Session, UserTimezone
 
 
@@ -17,7 +17,7 @@ class CommishPrice(object):
 
 __all__ = [
     'Character', 'Comment', 'Journal', 'Submission',
-    'MediaItem', 'SubmissionMediaLink', 'UserMediaLink', 'MediaMediaLink',
+    'MediaItem', 'SubmissionMediaLink', 'UserMediaLink',
     'OAuthBearerToken', 'OAuthConsumer', 'APIToken',
     'Follow', 'Login', 'Profile', 'Session', 'UserTimezone',
     'CommishClass', 'CommishPrice',

--- a/weasyl/templates/detail/character.html
+++ b/weasyl/templates/detail/character.html
@@ -5,9 +5,8 @@ $def with (myself, query, violations)
   <h1 id="detail-title" class="pad-left pad-right">${query['title']} <i>by</i> <a class="username" href="/~${LOGIN(query['username'])}">${query['username']}</a></h1>
 
   <div id="detail-art">
-    $ submissions = query['sub_media'].get('submission')
-    $ submission = submissions[0]
-    $ cover = submission['described']['cover'][0]
+    $ submission = query['sub_media']['submission'][0]
+    $ cover = query['sub_media']['cover'][0]
     <a href="${submission['display_url']}">
       <img src="${cover['display_url']}" alt="" />
     </a>

--- a/weasyl/test/web/test_api.py
+++ b/weasyl/test/web/test_api.py
@@ -41,7 +41,6 @@ def test_submission_view(app, submission_user):
     }
     assert set(media) == {'thumbnail', 'submission', 'cover', 'thumbnail-generated-webp', 'thumbnail-generated'}
     assert type(media['submission'][0].pop('mediaid')) is int
-    assert set(media['submission'][0].pop('links')) == {'cover'}
     assert media['submission'] == [{
         'url': 'http://localhost/~submissiontest/submissions/%i/ca23760d8ca4bf6c2d721f5b02e389627b6b9181d5f323001f2d5801c086407b/submissiontest-test-title.png' % (submission,),
     }]


### PR DESCRIPTION
They add a lot of complexity along with other types of overhead, and are generated lazily in confusing ways while providing only a small benefit (not regenerating covers when identical submission files are reuploaded).

This slightly breaks the public HTTP API’s backwards-compatibility, but anything making use of the removed properties is already broken.

Can be deployed safely without running the migration, making it reversible (except for the missing links on new media).