### PR TITLE
Add submission tag history index

### DIFF
--- a/libweasyl/libweasyl/alembic/versions/af3b8d60b7ba_add_submission_tag_history_index.py
+++ b/libweasyl/libweasyl/alembic/versions/af3b8d60b7ba_add_submission_tag_history_index.py
@@ -1,0 +1,21 @@
+"""Add submission tag history index
+
+Revision ID: af3b8d60b7ba
+Revises: bcb0d75b6f8b
+Create Date: 2021-07-23 02:04:11.970503
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'af3b8d60b7ba'
+down_revision = 'bcb0d75b6f8b'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('ind_tag_updates_submitid', 'tag_updates', ['submitid'], unique=False)
+
+
+def downgrade():
+    op.drop_index('ind_tag_updates_submitid', table_name='tag_updates')

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -793,6 +793,8 @@ tag_updates = Table(
     default_fkey(['userid'], ['login.userid'], name='tag_updates_userid_fkey'),
 )
 
+Index('ind_tag_updates_submitid', tag_updates.c.submitid)
+
 
 user_media_links = Table(
     'user_media_links', metadata,


### PR DESCRIPTION
Oops.

Makes the submission tag history page not scan every row.