### PR TITLE
Remove Google CAPTCHA

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -4341,8 +4341,6 @@ img + #detail-art-text {
     visibility: hidden;
 }
 
-#recaptcha_table { table-layout: auto !important; }
-
 /* ------------------------------------ =kihari --*/
 .thumbnail_list_item {
     padding-bottom: 1em;

--- a/ci/site.config.txt
+++ b/ci/site.config.txt
@@ -1,6 +1,5 @@
 [general]
 allow_submit = true
-captcha_disable_verification = true
 # Whether currency exchange rates should be fetched for /marketplace
 convert_currency = false
 
@@ -19,10 +18,6 @@ servers = weasyl-memcached
 
 [smtp]
 host = localhost
-
-[recaptcha-lo.weasyl.com]
-public_key = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-private_key = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 
 [two_factor_auth]
 # This key MUST be changed when in production;

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -1,6 +1,5 @@
 [general]
 allow_submit = true
-captcha_disable_verification = true
 # Whether currency exchange rates should be fetched for /marketplace
 convert_currency = false
 
@@ -20,10 +19,6 @@ servers = memcached
 
 [smtp]
 host = localhost
-
-[recaptcha-lo.weasyl.com]
-public_key = 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
-private_key = 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
 
 [two_factor_auth]
 # This key MUST be changed when in production;

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -10,6 +10,7 @@ from libweasyl.text import markdown, slug_for
 from weasyl import (
     character, comment, define, folder, journal, macro, profile,
     report, searchtag, shout, submission, orm)
+from weasyl.config import config_read_bool
 from weasyl.controllers.decorators import login_required, supports_json, token_checked
 from weasyl.error import WeasylError
 from weasyl.login import get_user_agent_id
@@ -52,7 +53,7 @@ def submit_visual_post_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    if not define.config_read_bool("allow_submit"):
+    if not config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
     if not define.is_vouched_for(request.userid):
@@ -105,7 +106,7 @@ def submit_literary_post_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    if not define.config_read_bool("allow_submit"):
+    if not config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
     if not define.is_vouched_for(request.userid):
@@ -157,7 +158,7 @@ def submit_multimedia_post_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    if not define.config_read_bool("allow_submit"):
+    if not config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
     if not define.is_vouched_for(request.userid):
@@ -208,7 +209,7 @@ def submit_character_post_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    if not define.config_read_bool("allow_submit"):
+    if not config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
     if not define.is_vouched_for(request.userid):
@@ -249,7 +250,7 @@ def submit_journal_post_(request):
 
     tags = searchtag.parse_tags(form.tags)
 
-    if not define.config_read_bool("allow_submit"):
+    if not config_read_bool("allow_submit"):
         raise WeasylError("FeatureDisabled")
 
     if not define.is_vouched_for(request.userid):

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -215,11 +215,6 @@ def signup_post_(request):
         username="", password="", passcheck="", email="", emailcheck="",
         day="", month="", year="")
 
-    if not define.captcha_verify(form.get('g-recaptcha-response')):
-        return Response(define.errorpage(
-            request.userid,
-            "There was an error validating the CAPTCHA response; you should go back and try again."))
-
     login.create(form)
     return Response(define.errorpage(
         request.userid,

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -29,7 +29,7 @@ from libweasyl import html, text, ratings, security, staff
 from weasyl import config
 from weasyl import errorcode
 from weasyl import macro
-from weasyl.config import config_obj, config_read_setting, config_read_bool
+from weasyl.config import config_obj, config_read_setting
 from weasyl.error import WeasylError
 from weasyl.macro import MACRO_SUPPORT_ADDRESS
 
@@ -169,7 +169,6 @@ def _compile(template_name):
                 "TITLE": titlebar,
                 "RENDER": render,
                 "COMPILE": _compile,
-                "CAPTCHA": _captcha_public,
                 "MARKDOWN": text.markdown,
                 "MARKDOWN_EXCERPT": text.markdown_excerpt,
                 "SUMMARIZE": summarize,
@@ -229,38 +228,6 @@ def webpage(userid, template, argv=None, options=None, **extras):
     page.append(render(template, argv))
 
     return common_page_end(userid, page, options=options)
-
-
-def _captcha_section():
-    request = get_current_request()
-    host = request.environ.get('HTTP_HOST', '').partition(':')[0]
-    return 'recaptcha-' + host
-
-
-def _captcha_public():
-    """
-    Returns the reCAPTCHA public key, or None if CAPTCHA verification
-    is disabled.
-    """
-    if config_read_bool("captcha_disable_verification"):
-        return None
-
-    return config_obj.get(_captcha_section(), 'public_key')
-
-
-def captcha_verify(captcha_response):
-    if config_read_bool("captcha_disable_verification"):
-        return True
-    if not captcha_response:
-        return False
-
-    data = dict(
-        secret=config_obj.get(_captcha_section(), 'private_key'),
-        response=captcha_response,
-        remoteip=get_address())
-    response = http_post('https://www.google.com/recaptcha/api/siteverify', data=data)
-    captcha_validation_result = response.json()
-    return captcha_validation_result['success']
 
 
 def get_weasyl_session():

--- a/weasyl/emailer.py
+++ b/weasyl/emailer.py
@@ -3,6 +3,7 @@ from email.mime.text import MIMEText
 from smtplib import SMTP
 
 from weasyl import define, macro
+from weasyl.config import config_read_setting
 
 
 EMAIL_ADDRESS = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+\Z")
@@ -37,7 +38,7 @@ def send(mailto, subject, content):
     # smtp.sendmail() only converts CR and LF (produced by MIMEText and our templates) to CRLF in Python 3. In Python 2, we need this:
     msg_crlf = re.sub(r"\r\n|[\r\n]", "\r\n", message.as_string())
 
-    smtp = SMTP(define.config_read_setting('host', "localhost", section='smtp'))
+    smtp = SMTP(config_read_setting('host', "localhost", section='smtp'))
 
     try:
         smtp.sendmail(

--- a/weasyl/templates/etc/signup.html
+++ b/weasyl/templates/etc/signup.html
@@ -9,34 +9,6 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
     <label for="signup-username">Username</label>
     <input type="text" id="signup-username" class="input" name="username" autofocus required maxlength="25" />
 
-    $ captcha_public_key = CAPTCHA()
-
-    $if captcha_public_key:
-      <label for="g-recaptcha-response">Captcha</label>
-      <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-      <div class="g-recaptcha" data-sitekey="${captcha_public_key}" data-theme="light"></div>
-      <noscript>
-        <div>
-          <div style="width: 302px; height: 422px; position: relative;">
-            <div style="width: 302px; height: 422px; position: absolute;">
-              <iframe src="https://www.google.com/recaptcha/api/fallback?k=${captcha_public_key}"
-                      frameborder="0" scrolling="no"
-                      style="width: 302px; height:422px; border-style: none;">
-              </iframe>
-            </div>
-          </div>
-          <div style="width: 300px; height: 60px; border-style: none;
-                       bottom: 12px; left: 25px; margin: 0px; padding: 0px; right: 25px;
-                       background: #f9f9f9; border: 1px solid #c1c1c1; border-radius: 3px;">
-            <textarea id="g-recaptcha-response" name="g-recaptcha-response"
-                      class="g-recaptcha-response"
-                      style="width: 250px; height: 40px; border: 1px solid #c1c1c1;
-                              margin: 10px 25px; padding: 0px; resize: none;" >
-            </textarea>
-          </div>
-        </div>
-      </noscript>
-
     <div class="form-2up clear">
       <div class="form-2up-1">
         <label for="signup-password">Password</label>

--- a/weasyl/weasyl.tac
+++ b/weasyl/weasyl.tac
@@ -11,6 +11,7 @@ import weasyl.wsgi
 import weasyl.define as d
 from libweasyl import cache
 from weasyl.cache import RequestMemcachedStats
+from weasyl.config import config_read_bool, config_read_setting
 
 threadPool = reactor.getThreadPool()
 
@@ -33,7 +34,7 @@ def attachServerEndpoint(factory, endpointEnvironKey, defaultString):
 
 attachServerEndpoint(site, 'WEASYL_WEB_ENDPOINT', 'tcp:8080:interface=127.0.0.1')
 
-if d.config_read_bool('run_periodic_tasks', section='backend'):
+if config_read_bool('run_periodic_tasks', section='backend'):
     from weasyl.cron import run_periodic_tasks
     weasyl.polecat.PeriodicTasksService(reactor, run_periodic_tasks).setServiceParent(application)
 
@@ -41,7 +42,7 @@ if d.config_read_bool('run_periodic_tasks', section='backend'):
 cache.region.configure(
     'dogpile.cache.pylibmc',
     arguments={
-        'url': d.config_read_setting('servers', "127.0.0.1", section='memcached').split(),
+        'url': config_read_setting('servers', "127.0.0.1", section='memcached').split(),
         'binary': True,
     },
     wrap=[cache.ThreadCacheProxy, cache.JSONProxy, RequestMemcachedStats],

--- a/weasyl/wsgi.py
+++ b/weasyl/wsgi.py
@@ -6,6 +6,7 @@ from libweasyl.configuration import configure_libweasyl
 from weasyl.controllers.routes import setup_routes_and_views
 import weasyl.define as d
 import weasyl.macro as m
+from weasyl.config import config_obj, config_read_bool
 from weasyl.media import format_media_link
 import weasyl.middleware as mw
 from weasyl import staff_config
@@ -48,12 +49,12 @@ config.add_request_method(mw.delete_cookie_on_response)
 wsgi_app = config.make_wsgi_app()
 wsgi_app = mw.InputWrapMiddleware(wsgi_app)
 wsgi_app = mw.URLSchemeFixingMiddleware(wsgi_app)
-if d.config_read_bool('profile_responses', section='backend'):
+if config_read_bool('profile_responses', section='backend'):
     from werkzeug.contrib.profiler import ProfilerMiddleware
     wsgi_app = ProfilerMiddleware(
         wsgi_app, profile_dir=m.MACRO_STORAGE_ROOT + 'profile-stats')
-if d.config_obj.has_option('sentry', 'dsn'):
-    wsgi_app = mw.SentryEnvironmentMiddleware(wsgi_app, d.config_obj.get('sentry', 'dsn'))
+if config_obj.has_option('sentry', 'dsn'):
+    wsgi_app = mw.SentryEnvironmentMiddleware(wsgi_app, config_obj.get('sentry', 'dsn'))
 
 
 configure_libweasyl(


### PR DESCRIPTION
We’re already going through Cloudflare and can use its captcha challenge on the `/signup` path.

Removing this means a better signup experience, less code complexity, slightly less exposure to third parties for Weasyl users, and a slightly nicer Content-Security-Policy when that’s implemented.