### PR TITLE
Fix test deprecation warnings

### DIFF
--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -19,12 +19,12 @@ def slug_for(title):
 
 
 AUTOLINK_URL = (
-    r"(?P<url>(?isu)\b(?:https?://|www\d{,3}\.|[a-z0-9.-]+\.[a-z]{2,4}/)[^\s()"
+    r"(?P<url>\b(?:https?://|www\d{,3}\.|[a-z0-9.-]+\.[a-z]{2,4}/)[^\s()"
     r"<>\[\]\x02]+(?![^\s`!()\[\]{};:'\".,<>?\x02\xab\xbb\u201c\u201d\u2018"
     r"\u2019]))"
 )
 
-url_regexp = re.compile(AUTOLINK_URL)
+url_regexp = re.compile(AUTOLINK_URL, re.I | re.S)
 
 USER_LINK = re.compile(r"""
     \\(?P<escaped>[\\<])

--- a/weasyl/config.py
+++ b/weasyl/config.py
@@ -9,7 +9,7 @@ _in_test = False
 config_obj = ConfigParser()
 
 with open(macro.MACRO_CFG_SITE_CONFIG, 'r') as f:
-    config_obj.readfp(f)
+    config_obj.read_file(f, source=macro.MACRO_CFG_SITE_CONFIG)
 
 
 def config_read_setting(setting, value=None, section='general'):

--- a/weasyl/test/login/test_authenticate_bcrypt.py
+++ b/weasyl/test/login/test_authenticate_bcrypt.py
@@ -42,9 +42,9 @@ def test_login_fails_for_incorrect_credentials():
 
 
 @pytest.mark.usefixtures('db')
-def test_login_fails_for_invalid_auth_and_logs_failure_if_mod_account(tmpdir, monkeypatch):
+def test_login_fails_for_invalid_auth_and_logs_failure_if_mod_account(tmp_path, monkeypatch):
     # Required: Monkeypatch the log directory, and the staff.MODS frozenset
-    monkeypatch.setenv(macro.MACRO_SYS_LOG_PATH, tmpdir + "/")
+    monkeypatch.setattr(macro, 'MACRO_SYS_LOG_PATH', f"{tmp_path}/")
     log_path = '%s%s.%s.log' % (macro.MACRO_SYS_LOG_PATH, 'login.fail', d.get_timestamp())
     user_id = db_utils.create_user(username='ikani', password=raw_password)
     # Set the moderators in libweasyl/staff.py via monkeypatch

--- a/weasyl/test/test_submission.py
+++ b/weasyl/test/test_submission.py
@@ -328,9 +328,9 @@ class SubmissionNotificationsTestCase(unittest.TestCase):
         """
         s = db_utils.create_submission(self.owner)
         welcome.submission_insert(self.owner, s)
-        self.assertEquals(1, self._notification_count(self.friend))
-        self.assertEquals(1, self._notification_count(self.nonfriend))
-        self.assertEquals(1, self._notification_count(self.ignored))
+        self.assertEqual(1, self._notification_count(self.friend))
+        self.assertEqual(1, self._notification_count(self.nonfriend))
+        self.assertEqual(1, self._notification_count(self.ignored))
 
     def test_friends_only_submission(self):
         """
@@ -340,9 +340,9 @@ class SubmissionNotificationsTestCase(unittest.TestCase):
             self.owner,
             settings=CharSettings({'friends-only'}, {}, {}))
         welcome.submission_insert(self.owner, s, settings='f')
-        self.assertEquals(1, self._notification_count(self.friend))
-        self.assertEquals(0, self._notification_count(self.nonfriend))
-        self.assertEquals(0, self._notification_count(self.ignored))
+        self.assertEqual(1, self._notification_count(self.friend))
+        self.assertEqual(0, self._notification_count(self.nonfriend))
+        self.assertEqual(0, self._notification_count(self.ignored))
 
     def test_submission_becomes_friends_only(self):
         """
@@ -352,11 +352,11 @@ class SubmissionNotificationsTestCase(unittest.TestCase):
         # Initial behavior should match with normal.
         s = db_utils.create_submission(self.owner)
         welcome.submission_insert(self.owner, s)
-        self.assertEquals(1, self._notification_count(self.friend))
-        self.assertEquals(1, self._notification_count(self.nonfriend))
-        self.assertEquals(1, self._notification_count(self.ignored))
+        self.assertEqual(1, self._notification_count(self.friend))
+        self.assertEqual(1, self._notification_count(self.nonfriend))
+        self.assertEqual(1, self._notification_count(self.ignored))
 
         welcome.submission_became_friends_only(s, self.owner)
-        self.assertEquals(1, self._notification_count(self.friend))
-        self.assertEquals(0, self._notification_count(self.nonfriend))
-        self.assertEquals(0, self._notification_count(self.ignored))
+        self.assertEqual(1, self._notification_count(self.friend))
+        self.assertEqual(0, self._notification_count(self.nonfriend))
+        self.assertEqual(0, self._notification_count(self.ignored))


### PR DESCRIPTION
Now they pass in green instead of yellow, and without a bunch of noise!