### PR TITLE
Add external-web network to web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   test-cache:
 
 networks:
+  external-web:
   external-nginx:
   nginx-web:
     internal: true
@@ -51,6 +52,7 @@ services:
       - type: tmpfs
         target: /tmp
     networks:
+      - external-web
       - nginx-web
       - web-memcached
       - web-postgres


### PR DESCRIPTION
Actions which require external access (e.g., embedding a YouTube link via multimedia submissions) will fail unless web can access external network resources. This fixes it by adding an external network to the ``web`` container.

Found as a result of testing #1056, which without this fix would result in an HTTP504 (because it couldn't actually get out _to_ the external resource).