### PR TITLE
Fix exchange rate fetching for Python 3

### DIFF
--- a/weasyl/commishinfo.py
+++ b/weasyl/commishinfo.py
@@ -78,7 +78,7 @@ def _fetch_rates_no_cache_failure():
 
     rates = {'EUR': 1.0}
 
-    for match in re.finditer(r"currency='([A-Z]{3})' rate='([0-9.]+)'", response.content):
+    for match in re.finditer(r"currency='([A-Z]{3})' rate='([0-9.]+)'", response.text):
         code, rate = match.groups()
 
         try:


### PR DESCRIPTION
Unnoticed until now because it’s disabled in both production and dev, but I tested it as part of the sentry-sdk migration. :)