### PR TITLE
Rely on `Origin` header for CSRF prevention

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/weasyl/ci-base-image@sha256:893c70251e56e2d443a132602c6f22d1d58fdf3f14fb77443d0d0d71a959e3b3
+      image: ghcr.io/weasyl/ci-base-image@sha256:7d9187051aa04f2e8947a197ee6ab815f1c9dd93089c380bb6d5b76f29447e51
       options: --user 1001
 
     services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ FROM docker.io/library/python:3.9-alpine3.13 AS bdist
 # postgresql-dev: psycopg2cffi
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
-    musl-dev gcc make \
+    musl-dev gcc g++ make \
     imagemagick6-dev \
     libffi-dev \
     libjpeg-turbo-dev \

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -8,8 +8,6 @@
         'August', 'September', 'October', 'November', 'December', 'Smarch'
     ];
 
-    var csrfToken = document.documentElement.getAttribute('data-csrf-token');
-
     function forEach(list, callback) {
         for (var i = 0, l = list.length; i < l; i++) {
             callback(list[i]);
@@ -865,7 +863,6 @@
 
                 rq.send(
                     'format=json&feature=' + commentInfo.feature +
-                    '&token=' + encodeURIComponent(csrfToken) +
                     '&commentid=' + commentInfo.id);
 
                 comment.classList.add('removing');
@@ -1075,7 +1072,6 @@
 
                     rq.send(
                         'format=json' +
-                        '&token=' + encodeURIComponent(csrfToken) +
                         '&' + targetIdField.name + '=' + targetId +
                         '&parentid=' + commentInfo.id +
                         '&content=' + encodeURIComponent(contentField.value)
@@ -1270,7 +1266,7 @@
                 favoriteForm.submit();
             };
 
-            rq.send('token=' + encodeURIComponent(csrfToken));
+            rq.send(null);
 
             favoriteButton.classList.add('pending');
 

--- a/ci/site.config.txt
+++ b/ci/site.config.txt
@@ -3,6 +3,9 @@ allow_submit = true
 # Whether currency exchange rates should be fetched for /marketplace
 convert_currency = false
 
+# value checked against the Origin header to prevent CSRF
+origin = http://weasyl-ci.invalid
+
 [backend]
 profile_responses = false
 

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -3,6 +3,9 @@ allow_submit = true
 # Whether currency exchange rates should be fetched for /marketplace
 convert_currency = false
 
+# value checked against the Origin header to prevent CSRF
+origin = http://weasyl:8080
+
 [backend]
 profile_responses = false
 

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -23,7 +23,7 @@ Pillow==8.3.1
 psycopg2cffi==2.9.0
 #pyramid ...
 pytz==2020.4
-sqlalchemy==1.3.20
+sqlalchemy==1.4.20
 
 # https://github.com/Weasyl/misaka
 misaka @ https://pypi.weasyl.dev/misaka/misaka-1.0.3%2Bweasyl.7.tar.gz#sha224=cc3767d791466c857ec0b147e8c4809eb09948a7a6a72278d49427bb

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -633,7 +633,6 @@ sessions = Table(
     Column('sessionid', String(length=64), primary_key=True, nullable=False),
     Column('created_at', ArrowColumn(), nullable=False, server_default=text('now()')),
     Column('userid', Integer()),
-    Column('csrf_token', String(length=64)),
     Column('additional_data', JSONValuesColumn(), nullable=False, server_default=text(u"''::hstore")),
     Column('ip_address', String(length=39), nullable=True),
     Column('user_agent_id', Integer(), nullable=True),

--- a/libweasyl/libweasyl/models/users.py
+++ b/libweasyl/libweasyl/models/users.py
@@ -46,8 +46,6 @@ class Session(Base):
     """
 
     __table__ = tables.sessions
-    save = False
-    create = False
 
     user = orm.relationship(Login)
 
@@ -57,21 +55,9 @@ class Session(Base):
     @reify
     def timezone(self):
         if not self.userid:
-            return _server_time
+            return DEFAULT_TIMEZONE
         else:
-            return UserTimezone.load_from_memcached_or_database(self.userid) or _server_time
-
-
-class GuestSession(object):
-    __slots__ = ('sessionid', 'csrf_token', 'create')
-
-    userid = None
-    additional_data = None
-
-    def __init__(self, sessionid):
-        self.sessionid = sessionid
-        self.csrf_token = sessionid
-        self.create = False
+            return UserTimezone.load_from_memcached_or_database(self.userid) or DEFAULT_TIMEZONE
 
 
 class UserTimezone(Base):
@@ -140,4 +126,4 @@ class Follow(Base):
     __table__ = tables.watchuser
 
 
-_server_time = GuestSession.timezone = UserTimezone(timezone='America/Denver')
+DEFAULT_TIMEZONE = UserTimezone(timezone='America/Denver')

--- a/weasyl/controllers/decorators.py
+++ b/weasyl/controllers/decorators.py
@@ -94,7 +94,8 @@ def twofactorauth_disabled_required(view_callable):
 
 def token_checked(view_callable):
     def inner(request):
-        if not weasyl.api.is_api_user(request) and not define.is_csrf_valid(request, request.params.get('token')):
+        assert request.method in ("POST", "DELETE", "PUT", "PATCH")
+        if not weasyl.api.is_api_user(request) and not define.is_csrf_valid(request):
             raise WeasylError('token')
         return view_callable(request)
     return inner

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -312,7 +312,7 @@ def control_editpreferences_get_(request):
         current_sfw_rating,
         age,
         allowed_ratings,
-        request.weasyl_session.timezone.timezone,
+        define.request_timezone(request.weasyl_session).timezone,
         define.timezones(),
     ], title="Site Preferences"))
 
@@ -795,7 +795,8 @@ def sfw_toggle_(request):
 
     currentstate = request.cookies.get('sfwmode', "nsfw")
     newstate = "sfw" if currentstate == "nsfw" else "nsfw"
-    request.set_cookie_on_response("sfwmode", newstate, 60 * 60 * 24 * 365)
     # release the index page's cache so it shows the new ratings if they visit it
     index.template_fields.invalidate(request.userid)
-    raise HTTPSeeOther(location=form.redirect)
+    response = HTTPSeeOther(location=form.redirect)
+    response.set_cookie("sfwmode", newstate, max_age=60 * 60 * 24 * 365)
+    return response

--- a/weasyl/controllers/two_factor_auth.py
+++ b/weasyl/controllers/two_factor_auth.py
@@ -1,6 +1,7 @@
 import arrow
 from pyramid.response import Response
 from pyramid.httpexceptions import HTTPSeeOther
+from sqlalchemy.orm.attributes import flag_modified
 
 from weasyl import define
 from weasyl import login
@@ -15,41 +16,42 @@ from weasyl.error import WeasylError
 from weasyl.profile import invalidate_other_sessions
 
 
-def _set_totp_code_on_session(totp_code):
-    sess = define.get_weasyl_session()
-    sess.additional_data['2fa_totp_code'] = totp_code
-    sess.save = True
+def _set_totp_code_on_session(request, totp_code):
+    sess = request.weasyl_session
+
+    with define.sessionmaker_future.begin() as tx:
+        sess.additional_data['2fa_totp_code'] = totp_code
+        flag_modified(sess, 'additional_data')
+        tx.add(sess)
 
 
-def _get_totp_code_from_session():
-    sess = define.get_weasyl_session()
-    return sess.additional_data['2fa_totp_code']
+def _get_totp_code_from_session(request):
+    return request.weasyl_session.additional_data['2fa_totp_code']
 
 
-def _set_recovery_codes_on_session(recovery_codes):
-    sess = define.get_weasyl_session()
-    sess.additional_data['2fa_recovery_codes'] = recovery_codes
-    sess.additional_data['2fa_recovery_codes_timestamp'] = arrow.now().timestamp
-    sess.save = True
+def _set_recovery_codes_on_session(request, recovery_codes):
+    sess = request.weasyl_session
+
+    with define.sessionmaker_future.begin() as tx:
+        sess.additional_data['2fa_recovery_codes'] = recovery_codes
+        sess.additional_data['2fa_recovery_codes_timestamp'] = arrow.now().timestamp
+        flag_modified(sess, 'additional_data')
+        tx.add(sess)
 
 
-def _get_recovery_codes_from_session():
-    sess = define.get_weasyl_session()
-    if '2fa_recovery_codes' in sess.additional_data:
-        return sess.additional_data['2fa_recovery_codes']
-    else:
-        return None
+def _get_recovery_codes_from_session(request):
+    return request.weasyl_session.additional_data.get('2fa_recovery_codes')
 
 
-def _cleanup_session():
-    sess = define.get_weasyl_session()
-    if '2fa_recovery_codes' in sess.additional_data:
-        del sess.additional_data['2fa_recovery_codes']
-    if '2fa_recovery_codes_timestamp' in sess.additional_data:
-        del sess.additional_data['2fa_recovery_codes_timestamp']
-    if '2fa_totp_code' in sess.additional_data:
-        del sess.additional_data['2fa_totp_code']
-    sess.save = True
+def _cleanup_session(request):
+    sess = request.weasyl_session
+
+    with define.sessionmaker_future.begin() as tx:
+        sess.additional_data.pop('2fa_recovery_codes', None)
+        sess.additional_data.pop('2fa_recovery_codes_timestamp', None)
+        sess.additional_data.pop('2fa_totp_code', None)
+        flag_modified(sess, 'additional_data')
+        tx.add(sess)
 
 
 @login_required
@@ -83,7 +85,7 @@ def tfa_init_post_(request):
     # The user has authenticated, so continue with the initialization process.
     else:
         tfa_secret, tfa_qrcode = tfa.init(request.userid)
-        _set_totp_code_on_session(tfa_secret)
+        _set_totp_code_on_session(request, tfa_secret)
         return Response(define.webpage(request.userid, "control/2fa/init_qrcode.html", [
             define.get_display_name(request.userid),
             tfa_secret,
@@ -109,7 +111,7 @@ def tfa_init_qrcode_get_(request):
 def tfa_init_qrcode_post_(request):
     # Strip any spaces from the TOTP code (some authenticators display the digits like '123 456')
     tfaresponse = request.params['tfaresponse'].replace(' ', '')
-    tfa_secret_sess = _get_totp_code_from_session()
+    tfa_secret_sess = _get_totp_code_from_session(request)
 
     # Check to see if the tfaresponse matches the tfasecret when run through the TOTP algorithm
     tfa_secret, recovery_codes = tfa.init_verify_tfa(tfa_secret_sess, tfaresponse)
@@ -123,7 +125,7 @@ def tfa_init_qrcode_post_(request):
             "2fa"
         ], title="Enable 2FA: Step 2"))
     else:
-        _set_recovery_codes_on_session(','.join(recovery_codes))
+        _set_recovery_codes_on_session(request, ','.join(recovery_codes))
         return Response(define.webpage(request.userid, "control/2fa/init_verify.html", [
             recovery_codes,
             None
@@ -149,8 +151,8 @@ def tfa_init_verify_get_(request):
 def tfa_init_verify_post_(request):
     # Extract parameters from the form
     verify_checkbox = 'verify' in request.params
-    tfasecret = _get_totp_code_from_session()
-    tfarecoverycodes = _get_recovery_codes_from_session()
+    tfasecret = _get_totp_code_from_session(request)
+    tfarecoverycodes = _get_recovery_codes_from_session(request)
 
     # Does the user want to proceed with enabling 2FA?
     if verify_checkbox and tfa.store_recovery_codes(request.userid, tfarecoverycodes):
@@ -162,7 +164,7 @@ def tfa_init_verify_post_(request):
             # Invalidate all other login sessions
             invalidate_other_sessions(request.userid)
             # Clean up the stored session variables
-            _cleanup_session()
+            _cleanup_session(request)
             raise HTTPSeeOther(location="/control/2fa/status")
         # TOTP+2FA Secret did not validate
         else:
@@ -255,7 +257,7 @@ def tfa_generate_recovery_codes_verify_password_post_(request):
         if gen_rec_codes:
             # Either this is a fresh request to generate codes, or the timelimit was exceeded.
             recovery_codes = tfa.generate_recovery_codes()
-            _set_recovery_codes_on_session(','.join(recovery_codes))
+            _set_recovery_codes_on_session(request, ','.join(recovery_codes))
         return Response(define.webpage(request.userid, "control/2fa/generate_recovery_codes.html", [
             recovery_codes,
             None
@@ -283,14 +285,14 @@ def tfa_generate_recovery_codes_post_(request):
     # Extract parameters from the form
     verify_checkbox = 'verify' in request.params
     tfaresponse = request.params['tfaresponse']
-    tfarecoverycodes = _get_recovery_codes_from_session()
+    tfarecoverycodes = _get_recovery_codes_from_session(request)
 
     # Does the user want to save the new recovery codes?
     if verify_checkbox:
         if tfa.verify(request.userid, tfaresponse, consume_recovery_code=False):
             if tfa.store_recovery_codes(request.userid, tfarecoverycodes):
                 # Clean up the stored session variables
-                _cleanup_session()
+                _cleanup_session(request)
                 # Successfuly stored new recovery codes.
                 raise HTTPSeeOther(location="/control/2fa/status")
             else:

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -1,5 +1,6 @@
 import pytz
 import sqlalchemy as sa
+from pyramid.threadlocal import get_current_request
 
 from libweasyl import ratings
 from libweasyl import security
@@ -607,7 +608,7 @@ def invalidate_other_sessions(userid):
 
     Returns: Nothing.
     """
-    sess = d.get_weasyl_session()
+    sess = get_current_request().weasyl_session
     d.engine.execute("""
         DELETE FROM sessions
         WHERE userid = %(userid)s

--- a/weasyl/sessions.py
+++ b/weasyl/sessions.py
@@ -1,26 +1,12 @@
-from libweasyl import security
-from libweasyl.models.users import GuestSession, Session
+import secrets
+from libweasyl.models.users import Session
 
 
-USER_TOKEN_LENGTH = 64
-GUEST_TOKEN_LENGTH = 20
+_USER_TOKEN_BYTES = 16
 
 
 def create_session(userid):
-    sess = Session(userid=userid)
-    sess.sessionid = security.generate_key(USER_TOKEN_LENGTH)
-    sess.create = True
-    sess.save = True
-    return sess
-
-
-def create_guest_session():
-    token = security.generate_key(GUEST_TOKEN_LENGTH)
-    sess = GuestSession(token)
-    sess.create = True
-    return sess
-
-
-def is_guest_token(token):
-    token = str(token)
-    return len(token) == GUEST_TOKEN_LENGTH and token.isalnum()
+    return Session(
+        userid=userid,
+        sessionid=secrets.token_urlsafe(_USER_TOKEN_BYTES),
+    )

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -5,7 +5,7 @@ $code:
     return 'on' if mode == 'sfw' else 'off'
 
 <!DOCTYPE html>
-<html class="no-js" data-csrf-token="${TOKEN()}">
+<html class="no-js">
 <head>
 
   <meta charset="utf-8" />

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -146,9 +146,9 @@ def template_cache():
     define._template_cache.clear()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def no_csrf(monkeypatch):
-    monkeypatch.setattr(define, 'is_csrf_valid', lambda request, token: True)
+    monkeypatch.setattr(define, 'is_csrf_valid', lambda request: True)
 
 
 @pytest.fixture(autouse=True)

--- a/weasyl/test/login/test_signin.py
+++ b/weasyl/test/login/test_signin.py
@@ -6,7 +6,6 @@ from pyramid.threadlocal import get_current_request
 
 from weasyl import login
 from weasyl import define as d
-from weasyl.sessions import create_session
 from weasyl.test import db_utils
 
 
@@ -14,10 +13,7 @@ from weasyl.test import db_utils
 def test_verify_login_record_is_updated():
     # Use a fake session for this test.
     user_id = db_utils.create_user()
-    sess = get_current_request().weasyl_session = create_session(user_id)
-    db = d.connect()
-    db.add(sess)
-    db.flush()
+    get_current_request().weasyl_session = None
     time = datetime(2020, 1, 1, 00, 00, 1, tzinfo=pytz.UTC)  # Arbitrary date that should be earlier than now.
     d.engine.execute("UPDATE login SET last_login = %(timestamp)s WHERE userid = %(id)s", id=user_id, timestamp=time)
     login.signin(get_current_request(), user_id)

--- a/weasyl/test/web/test_api.py
+++ b/weasyl/test/web/test_api.py
@@ -5,7 +5,7 @@ import weasyl.define as d
 from weasyl.test.web.common import create_visual, read_asset
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_submission_view(app, submission_user):
     submission = create_visual(
         app,

--- a/weasyl/test/web/test_blacklist.py
+++ b/weasyl/test/web/test_blacklist.py
@@ -4,7 +4,7 @@ from libweasyl import ratings
 from weasyl.test import db_utils
 
 
-@pytest.mark.usefixtures('db', 'cache', 'no_csrf')
+@pytest.mark.usefixtures('db', 'cache')
 def test_blacklist_homepage(app):
     """
     Assert that changes to the blacklist apply to the home page immediately.
@@ -40,7 +40,7 @@ def test_blacklist_homepage(app):
     assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 2
 
 
-@pytest.mark.usefixtures('db', 'cache', 'no_csrf')
+@pytest.mark.usefixtures('db', 'cache')
 def test_block_user_homepage(app):
     """
     Assert that changes to blocked users apply to the home page immediately.

--- a/weasyl/test/web/test_characters.py
+++ b/weasyl/test/web/test_characters.py
@@ -34,7 +34,7 @@ def _character_user(db):
 
 
 @pytest.fixture(name='character')
-def _character(app, db, character_user, no_csrf):
+def _character(app, db, character_user):
     cookie = db_utils.create_session(character_user)
 
     form = dict(
@@ -64,7 +64,7 @@ def test_create_default_thumbnail(app, character):
     assert _read_character_image(image_url).tobytes() == read_asset_image('img/wesley1.png').tobytes()
 
 
-@pytest.mark.usefixtures('db', 'character_user', 'character', 'no_csrf')
+@pytest.mark.usefixtures('db', 'character_user', 'character')
 def test_owner_edit_details(app, character_user, character):
     cookie = db_utils.create_session(character_user)
 
@@ -78,7 +78,7 @@ def test_owner_edit_details(app, character_user, character):
     assert resp.html.find(id='detail-bar-title').string == u'Edited name'
 
 
-@pytest.mark.usefixtures('db', 'character_user', 'character', 'no_csrf')
+@pytest.mark.usefixtures('db', 'character_user', 'character')
 def test_owner_reupload(app, character_user, character):
     cookie = db_utils.create_session(character_user)
 

--- a/weasyl/test/web/test_journals.py
+++ b/weasyl/test/web/test_journals.py
@@ -74,7 +74,7 @@ def test_list_unicode_username(app):
     assert titles == [u'Unícode journal 😊']
 
 
-@pytest.mark.usefixtures('db', 'journal_user', 'no_csrf')
+@pytest.mark.usefixtures('db', 'journal_user')
 def test_create(app, journal_user):
     cookie = db_utils.create_session(journal_user)
 
@@ -82,21 +82,6 @@ def test_create(app, journal_user):
 
     resp = app.get('/~journal_test')
     assert resp.html.find(id='user-journal').h4.string == u'Created journal'
-
-
-@pytest.mark.usefixtures('db', 'journal_user')
-def test_csrf_on_journal_edit(app, journal_user):
-    # Test purpose: Verify that a CSRF token is required to submit a journal entry.
-    cookie = db_utils.create_session(journal_user)
-    journalid = db_utils.create_journal(journal_user, "Test", content="Test")
-
-    resp = app.post(
-        '/edit/journal',
-        {'title': u'Created journal', 'rating': '10', 'content': u'A journal', 'journalid': journalid},
-        headers={'Cookie': cookie},
-        status=403,
-    )
-    assert resp.html.find(id='error_content').p.text.startswith(u"This action appears to have been performed illegitimately")
 
 
 @pytest.mark.usefixtures('db', 'journal_user')

--- a/weasyl/test/web/test_login.py
+++ b/weasyl/test/web/test_login.py
@@ -10,31 +10,19 @@ from weasyl.test import db_utils
 def test_user_change_changes_token(app):
     user = db_utils.create_user(username='user1', password='password1')
 
-    resp = app.get('/')
-    old_cookie = app.cookies['WZL']
-    csrf = resp.html.find('html')['data-csrf-token']
+    app.get('/')
+    assert 'WZL' not in app.cookies
 
-    resp = app.get('/')
-    assert resp.html.find('html')['data-csrf-token'] == csrf
-
-    resp = app.post('/signin', {'token': csrf, 'username': 'user1', 'password': 'password1'})
-    new_cookie = app.cookies['WZL']
-    resp = resp.follow()
-    new_csrf = resp.html.find('html')['data-csrf-token']
-    assert new_cookie != old_cookie
-    assert new_csrf != csrf
+    app.post('/signin', {'username': 'user1', 'password': 'password1'})
+    new_cookie = app.cookies.get('WZL')
+    assert new_cookie
 
     sessionid = d.engine.scalar("SELECT sessionid FROM sessions WHERE userid = %(user)s", user=user)
     assert sessionid is not None
 
-    resp = app.post('/signout', {'token': new_csrf})
-    new_cookie_2 = app.cookies['WZL']
-    resp = resp.follow()
-    new_csrf_2 = resp.html.find('html')['data-csrf-token']
-    assert new_cookie_2 != new_cookie
-    assert new_cookie_2 != old_cookie
-    assert new_csrf_2 != new_csrf
-    assert new_csrf_2 != csrf
+    resp = app.post('/signout')
+    assert 'WZL' not in app.cookies
+    resp.follow()
 
     assert not d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE sessionid = %(id)s)", id=sessionid)
 
@@ -43,20 +31,15 @@ def test_user_change_changes_token(app):
 def test_2fa_changes_token(app):
     user = db_utils.create_user(username='user1', password='password1')
 
-    resp = app.get('/')
-    csrf = resp.html.find('html')['data-csrf-token']
-
     assert tfa.store_recovery_codes(user, ','.join(tfa.generate_recovery_codes()))
     tfa_secret = pyotp.random_base32()
     totp = pyotp.TOTP(tfa_secret)
     tfa_response = totp.now()
     assert tfa.activate(user, tfa_secret, tfa_response)
 
-    old_cookie = app.cookies['WZL']
-    resp = app.post('/signin', {'token': csrf, 'username': 'user1', 'password': 'password1'})
-    new_csrf = resp.html.find('html')['data-csrf-token']
-    assert app.cookies['WZL'] != old_cookie
-    assert new_csrf != csrf
+    assert 'WZL' not in app.cookies
+    app.post('/signin', {'username': 'user1', 'password': 'password1'})
+    assert app.cookies.get('WZL')
     assert not d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE userid = %(user)s)", user=user)
     assert d.engine.scalar("SELECT EXISTS (SELECT 0 FROM sessions WHERE additional_data->'2fa_pwd_auth_userid' = %(user)s::text)", user=user)
 

--- a/weasyl/test/web/test_notes.py
+++ b/weasyl/test/web/test_notes.py
@@ -4,7 +4,7 @@ from weasyl import define as d
 from weasyl.test import db_utils
 
 
-@pytest.mark.usefixtures('db', 'cache', 'no_csrf')
+@pytest.mark.usefixtures('db', 'cache')
 def test_reply_to_restricted_notes(app):
     user1 = db_utils.create_user(username='user1')
     user2 = db_utils.create_user(username='user2')
@@ -31,7 +31,7 @@ def test_reply_to_restricted_notes(app):
     try_send(303)
 
 
-@pytest.mark.usefixtures('db', 'cache', 'no_csrf')
+@pytest.mark.usefixtures('db', 'cache')
 def test_reply_when_blocked(app):
     user1 = db_utils.create_user(username='user1')
     user2 = db_utils.create_user(username='user2')

--- a/weasyl/test/web/test_site_updates.py
+++ b/weasyl/test/web/test_site_updates.py
@@ -93,7 +93,7 @@ def test_list(app, monkeypatch, site_updates):
     assert resp.html.find(None, 'text-post-actions').a['href'] == '/site-updates/%d/edit' % (updates[-1].updateid,)
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_create(app, monkeypatch):
     user = db_utils.create_user()
     cookie = db_utils.create_session(user)
@@ -103,7 +103,7 @@ def test_create(app, monkeypatch):
     assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_create_strip(app, monkeypatch):
     user = db_utils.create_user()
     cookie = db_utils.create_session(user)
@@ -115,16 +115,6 @@ def test_create_strip(app, monkeypatch):
         headers={'Cookie': cookie},
     ).follow()
     assert resp.html.find(id='home-content').h3.string == u'test title'
-
-
-@pytest.mark.usefixtures('db')
-def test_create_csrf(app, monkeypatch):
-    user = db_utils.create_user()
-    cookie = db_utils.create_session(user)
-    monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
-
-    resp = app.post('/admincontrol/siteupdate', _FORM, headers={'Cookie': cookie}, status=403)
-    assert resp.html.find(id='error_content').p.string == errorcode.token
 
 
 @pytest.mark.usefixtures('db')
@@ -156,7 +146,7 @@ def test_create_restricted(app, monkeypatch):
     assert resp.html.find(id='error_content') is None
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_create_validation(app, monkeypatch):
     user = db_utils.create_user()
     cookie = db_utils.create_session(user)
@@ -169,7 +159,7 @@ def test_create_validation(app, monkeypatch):
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.error_messages['contentInvalid']
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_create_notifications(app, monkeypatch):
     admin_user = db_utils.create_user()
     normal_user = db_utils.create_user()
@@ -185,7 +175,7 @@ def test_create_notifications(app, monkeypatch):
     assert resp.html.find(id='site_updates').find(None, 'item').a.string == _FORM['title']
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_edit(app, monkeypatch, site_updates):
     _, updates = site_updates
 
@@ -197,7 +187,7 @@ def test_edit(app, monkeypatch, site_updates):
     assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_edit_strip(app, monkeypatch, site_updates):
     _, updates = site_updates
 
@@ -213,7 +203,7 @@ def test_edit_strip(app, monkeypatch, site_updates):
     assert resp.html.find(id='home-content').h3.string == u'test title'
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_edit_nonexistent(app, monkeypatch, site_updates):
     _, updates = site_updates
 
@@ -222,18 +212,6 @@ def test_edit_nonexistent(app, monkeypatch, site_updates):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
     app.post('/site-updates/%d' % (updates[-1].updateid + 1,), _FORM, headers={'Cookie': cookie}, status=404)
-
-
-@pytest.mark.usefixtures('db')
-def test_edit_csrf(app, monkeypatch, site_updates):
-    _, updates = site_updates
-
-    user = db_utils.create_user()
-    cookie = db_utils.create_session(user)
-    monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
-
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, headers={'Cookie': cookie}, status=403)
-    assert resp.html.find(id='error_content').p.text.strip() == errorcode.token
 
 
 @pytest.mark.usefixtures('db')
@@ -267,7 +245,7 @@ def test_edit_restricted(app, monkeypatch, site_updates):
     assert resp.html.find(id='error_content') is None
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_edit_validation(app, monkeypatch, site_updates):
     _, updates = site_updates
 
@@ -282,7 +260,7 @@ def test_edit_validation(app, monkeypatch, site_updates):
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.error_messages['contentInvalid']
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_edit_notifications(app, monkeypatch):
     admin_user = db_utils.create_user()
     normal_user = db_utils.create_user()

--- a/weasyl/test/web/test_submissions.py
+++ b/weasyl/test/web/test_submissions.py
@@ -26,7 +26,7 @@ def _image_hash(image):
 
 
 @pytest.mark.parametrize('age', [17, 19])
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_rating_accessibility(app, age):
     submission_user = db_utils.create_user('submission_test', birthday=arrow.utcnow().shift(years=-age))
     cookie = db_utils.create_session(submission_user)
@@ -57,7 +57,7 @@ def test_rating_accessibility(app, age):
     _post_expecting(form, 'General')
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_gif_thumbnail_static(app, submission_user):
     create_visual(
         app, submission_user,
@@ -72,7 +72,7 @@ def test_gif_thumbnail_static(app, submission_user):
     assert thumb.picture.source['srcset'].endswith('.webp')
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_visual_reupload_thumbnail_and_cover(app, submission_user):
     # resized to be larger than COVER_SIZE so a cover is created
     with BytesIO() as f:
@@ -127,7 +127,7 @@ class CrosspostHandler(BaseHTTPRequestHandler):
         self.wfile.write(read_asset('img/wesley1.png'))
 
 
-@pytest.mark.usefixtures('db', 'no_csrf')
+@pytest.mark.usefixtures('db')
 def test_crosspost(app, submission_user, monkeypatch):
     monkeypatch.setattr(submission, '_ALLOWED_CROSSPOST_HOST', re.compile(r'\Alocalhost:[0-9]+\Z'))
 

--- a/weasyl/wsgi.py
+++ b/weasyl/wsgi.py
@@ -45,8 +45,6 @@ setup_routes_and_views(config)
 config.add_request_method(mw.pg_connection_request_property, name='pg_connection', reify=True)
 config.add_request_method(mw.userid_request_property, name='userid', reify=True)
 config.add_request_method(mw.web_input_request_method, name='web_input')
-config.add_request_method(mw.set_cookie_on_response)
-config.add_request_method(mw.delete_cookie_on_response)
 
 
 def make_wsgi_app(*, configure_cache=True):


### PR DESCRIPTION
It’s supported by all modern browsers. Allows guests to be cookie-free and to share cache.

Some of the 2FA edge cases are probably broken (and it looks like they already were before), but I’d like to refactor that soon anyway.

SQLAlchemy is horrible as usual.

Intentionally missing a migration to delete `csrf_token` for now, just in case we want to undo this.