### PR TITLE
Login experience improvements

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -172,9 +172,9 @@
 
             $('body').addClass('modal-login');
 
-            $('#login-box-container').empty().append(
+            $('#login-top').empty().append(
                 $('<div>', { id: 'login-box', class: 'content' }).append(
-                    $('<img>', { id: 'modal-loader', src: $('#login-box-container').data('loader'), alt: '' })
+                    $('<img>', { id: 'modal-loader', src: $('#login-top').data('loader'), alt: '' })
                 )
             ).load('/signin #login-box', function () {
                 $('#login-user').focus();

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -180,6 +180,10 @@
         }
 
         $('#hg-login').on('click', function (ev) {
+            if (ev.metaKey || ev.altKey || ev.ctrlKey || ev.shiftKey) {
+                return;
+            }
+
             ev.preventDefault();
 
             if (!$('body').hasClass('modal-login')) {

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -167,29 +167,32 @@
         });
 
         // modal login
+        function closeLogin() {
+            $('body').removeClass('modal-login');
+            $(document).off('keyup', closeLoginIfEscape);
+        }
+
+        function closeLoginIfEscape(e) {
+            if (e.key === 'Escape' && !e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey) {
+                e.preventDefault();
+                closeLogin();
+            }
+        }
+
         $('#hg-login').on('click', function (ev) {
             ev.preventDefault();
 
-            $('body').addClass('modal-login');
+            if (!$('body').hasClass('modal-login')) {
+                $('body').addClass('modal-login');
+                $(document).on('keyup', closeLoginIfEscape);
+            }
 
-            $('#login-top').empty().append(
-                $('<div>', { id: 'login-box', class: 'content' }).append(
-                    $('<img>', { id: 'modal-loader', src: $('#login-top').data('loader'), alt: '' })
-                )
-            ).load('/signin #login-box', function () {
-                $('#login-user').focus();
+            $('#login-user').focus();
+        });
 
-                $('#lb-close').on('click', function (ev) {
-                    ev.preventDefault();
-                    $('body').removeClass('modal-login');
-                });
-
-                $(document).keyup(function (e) {
-                    if (e.keyCode === 27) {
-                        $('body').removeClass('modal-login');
-                    }
-                });
-            });
+        $('#lb-close').on('click', function (ev) {
+            ev.preventDefault();
+            closeLogin();
         });
 
         // submission notifs buttons

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1571,10 +1571,6 @@ blockquote + blockquote {
     padding-top: 0;
 }
 
-#login-content h3, #lb-close {
-    display: none;
-}
-
 #login-box {
     margin: 0 auto;
     padding: 24px 16px 16px;
@@ -1635,7 +1631,7 @@ blockquote + blockquote {
     position: relative;
 }
 
-.modal-login #login-top, .modal-login #login-top #login-content h3, .modal-login #login-top #lb-close {
+.modal-login #login-top {
     display: block;
 }
 
@@ -1644,8 +1640,7 @@ blockquote + blockquote {
     padding-bottom: 1.5rem;
 }
 
-.modal-login #login-top #lb-close {
-    display: block;
+#lb-close {
     position: absolute;
     top: 20px;
     top: 1.25rem;
@@ -1725,7 +1720,7 @@ blockquote + blockquote {
         z-index: 200;
     }
 
-    .modal-login #login-top #lb-close {
+    #lb-close {
         padding-right: 32px;
         padding-right: 2rem;
     }

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1703,9 +1703,8 @@ blockquote + blockquote {
         padding-top: 3rem;
     }
 
-    .modal-login #login-box-container {
+    .modal-login #login-top {
         background-color: rgba(128,128,128,0.5);
-        display: block;
         width: 100%;
         height: 100%;
         position: absolute;
@@ -1714,7 +1713,7 @@ blockquote + blockquote {
         z-index: 101;
     }
 
-    .modal-login #login-box-container #login-box {
+    .modal-login #login-top #login-box {
         max-height: 9999px;
         width: 30em;
         height: 32em;
@@ -1729,7 +1728,7 @@ blockquote + blockquote {
         z-index: 200;
     }
 
-    .modal-login #login-box-container #login-box.short {
+    .modal-login #login-top #login-box.short {
         height: 28em;
     }
 

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -2187,11 +2187,11 @@ blockquote + blockquote {
     }
 }
 
-.sfw-toggle {
+.user-nav-form {
     display: inline;
 }
 
-.sfw-toggle button {
+.user-nav-form button {
     color: #999;
 }
 

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1631,7 +1631,6 @@ blockquote + blockquote {
 #login-top #login-box {
     padding-top: 0;
     padding-bottom: 0;
-    max-height: 0;
     overflow: hidden;
     position: relative;
 }
@@ -1641,7 +1640,6 @@ blockquote + blockquote {
 }
 
 .modal-login #login-top #login-box {
-    max-height: 28em;
     padding-bottom: 24px;
     padding-bottom: 1.5rem;
 }
@@ -1714,7 +1712,6 @@ blockquote + blockquote {
     }
 
     .modal-login #login-top #login-box {
-        max-height: 9999px;
         width: 30em;
         height: 28em;
         padding: 0 2em;

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1703,7 +1703,7 @@ blockquote + blockquote {
         padding-top: 3rem;
     }
 
-    .modal-login #login-box-container, .modal-login #lt-modal, .modal-login #lt-modal iframe {
+    .modal-login #login-box-container, .modal-login #lt-modal {
         display: block;
         width: 100%;
         height: 100%;
@@ -1715,10 +1715,6 @@ blockquote + blockquote {
 
     .modal-login #lt-modal {
         background-color: rgba(128,128,128,0.5);
-    }
-
-    .modal-login #lt-modal iframe {
-        opacity: 0;
     }
 
     .modal-login #login-box-container #login-box {

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1536,7 +1536,7 @@ blockquote + blockquote {
 
 /* ------------------------------------ =forms -- */
 
-#login-top, #lt-modal {
+#login-top {
     display: none;
 }
 
@@ -1703,7 +1703,8 @@ blockquote + blockquote {
         padding-top: 3rem;
     }
 
-    .modal-login #login-box-container, .modal-login #lt-modal {
+    .modal-login #login-box-container {
+        background-color: rgba(128,128,128,0.5);
         display: block;
         width: 100%;
         height: 100%;
@@ -1711,10 +1712,6 @@ blockquote + blockquote {
         left: 0;
         top: 0;
         z-index: 101;
-    }
-
-    .modal-login #lt-modal {
-        background-color: rgba(128,128,128,0.5);
     }
 
     .modal-login #login-box-container #login-box {

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1716,7 +1716,7 @@ blockquote + blockquote {
     .modal-login #login-top #login-box {
         max-height: 9999px;
         width: 30em;
-        height: 32em;
+        height: 28em;
         padding: 0 2em;
         position: absolute;
         left: 50%;
@@ -1726,10 +1726,6 @@ blockquote + blockquote {
         border-radius: 4px;
         box-shadow: 0 2px 10px rgba(0,0,0,0.5);
         z-index: 200;
-    }
-
-    .modal-login #login-top #login-box.short {
-        height: 28em;
     }
 
     .modal-login #modal-loader {

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1725,15 +1725,6 @@ blockquote + blockquote {
         z-index: 200;
     }
 
-    .modal-login #modal-loader {
-        display: block;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        margin-left: -12px;
-        margin-top: -12px;
-    }
-
     .modal-login #login-top #lb-close {
         padding-right: 32px;
         padding-right: 2rem;

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -41,7 +41,7 @@ routes = (
     # Signin and out views.
     Route("/signin", "signin", {'GET': user.signin_get_, 'POST': user.signin_post_}),
     Route("/signin/2fa-auth", "signin_2fa_auth", {'GET': user.signin_2fa_auth_get_, 'POST': user.signin_2fa_auth_post_}),
-    Route("/signout", "signout", user.signout_),
+    Route("/signout", "signout", {'POST': user.signout_}),
     Route("/signup", "signup", {'GET': user.signup_get_, 'POST': user.signup_post_}),
 
     # Verification and password management views.

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -28,10 +28,7 @@ from weasyl.macro import MACRO_SUPPORT_ADDRESS
 
 @guest_required
 def signin_get_(request):
-    return Response(define.webpage(request.userid, "etc/signin.html", [
-        False,
-        request.environ.get('HTTP_REFERER', ''),
-    ], title="Sign In"))
+    return Response(define.webpage(request.userid, "etc/signin.html", (False, ""), title="Sign In"))
 
 
 @guest_required

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -182,10 +182,8 @@ def signin_2fa_auth_post_(request):
 
 @login_required
 @disallow_api
+@token_checked
 def signout_(request):
-    if request.web_input(token="").token != define.get_token()[:8]:
-        raise WeasylError('token')
-
     login.signout(request)
 
     raise HTTPSeeOther(location="/", headers=request.response.headers)

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -177,13 +177,18 @@ def signin_2fa_auth_post_(request):
              "2fa"], title="Sign In - 2FA"))
 
 
-@login_required
-@disallow_api
+# TODO: simplify after CSRF tokens removed
 @token_checked
-def signout_(request):
+def _signout_user(request):
     login.signout(request)
 
-    raise HTTPSeeOther(location="/", headers=request.response.headers)
+
+@disallow_api
+def signout_(request):
+    if request.userid != 0:
+        _signout_user(request)
+
+    return HTTPSeeOther(location="/", headers=request.response.headers)
 
 
 @guest_required

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -510,7 +510,7 @@ def get_address():
 
 
 def _get_path():
-    return get_current_request().path_url
+    return get_current_request().url
 
 
 def text_price_amount(target):

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -52,10 +52,7 @@ $code:
 
 <div id="page-container">
   $if query is None:
-    <div id="login-top">
-      <div id="login-box-container" data-loader="${resource_path('img/loader.gif')}">
-      </div>
-    </div>
+    <div id="login-top" data-loader="${resource_path('img/loader.gif')}"></div>
 
   <header><div id="header" class="clear">
 

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -53,8 +53,6 @@ $code:
 <div id="page-container">
   $if query is None:
     <div id="login-top">
-      <div id="lt-modal">
-      </div>
       <div id="login-box-container" data-loader="${resource_path('img/loader.gif')}">
       </div>
     </div>

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -54,7 +54,6 @@ $code:
   $if query is None:
     <div id="login-top">
       <div id="lt-modal">
-        <iframe src="javascript:false;"></iframe>
       </div>
       <div id="login-box-container" data-loader="${resource_path('img/loader.gif')}">
       </div>

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -52,7 +52,9 @@ $code:
 
 <div id="page-container">
   $if query is None:
-    <div id="login-top" data-loader="${resource_path('img/loader.gif')}"></div>
+    <div id="login-top">
+      $:{RENDER("etc/login_box.html", (False, PATH(), False))}
+    </div>
 
   <header><div id="header" class="clear">
 

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -77,7 +77,7 @@ $code:
         <a class="avatar" href="/~${LOGIN(query['username'])}"><img id="avatar" src="${avatar['display_url']}" alt="${query['username']}"></a>
         <h2><i>Welcome,</i> <a id="username" class="username" href="/~${LOGIN(query['username'])}">${query['username']}</a></h2>
         <div id="header-utility">
-          <form class="sfw-toggle" action="/control/sfwtoggle" method="POST">
+          <form class="user-nav-form sfw-toggle" action="/control/sfwtoggle" method="POST">
             $:{CSRF()}
             <input type="hidden" name="redirect" value="${PATH()}">
             <button class="link-button ${query['sfw']}">sfw ${_SFWTOGGLE(query['sfw'])}</button>
@@ -92,7 +92,10 @@ $code:
           $elif query['userid'] in staff.MODS:
             <a href="/modcontrol">mod</a> <span>|</span>
 
-          <a href="/signout?token=${TOKEN()[:8]}">log&#160;out</a>
+          <form class="user-nav-form" method="POST" action="/signout">
+            $:{CSRF()}
+            <button class="link-button">log out</button>
+          </form>
         </div>
       </div>
 

--- a/weasyl/templates/etc/login_box.html
+++ b/weasyl/templates/etc/login_box.html
@@ -1,0 +1,30 @@
+$def with (error, referer, autofocus)
+
+<div id="login-box" class="clear content">
+  <h3>Sign In</h3>
+  <a id="lb-close" class="color-c" href="#">Close</a>
+
+  $if error:
+    <div id="signin_error"><strong>Whoops!</strong> The login information you entered was not correct.</div>
+
+  <form class="form" name="signin" action="/signin" method="post">
+    $:{CSRF()}
+
+    <label for="login-user">Username</label>
+    <input type="text" id="login-user" class="input" name="username" placeholder="Username"$:{" autofocus" if autofocus else ""} />
+
+    <label for="login-pass">Password</label>
+    <input type="password" id="login-pass" class="input" name="password" placeholder="Password" />
+
+    <label id="login-sfw" class="input-checkbox">
+      <input type="checkbox" name="sfwmode" value="sfw" /> Sign in using SFW mode
+    </label>
+
+    <input type="hidden" name="referer" value="${referer}" />
+
+    <a href="/forgotpassword" id="login-recover" class="color-c">Forgot your password?</a>
+    <a href="/signup" id="login-register" class="color-c">No account yet?</a>
+    <button type="submit" class="button">Sign In</button>
+  </form>
+
+</div>

--- a/weasyl/templates/etc/login_box.html
+++ b/weasyl/templates/etc/login_box.html
@@ -1,8 +1,10 @@
-$def with (error, referer, autofocus)
+$def with (error, referer, login_page)
 
 <div id="login-box" class="clear content">
-  <h3>Sign In</h3>
-  <a id="lb-close" class="color-c" href="#">Close</a>
+  $if not login_page:
+    <h3>Sign In</h3>
+
+    <a id="lb-close" class="color-c" href="#">Close</a>
 
   $if error:
     <div id="signin_error"><strong>Whoops!</strong> The login information you entered was not correct.</div>
@@ -11,7 +13,7 @@ $def with (error, referer, autofocus)
     $:{CSRF()}
 
     <label for="login-user">Username</label>
-    <input type="text" id="login-user" class="input" name="username" placeholder="Username"$:{" autofocus" if autofocus else ""} />
+    <input type="text" id="login-user" class="input" name="username" placeholder="Username"$:{" autofocus" if login_page else ""} />
 
     <label for="login-pass">Password</label>
     <input type="password" id="login-pass" class="input" name="password" placeholder="Password" />

--- a/weasyl/templates/etc/signin.html
+++ b/weasyl/templates/etc/signin.html
@@ -2,34 +2,5 @@ $def with (error, referer)
 $:{RENDER("common/stage_title.html", ["Sign In"])}
 
 <div id="login-content" class="content">
-
-  <div id="login-box" class="clear content">
-    <h3>Sign In</h3>
-    <a id="lb-close" class="color-c" href="#">Close</a>
-
-    $if error:
-      <div id="signin_error"><strong>Whoops!</strong> The login information you entered was not correct.</div>
-
-    <form class="form" name="signin" action="/signin" method="post">
-      $:{CSRF()}
-
-      <label for="login-user">Username</label>
-      <input type="text" id="login-user" class="input" name="username" placeholder="Username" autofocus="autofocus" />
-
-      <label for="login-pass">Password</label>
-      <input type="password" id="login-pass" class="input" name="password" placeholder="Password" />
-
-      <label id="login-sfw" class="input-checkbox">
-        <input type="checkbox" name="sfwmode" value="sfw" /> Sign in using SFW mode
-      </label>
-
-      <input type="hidden" name="referer" value="${referer}" />
-
-      <a href="/forgotpassword" id="login-recover" class="color-c">Forgot your password?</a>
-      <a href="/signup" id="login-register" class="color-c">No account yet?</a>
-      <button type="submit" class="button">Sign In</button>
-    </form>
-
-  </div>
-
+  $:{RENDER("etc/login_box.html", (error, referer, True))}
 </div>

--- a/weasyl/templates/etc/signin.html
+++ b/weasyl/templates/etc/signin.html
@@ -3,7 +3,7 @@ $:{RENDER("common/stage_title.html", ["Sign In"])}
 
 <div id="login-content" class="content">
 
-  <div id="login-box" class="clear content short">
+  <div id="login-box" class="clear content">
     <h3>Sign In</h3>
     <a id="lb-close" class="color-c" href="#">Close</a>
 

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -27,7 +27,7 @@ def test_user_change_changes_token(app):
     sessionid = d.engine.scalar("SELECT sessionid FROM sessions WHERE userid = %(user)s", user=user)
     assert sessionid is not None
 
-    resp = app.get('/signout?token=' + new_csrf[:8])
+    resp = app.post('/signout', {'token': new_csrf})
     new_cookie_2 = app.cookies['WZL']
     resp = resp.follow()
     new_csrf_2 = resp.html.find('html')['data-csrf-token']

--- a/weasyl/test/web/test_site_updates.py
+++ b/weasyl/test/web/test_site_updates.py
@@ -74,7 +74,7 @@ def test_index(app, site_updates):
 @pytest.mark.usefixtures('db')
 def test_list_empty(app):
     resp = app.get('/site-updates/')
-    assert resp.html.find(None, 'content').p.string == u'No site updates to show.'
+    assert resp.html.find(None, 'text-post-list').p.string == u'No site updates to show.'
 
 
 @pytest.mark.usefixtures('db')
@@ -100,7 +100,7 @@ def test_create(app, monkeypatch):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
     resp = app.post('/admincontrol/siteupdate', _FORM, headers={'Cookie': cookie}).follow()
-    assert resp.html.find(None, 'content').h3.string == _FORM['title']
+    assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
 
 @pytest.mark.usefixtures('db', 'no_csrf')
@@ -114,7 +114,7 @@ def test_create_strip(app, monkeypatch):
         dict(_FORM, title=' test title \t '),
         headers={'Cookie': cookie},
     ).follow()
-    assert resp.html.find(None, 'content').h3.string == u'test title'
+    assert resp.html.find(id='home-content').h3.string == u'test title'
 
 
 @pytest.mark.usefixtures('db')
@@ -177,7 +177,7 @@ def test_create_notifications(app, monkeypatch):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([admin_user]))
 
     resp = app.post('/admincontrol/siteupdate', _FORM, headers={'Cookie': admin_cookie}).follow()
-    assert resp.html.find(None, 'content').h3.string == _FORM['title']
+    assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
     normal_cookie = db_utils.create_session(normal_user)
     resp = app.get('/messages/notifications', headers={'Cookie': normal_cookie})
@@ -194,7 +194,7 @@ def test_edit(app, monkeypatch, site_updates):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
     resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, headers={'Cookie': cookie}).follow()
-    assert resp.html.find(None, 'content').h3.string == _FORM['title']
+    assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
 
 @pytest.mark.usefixtures('db', 'no_csrf')
@@ -210,7 +210,7 @@ def test_edit_strip(app, monkeypatch, site_updates):
         dict(_FORM, title=' test title \t '),
         headers={'Cookie': cookie},
     ).follow()
-    assert resp.html.find(None, 'content').h3.string == u'test title'
+    assert resp.html.find(id='home-content').h3.string == u'test title'
 
 
 @pytest.mark.usefixtures('db', 'no_csrf')
@@ -290,7 +290,7 @@ def test_edit_notifications(app, monkeypatch):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([admin_user]))
 
     resp = app.post('/admincontrol/siteupdate', _FORM, headers={'Cookie': admin_cookie}).follow()
-    assert resp.html.find(None, 'content').h3.string == _FORM['title']
+    assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
     normal_cookie = db_utils.create_session(normal_user)
     resp = app.get('/messages/notifications', headers={'Cookie': normal_cookie})
@@ -302,7 +302,7 @@ def test_edit_notifications(app, monkeypatch):
         dict(_FORM, title=u'New title'),
         headers={'Cookie': admin_cookie},
     ).follow()
-    assert resp.html.find(None, 'content').h3.string == u'New title'
+    assert resp.html.find(id='home-content').h3.string == u'New title'
 
     resp = app.get('/messages/notifications', headers={'Cookie': normal_cookie})
     assert list(resp.html.find(id='header-messages').find(title='Notifications').stripped_strings)[1] == '1'


### PR DESCRIPTION
- Fixes search query (for example) disappearing when toggling SFW mode
- Fixes #697
- Removes potential point of poorly-handled failure: login modal XHR (also saving the corresponding delay)
- Makes logout a POST, and idempotent
- Removes unused frontend things

Known issue: the 2FA form’s redirect can still be specified with a URL parameter, and it still strips the querystring. Will be fixed in the upcoming 2FA refactor.