### PR TITLE
Fix rendered Markdown trailing `<` caused by new `lxml.html.tostring` trailing newline

### DIFF
--- a/libweasyl/libweasyl/text.py
+++ b/libweasyl/libweasyl/text.py
@@ -289,7 +289,8 @@ def _markdown_fragment(target):
 
 def markdown(target):
     fragment = _markdown_fragment(target)
-    return html.tostring(fragment, encoding="unicode")[5:-6]  # <div>...</div>
+    start, stripped, end = strip_outer_tag(html.tostring(fragment, encoding="unicode"))
+    return stripped
 
 
 def _itertext_spaced(element):


### PR DESCRIPTION
Possibly introduced by a new libxml2 version?

Bug found by @kfkitsune.