### PR TITLE
Changes timezone designation for user sessions in admin view from PDT to UTC

### DIFF
--- a/weasyl/templates/admincontrol/manageuser.html
+++ b/weasyl/templates/admincontrol/manageuser.html
@@ -31,7 +31,7 @@ $:{TITLE("User Management", "Administrator Control Panel", "/admincontrol")}
         </tr>
         $for sess in profile['user_sessions']:
           <tr>
-            <td>${arrow.get(sess.created_at).format('YYYY-MM-DD HH:mm:ss')} (PDT)</td>
+            <td>${arrow.get(sess.created_at).format('YYYY-MM-DD HH:mm:ss')} (UTC)</td>
             $if sess.ip_address:
               <td>${sess.ip_address}</td>
             $else:


### PR DESCRIPTION
Not quite sure when--if?--this changed, but the Docker environment now has logins showing as UTC for these session timestamps. So we should show the correct timezone, therefore. Found by @charmander.

(As far as I can tell, no code changes need to be made here; the time's showing up as UTC as-is.)