### PR TITLE
Remove Dogpile cache key mangler

### DIFF
--- a/libweasyl/libweasyl/cache.py
+++ b/libweasyl/libweasyl/cache.py
@@ -7,8 +7,6 @@ project.
 .. _dogpile.cache: http://dogpilecache.readthedocs.org/en/latest/
 """
 
-import os
-import re
 import threading
 import zlib
 
@@ -19,44 +17,9 @@ from dogpile.cache import make_region
 
 
 _GZIP_THRESHOLD = 1024 * 1024
-_MEMCACHED_PREFIX = os.environ.get('WEASYL_MEMCACHED_PREFIX', '') + ':'
-_bad_key_regexp = re.compile('[\x00-\x20\x7f]')
 
 
-def escape_key(key):
-    """
-    Escape a key so that it is valid for use in memcached.
-
-    Basically, this just removes nonprintable characters and replaces them with
-    a period (i.e. ``.``).
-
-    Parameters:
-        key: A :term:`native string`.
-
-    Returns:
-        An escaped :term:`native string`.
-    """
-    key = str(key)
-    return _bad_key_regexp.sub('.', key)
-
-
-def key_mangler(key):
-    """
-    Transform keys before they are sent to memcached.
-
-    This escapes *key* with :py:func:`escape_key` and then prepends a prefix
-    derived from the :envvar:`WEASYL_MEMCACHED_PREFIX` environment variable.
-
-    Parameters:
-        key: A :term:`native string`.
-
-    Returns:
-        An escaped, prefixed :term:`native string`.
-    """
-    return _MEMCACHED_PREFIX + escape_key(key)
-
-
-region = make_region(key_mangler=key_mangler)
+region = make_region()
 
 
 class ThreadCacheProxy(ProxyBackend):

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -87,7 +87,7 @@ def api_login_required(view_callable):
 @api_method
 def api_useravatar_(request):
     form = request.web_input(username="")
-    userid = profile.resolve_by_login(d.get_sysname(form.username))
+    userid = profile.resolve_by_username(form.username)
 
     if userid:
         media_items = media.get_user_media(userid)
@@ -223,7 +223,7 @@ def api_user_view_(request):
             return None
 
     userid = request.userid
-    otherid = profile.resolve_by_login(d.get_sysname(request.matchdict['login']))
+    otherid = profile.resolve_by_username(request.matchdict['login'])
     user = profile.select_profile(otherid)
 
     rating = d.get_rating(userid)
@@ -333,7 +333,7 @@ def api_user_view_(request):
 @view_config(route_name='api_user_gallery', renderer='json')
 @api_method
 def api_user_gallery_(request):
-    userid = profile.resolve_by_login(d.get_sysname(request.matchdict['login']))
+    userid = profile.resolve_by_username(request.matchdict['login'])
     if not userid:
         raise WeasylError('userRecordMissing')
 

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -125,7 +125,7 @@ def profile_(request):
 def profile_media_(request):
     name = request.matchdict['name']
     link_type = request.matchdict['link_type']
-    userid = profile.resolve_by_login(name)
+    userid = profile.resolve_by_username(name)
     media_items = media.get_user_media(userid)
     if not media_items.get(link_type):
         raise httpexceptions.HTTPNotFound()

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -104,17 +104,15 @@ def resolve(userid, otherid, othername):
         if result:
             return result
     elif othername:
-        return d.get_userids([othername])[othername]
+        return resolve_by_username(othername)
     elif userid:
         return userid
 
     return 0
 
 
-@region.cache_on_arguments()
-@d.record_timing
-def resolve_by_login(login):
-    return resolve(None, None, login)
+def resolve_by_username(username):
+    return d.get_userids([username])[username]
 
 
 def select_profile(userid, viewer=None):

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -78,8 +78,7 @@ def select_list(map_table, targetids):
 
 
 @region.cache_on_arguments()
-def get_or_create(name):
-    name = d.get_search_tag(name)
+def _get_or_create(name):
     tag = d.engine.scalar(
         'INSERT INTO searchtag (title) VALUES (%(name)s) ON CONFLICT (title) DO NOTHING RETURNING tagid',
         name=name)
@@ -90,6 +89,10 @@ def get_or_create(name):
     return d.engine.scalar(
         'SELECT tagid FROM searchtag WHERE title = %(name)s',
         name=name)
+
+
+def get_or_create(name):
+    return _get_or_create(d.get_search_tag(name))
 
 
 def get_ids(names):

--- a/weasyl/test/web/conftest.py
+++ b/weasyl/test/web/conftest.py
@@ -4,5 +4,5 @@ from weasyl.test import db_utils
 
 
 @pytest.fixture
-def submission_user(db):
+def submission_user(db, cache):
     return db_utils.create_user(username='submission_test')

--- a/weasyl/test/web/test_journals.py
+++ b/weasyl/test/web/test_journals.py
@@ -7,8 +7,7 @@ from weasyl.test import db_utils
 
 
 @pytest.fixture(name='journal_user')
-@pytest.mark.usefixtures('db')
-def _journal_user():
+def _journal_user(db, cache):
     return db_utils.create_user(username='journal_test')
 
 
@@ -34,7 +33,7 @@ def test_profile_guest(app):
     assert resp.html.find(id='user-journal').h4.string == u'Public journal'
 
 
-@pytest.mark.usefixtures('db', 'journal_user', 'journals')
+@pytest.mark.usefixtures('db', 'cache', 'journal_user', 'journals')
 def test_profile_user(app):
     user = db_utils.create_user(config=CharSettings(frozenset(), {}, {'tagging-level': 'max-rating-mature'}))
     cookie = db_utils.create_session(user)
@@ -43,7 +42,7 @@ def test_profile_user(app):
     assert resp.html.find(id='user-journal').h4.string == u'Restricted journal'
 
 
-@pytest.mark.usefixtures('db', 'journal_user', 'journals')
+@pytest.mark.usefixtures('db', 'cache', 'journal_user', 'journals')
 def test_profile_friend(app, journal_user):
     user = db_utils.create_user()
     cookie = db_utils.create_session(user)
@@ -60,7 +59,7 @@ def test_list_guest(app):
     assert titles == [u'Public journal', u'Test journal']
 
 
-@pytest.mark.usefixtures('db')
+@pytest.mark.usefixtures('db', 'cache')
 def test_list_unicode_username(app):
     """
     Test journal lists on profiles with usernames containing non-ASCII


### PR DESCRIPTION
It’s a disaster waiting to happen, since it maps distinct inputs to identical outputs. Luckily, the only arbitrary Unicode text passed to a cache function before this was tags, which discard information in a compatible way.

Preprocess before cache lookups to avoid creating keys incompatible with Memcached and also improve hit rate.

Also remove the unused configurable Memcached prefix.