### PR TITLE
Index sorted inbox/outbox views

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/ed80016034fd_index_sorted_inbox_view.py
+++ b/libweasyl/libweasyl/alembic/versions/ed80016034fd_index_sorted_inbox_view.py
@@ -1,0 +1,29 @@
+"""Index sorted inbox/outbox views
+
+Revision ID: ed80016034fd
+Revises: 259bc2d8e46c
+Create Date: 2021-07-08 19:10:42.862537
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ed80016034fd'
+down_revision = '259bc2d8e46c'
+
+from alembic import op
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_message_otherid_noteid ON message (otherid, noteid)")
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_message_userid_noteid ON message (userid, noteid)")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_message_otherid")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_message_userid")
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_message_otherid ON message (otherid)")
+        op.execute("CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_message_userid ON message (userid)")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_message_otherid_noteid")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_message_userid_noteid")

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -382,8 +382,8 @@ message = Table(
     default_fkey(['userid'], ['login.userid'], name='message_userid_fkey'),
 )
 
-Index('ind_message_otherid', message.c.otherid)
-Index('ind_message_userid', message.c.userid)
+Index('ind_message_otherid_noteid', message.c.otherid, message.c.noteid)
+Index('ind_message_userid_noteid', message.c.userid, message.c.noteid)
 
 
 oauth_bearer_tokens = Table(


### PR DESCRIPTION
`ORDER BY noteid` in `weasyl.note.select_inbox`/`select_outbox` without an index that includes `noteid` means PostgreSQL decides not to use the `userid`/`otherid` indexes, resulting in query times >1s to view some small inboxes.

Index `(otherid, noteid)` so `WHERE otherid = $1 ORDER BY noteid [DESC]` can use it; same for `userid`.