### PR TITLE
Perform JSON serialization at the pylibmc client level; remove gzip

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -16,7 +16,7 @@ publicsuffixlist==0.6.13    # For extracting the base domain for the email black
 alembic==1.5.8
 arrow==0.15.2
 bcrypt==3.2.0
-dogpile.cache==1.0.2
+dogpile.cache==1.1.3
 #lxml ...
 oauthlib==2.1.0
 Pillow==8.3.0

--- a/libweasyl/libweasyl/conftest.py
+++ b/libweasyl/libweasyl/conftest.py
@@ -26,7 +26,7 @@ def setup(request):
 
     cache.region.configure(
         'dogpile.cache.memory',
-        wrap=[cache.ThreadCacheProxy, cache.JSONProxy],
+        wrap=[cache.ThreadCacheProxy],
     )
 
 

--- a/libweasyl/setup.py
+++ b/libweasyl/setup.py
@@ -27,7 +27,7 @@ setup(
         'alembic==1.5.8',
         'arrow==0.15.2',
         'bcrypt==3.2.0',
-        'dogpile.cache==1.0.2',
+        'dogpile.cache==1.1.3',
         'lxml==4.6.2',
         'misaka==1.0.3+weasyl.6',    # https://github.com/Weasyl/misaka
         'oauthlib==2.1.0',

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -16,7 +16,7 @@ from weasyl import config
 config._in_test = True  # noqa
 
 from libweasyl import cache
-from libweasyl.cache import JSONProxy, ThreadCacheProxy
+from libweasyl.cache import ThreadCacheProxy
 from libweasyl.configuration import configure_libweasyl
 from libweasyl.models.tables import metadata
 from weasyl import (
@@ -33,7 +33,7 @@ from weasyl.wsgi import wsgi_app
 
 cache.region.configure(
     'dogpile.cache.memory',
-    wrap=[ThreadCacheProxy, JSONProxy],
+    wrap=[ThreadCacheProxy],
 )
 define.metric = lambda *a, **kw: None
 
@@ -137,7 +137,7 @@ def db(request):
 def cache_(request):
     cache.region.configure(
         'dogpile.cache.memory',
-        wrap=[ThreadCacheProxy, JSONProxy],
+        wrap=[ThreadCacheProxy],
         replace_existing_backend=True,
     )
 

--- a/weasyl/weasyl.tac
+++ b/weasyl/weasyl.tac
@@ -39,12 +39,16 @@ if config_read_bool('run_periodic_tasks', section='backend'):
     weasyl.polecat.PeriodicTasksService(reactor, run_periodic_tasks).setServiceParent(application)
 
 
+cache.JsonPylibmcBackend.register()
 cache.region.configure(
-    'dogpile.cache.pylibmc',
+    'libweasyl.cache.pylibmc',
     arguments={
         'url': config_read_setting('servers', "127.0.0.1", section='memcached').split(),
         'binary': True,
+        'behaviors': {
+            'tcp_nodelay': True,
+        },
     },
-    wrap=[cache.ThreadCacheProxy, cache.JSONProxy, RequestMemcachedStats],
+    wrap=[cache.ThreadCacheProxy, RequestMemcachedStats],
     replace_existing_backend=True
 )


### PR DESCRIPTION
I don’t think the gzip can be triggered by anything realistic – maybe 1MB of blocked tags. (But we should increase the object size limit anyway if that happens.)

I also tried packing the constant `ct` and `v` metadata separately, as well as msgpack, but they varied from slightly slower to much slower.

Development deployment:

- `./wzl restart memcached`

Production deployment:

- [ ] switch to new instance of previous version that only uses mcd3
- [ ] clear mcd4
- [ ] deploy new instance of new version that only uses mcd4
- [ ] clear mcd3
- [ ] switch to new instance of new version that uses both mcd3 and mcd4