### PR TITLE
Remove outdated index condition

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/bcb0d75b6f8b_remove_outdated_index_condition.py
+++ b/libweasyl/libweasyl/alembic/versions/bcb0d75b6f8b_remove_outdated_index_condition.py
@@ -1,0 +1,43 @@
+"""Remove outdated index condition
+
+Revision ID: bcb0d75b6f8b
+Revises: 41a6dbe0266d
+Create Date: 2021-07-22 01:26:20.485966
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bcb0d75b6f8b'
+down_revision = '41a6dbe0266d'
+
+from alembic import op
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_submission_score_new ON submission (
+                (
+                    log(favorites + 1)
+                        + log(page_views + 1) / 2
+                        + unixtime / 180000.0
+                )
+            )
+        """)
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_submission_score")
+        op.execute("ALTER INDEX ind_submission_score_new RENAME TO ind_submission_score")
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_submission_score_old ON submission (
+                (
+                    log(favorites + 1)
+                        + log(page_views + 1) / 2
+                        + unixtime / 180000.0
+                )
+            ) WHERE favorites IS NOT NULL
+        """)
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_submission_score")
+        op.execute("ALTER INDEX ind_submission_score_old RENAME TO ind_submission_score")

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -738,7 +738,6 @@ submission = Table(
                 + log(page_views + 1) / 2
                 + unixtime / 180000.0
         )"""),
-        postgresql_where=text("favorites IS NOT NULL"),
     ),
 )
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1095,7 +1095,6 @@ def select_recently_popular():
             INNER JOIN profile ON submission.userid = profile.userid
         WHERE
             submission.settings !~ '[hf]'
-            AND submission.favorites IS NOT NULL
         ORDER BY score DESC
         LIMIT 128
     """)


### PR DESCRIPTION
`favorites` has a `NOT NULL` constraint now.

Migration should run before app deployment.