### PR TITLE
Replace random art tab with critique tab

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -79,7 +79,7 @@
                 }
 
                 var row = [],
-                    rowWidth = 0,
+                    rowWidth = thumbnailOptions.itemGap,
                     difference = 1;
 
                 // construct a row
@@ -94,11 +94,12 @@
 
                 // fit row
                 if (rowWidth > containerWidth) {
-                    difference = containerWidth / rowWidth;
+                    var totalGap = (row.length + 1) * thumbnailOptions.itemGap;
+                    difference = (containerWidth - totalGap) / (rowWidth - totalGap);
                 }
                 forEach(row, function (item) {
-                    var width = getWidthAttr(item) * thumbRatio * difference - thumbnailOptions.itemGap;
-                    var height = startHeight * difference - thumbnailOptions.itemGap;
+                    var width = getWidthAttr(item) * thumbRatio * difference;
+                    var height = startHeight * difference;
 
                     item.style.width = width + 'px';
                     item.style.height = height + 'px';
@@ -1282,31 +1283,35 @@
             } catch (consoleError) {}
         }
 
-        var homePaneLinks = $('.home-pane-link');
-        var homePanes = $('#home-panes .pane');
-        var homePaneGrids = homePanes.find('.thumbnail-grid');
+        var homeTabs = document.getElementById('home-tabs');
+        var homePanes = document.getElementById('home-panes');
 
-        $('#home-art').on('click', '.home-pane-link', function (e) {
+        if (!homePanes) {
+            return;
+        }
+
+        var currentTab = homeTabs.getElementsByClassName('current')[0];
+        var currentPane = homePanes.getElementsByClassName('current')[0];
+
+        $(homeTabs).on('click touchstart', '.home-pane-link', function (e) {
             e.preventDefault();
 
             var paneId = this.getAttribute('href').substring(1);
+            var pane = document.getElementById(paneId);
 
-            homePaneLinks.removeClass('current');
-            homePanes.removeClass('current');
-            homePaneGrids.removeClass('current');
+            if (pane === currentPane) {
+                return;
+            }
 
-            // Select this tab or disclosure button and the corresponding
-            // disclosure button or tab. This approach works for both the tabs
-            // and disclosures. It relies on the fact that there are n tabs and
-            // n corresponding disclosure buttons selected by .home-pane-link
-            // in the same order.
-            $(this).addClass('current');
-            homePaneLinks
-                .eq((homePaneLinks.index(this) + homePanes.length) % homePaneLinks.length)
-                .addClass('current');
+            if (currentPane) {
+                currentTab.classList.remove('current');
+                currentPane.classList.remove('current');
+            }
 
-            $(document.getElementById(paneId)).addClass('current')
-                .children('.thumbnail-grid').addClass('current loaded');
+            currentTab = this;
+            currentPane = pane;
+            this.classList.add('current');
+            pane.classList.add('current');
 
             calculateThumbnailLayout();
 
@@ -1325,10 +1330,10 @@
             logStorageError(error);
         }
 
-        var savedTab = savedTabId && document.getElementById(savedTabId);
+        var savedTab = savedTabId && homeTabs.querySelector('.home-pane-link[href="#' + savedTabId + '"]');
 
         if (savedTab) {
-            savedTab.children[0].click();
+            savedTab.click();
         }
     })();
 

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -89,9 +89,13 @@ textarea {
     font-weight: normal !important;
 }
 
-i, #header-guest {
+@mixin serif {
     font-family: Georgia, serif;
     font-weight: 400;
+}
+
+i, #header-guest {
+    @include serif;
 }
 
 .formatted-content i {
@@ -101,14 +105,17 @@ i, #header-guest {
 
 /* Colors
 --------------------------------*/
+$color-a: #069bc0;
+$color-b: #8cad47;
+
 .color-a, .username, .content .username, .page-title, #header-nav .current,
-#user-nav .current, #home-tabs a.current,
-#submissions-stage .sectioned-sidebar .current, #home-art h3 {
-    color: #069bc0;
+#user-nav .current,
+#submissions-stage .sectioned-sidebar .current, #hc-streams h3 {
+    color: $color-a;
 }
 
-.color-b, a.more span, #header-messages a, .page-title a {
-    color: #8cad47;
+a.more span, #header-messages a, .page-title a {
+    color: $color-b;
 }
 
 .color-c, .title, .content a {
@@ -135,7 +142,7 @@ i, #header-guest {
     color: #687a89;
 }
 
-#header-nav ul a, #user-nav a, #home-tabs a {
+#header-nav ul a, #user-nav a, .home-pane-link {
     color: #9eb9bc;
 }
 
@@ -174,6 +181,10 @@ li.more, div.more, a.more-block {
 li.more {
     margin: 0.75em 0 0;
     border-top: 1px dashed #334047;
+
+    &.more-joined {
+        border-top: none;
+    }
 }
 
 hr.more {
@@ -973,7 +984,7 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     color: #3ad;
 }
 .content .avatar-grid .username {
-    color: #069bc0;
+    color: $color-a;
 }
 .avatar-grid .button {
     padding: 4px 0;
@@ -1000,27 +1011,23 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
 /* ------------------------------------ =thumbnails -- */
 
 .thumbnail-grid {
-    margin-right: -8px;
-    letter-spacing: -0.31em;
-    text-rendering: optimizeSpeed;
-    text-align: center;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
 }
-.thumbnail-grid .item, .thumbnail-grid .more {
-    letter-spacing: normal;
-    text-rendering: auto;
+.thumbnail-grid .more {
+    width: 100%;
 }
 .thumbnail-grid .item {
     box-sizing: border-box;
     display: inline-block;
     vertical-align: bottom;
     max-width: 43.5%;
-    padding: 0 8px 8px 0;
-    margin: 0 8px;
-    text-align: left;
+    margin: 0 4px 8px 4px;
 }
 .enhanced-thumbnails .thumbnail-grid .item {
-    margin: 0;
     max-width: 100%;
+    padding-left: 0;
 }
 .thumbnail-grid .thumb {
     display: block;
@@ -1039,8 +1046,6 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
 .thumbnail-grid figcaption {
     box-sizing: border-box;
     width: 100%;
-}
-.enhanced-thumbnails .thumbnail-grid figcaption {
     position: absolute;
     bottom: 5px;
     left: 0;
@@ -1085,7 +1090,7 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     color: #3ad;
 }
 .content .thumbnail-grid .username {
-    color: #069bc0;
+    color: $color-a;
 }
 .thumbnail-grid .username:hover {
     opacity: 1;
@@ -2141,67 +2146,201 @@ blockquote + blockquote {
 
 /* ------------------------------------ =homepage --*/
 
-#home-art {
-    padding-bottom: 8px;
-    padding-bottom: 0.5rem;
+.home-latest {
+    margin: 8px 0;
 }
 
-#home-art h3 {
-    font-size: 21px;
-    font-size: 1.3rem;
-    padding-top: 20px;
-    padding-top: 1.25rem;
-    padding-bottom: 8px;
-    padding-bottom: 0.5rem;
-    font-weight: 400;
+.home-tab-collapse {
+    display: none;
 }
 
-#home-tabs, #home-panes {
-    clear: both;
+#home-panes > .pane > .thumbnail-grid {
+    display: none;
+    padding: 8px 0;
+}
+
+#home-panes > .pane.current > .thumbnail-grid {
+    display: flex;
 }
 
 #home-tabs {
-    display: none;
+    display: flex;
+    flex-wrap: wrap;
 }
 
-.home-disclosure {
-    position: relative;
+.home-pane-link {
+    @extend .typeface-a;
+    @extend .color-c;
+    display: block;
+    padding: 0 16px;
+    line-height: 48px;
+    margin: 0;
+    font-size: 16px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+
+    @media (min-width: 53em) {
+        padding: 0 32px;
+    }
+
+    &:hover {
+        text-decoration: none;
+        color: #ddd;
+    }
+
+    &.current {
+        color: $color-a;
+    }
 }
 
-.home-disclosure .icon {
-    position: absolute;
-    right: 16px;
-    right: 1rem;
-    top: 50%;
-    margin-top: -10px;
-    transition: transform 0.2s linear;
-}
+@media (max-width: 500px) {
+    #home-tabs > li {
+        flex-grow: 1;
+    }
 
-.home-disclosure.loaded .icon {
-    transform: rotate(90deg);
+    .home-pane-link {
+        font-size: 14px;
+        padding: 0;
+        text-align: center;
+    }
 }
 
 #home-panes .thumbnail-grid {
-    display: none;
-    padding: 16px 0;
-    padding: 1rem 0;
-}
-
-#home-panes .thumbnail-grid.loaded {
-    display: block;
+    padding-bottom: 8px;
+    padding-bottom: 0.5rem;
 }
 
 #home-content {
     padding-bottom: 24px;
-    padding-bottom: 1.5rem;
 }
 
-#hc-critique li + li, #hc-streams li + li {
-    padding-top: 1rem;
+#hc-streams {
+    @extend .pad-left;
+    @extend .pad-right;
+    color: rgba(235, 234, 233, 0.8);
+    display: flex;
+    flex-direction: column;
+    padding-top: 24px;
+    padding-bottom: 24px;
 }
 
-#hc-streams .title {
-    color: #808080;
+#hc-streams a {
+    color: $color-a;
+}
+
+#hc-streams > h3 {
+    color: #ddd;
+    font-size: 19px;
+    font-weight: 400;
+    padding-bottom: 24px;
+    text-align: center;
+}
+
+#hc-streams > .streams-empty {
+    text-align: center;
+}
+
+.streams {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin: 0 auto;
+    max-width: 100%;
+
+    > li {
+        flex: 1;
+        min-width: 0;
+    }
+}
+
+.stream {
+    display: flex;
+    max-width: 50em;
+    margin-bottom: 32px;
+}
+
+.stream-detail {
+    border-left: 3px solid rgba(235, 234, 233, 0.07);
+    display: flex;
+    flex-direction: column;
+    margin-left: 16px;
+    min-width: 0;
+    padding-left: 16px;
+}
+
+.stream-header {
+    @include serif;
+    color: scale-color($color-a, $saturation: -75%, $lightness: 15%);
+    font-style: italic;
+}
+
+.stream-header > .username {
+    font-size: 16px;
+    font-style: normal;
+    margin-right: 4px;
+}
+
+.stream-link {
+    font-size: 14px;
+    margin-top: auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.streams-footer {
+    text-align: center;
+}
+
+.streams-all {
+    font-size: 16px;
+
+    &::after {
+        content: ' ›';
+    }
+}
+
+@supports (column-gap: 40px) {
+    @media (min-width: 1280px) {
+        .streams-sample {
+            display: inline-grid;
+            grid-auto-columns: 1fr;
+            grid-auto-flow: column;
+            column-gap: 40px;
+            padding: 0 40px;
+        }
+    }
+}
+
+.hc-update-header {
+    padding-bottom: 24px;
+}
+
+#hc-update .hc-update-title {
+    padding-bottom: 4px;
+    text-align: center;
+}
+
+.hc-update-footer {
+    margin-top: 8px;
+}
+
+.hc-update-attribution {
+    @include serif;
+    font-style: italic;
+    text-align: center;
+
+    > .username {
+        font-style: normal;
+        text-decoration: none;
+    }
+
+    > .username > img {
+        vertical-align: middle;
+        width: 25px;
+        height: 25px;
+    }
 }
 
 #view-streams-link {
@@ -2210,89 +2349,16 @@ blockquote + blockquote {
 }
 
 @media (min-width: 45em) {
-    #home-art h3 {
-        font-size: 24px;
-        font-size: 1.5rem;
-    }
-
-    .home-disclosure {
-        display: none;
-    }
-
-    #home-tabs {
-        display: block;
-        margin-top: 8px;
-        margin-top: 0.5rem;
-    }
-
-    #home-tabs li a {
-        display: block;
-        float: left;
-        height: 48px;
-        height: 3rem;
-        line-height: 48px;
-        line-height: 3rem;
-        margin: 0;
-        font-size: 16px;
-        font-size: 1rem;
-        background: transparent;
-        border: none;
-        cursor: pointer;
-    }
-
-    #home-tabs li a:hover {
-        text-decoration: none;
-        color: #ddd;
-    }
-
-    #home-panes .thumbnail-grid {
-        padding-bottom: 8px;
-        padding-bottom: 0.5rem;
-    }
-
-    #home-panes .thumbnail-grid.loaded {
-        display: none;
-    }
-
-    #home-panes .thumbnail-grid.current {
-        display: block !important;
-    }
-
-    #hc-update .avatar {
-        max-width: 75px;
-        margin-bottom: 1em;
-    }
-
-    #hc-critique, #hc-streams {
-        width: 48%;
-        float: left;
-    }
-
-    #hc-streams.fullpage {
-        width: auto;
-        float: none;
+    .home-tab-collapse {
+        display: inline;
     }
 
     #hc-streams {
-        padding-left: 4%;
-    }
-}
-
-@media (min-width: 53em) {
-    #home-art {
-        padding-bottom: 16px;
-        padding-bottom: 1rem;
-    }
-}
-
-@media (min-width: 70em) {
-    #hc-update, #hc-critique, #hc-streams {
-        width: 30%;
-        float: left;
+        padding: 28px 0;
     }
 
-    #hc-critique, #hc-streams {
-        padding-left: 5%;
+    #hc-streams > h3 {
+        font-size: 24px;
     }
 }
 
@@ -3090,7 +3156,7 @@ img + #detail-art-text {
     opacity: 0.5;
 }
 .detail-folder-nav a {
-    color: #069bc0;
+    color: $color-a;
 }
 .detail-folder-nav a:hover {
     text-decoration: none;
@@ -4448,38 +4514,12 @@ a.user-icon:hover > span, a.user-icon:focus > span {
     opacity: 0.5;
 }
 
-/* Thumbnail stacks
+/* Streams page
 --------------------------------*/
-.thumbnail-stack .thumb-bounds {
-    max-width: 40%;
-    float: left;
-    margin-right: 10px;
-    position: relative;
+#streams .streams > li:last-child > .stream {
+    margin-bottom: 0;
 }
 
-.thumbnail-stack .thumb-bounds img {
-    max-width: 100%;
-    vertical-align: top;
-}
-
-.thumbnail-stack .rating {
-    width: 60px;
-    height: 60px;
-    border-style: solid;
-    border-width: 0 4px 4px 0;
-    position: absolute;
-    right: -2px;
-    bottom: -2px;
-    color: transparent;
-    overflow: hidden;
-    text-indent: 150%;
-    z-index: 3;
-}
-
-.thumbnail-stack .caption {
-    margin-top: 10px;
-}
-
-.thumbnail-stack .caption .title {
-    font-size: 13px;
+#streams .stream-detail {
+    border-left-color: rgba(0, 0, 0, 0.07);
 }

--- a/libweasyl/libweasyl/alembic/versions/571762845c10_index_critique_requests.py
+++ b/libweasyl/libweasyl/alembic/versions/571762845c10_index_critique_requests.py
@@ -1,0 +1,22 @@
+"""Index critique requests
+
+Revision ID: 571762845c10
+Revises: e2bedd00b085
+Create Date: 2021-08-09 05:05:25.910797
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '571762845c10'
+down_revision = 'e2bedd00b085'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_index('ind_submission_submitid_critique', 'submission', ['submitid'], unique=False, postgresql_where=sa.text('critique AND NOT hidden'))
+
+
+def downgrade():
+    op.drop_index('ind_submission_submitid_critique', table_name='submission', postgresql_where=sa.text('critique AND NOT hidden'))

--- a/libweasyl/libweasyl/legacy.py
+++ b/libweasyl/libweasyl/legacy.py
@@ -10,11 +10,17 @@ to use them.
 import string
 import unicodedata
 
+import sqlalchemy as sa
+from sqlalchemy import func
+
 
 UNIXTIME_OFFSET = -18000
 """
 The offset added to UNIX timestamps before storing them in the database.
 """
+
+
+UNIXTIME_NOW_SQL = func.extract('epoch', func.now()).cast(sa.BigInteger()) + sa.bindparam('offset', UNIXTIME_OFFSET, literal_execute=True)
 
 
 _SYSNAME_CHARACTERS = frozenset(string.ascii_lowercase + string.digits)

--- a/libweasyl/libweasyl/models/helpers.py
+++ b/libweasyl/libweasyl/models/helpers.py
@@ -201,6 +201,7 @@ CharSettings.associate_with(CharSettingsColumn)
 
 class WeasylTimestampColumn(types.TypeDecorator):
     impl = types.INTEGER
+    cache_ok = True
 
     def process_result_value(self, value, dialect):
         if value is None:

--- a/libweasyl/libweasyl/models/site.py
+++ b/libweasyl/libweasyl/models/site.py
@@ -1,23 +1,8 @@
 from sqlalchemy.orm import relationship
 
-from libweasyl import staff
 from libweasyl.models.meta import Base
 from libweasyl.models.users import Login
 from libweasyl.models import tables
-
-
-class SiteUpdate(Base):
-    __table__ = tables.siteupdate
-
-    owner = relationship(Login, backref='siteupdate')
-
-    def get_display_owner(self):
-        if self.wesley and staff.WESLEY is not None:
-            wesley = Login.query.get(staff.WESLEY)
-            if wesley is not None:
-                return wesley
-
-        return self.owner
 
 
 class SavedNotification(Base):

--- a/libweasyl/libweasyl/models/tables.py
+++ b/libweasyl/libweasyl/models/tables.py
@@ -740,7 +740,7 @@ submission = Table(
 Index('ind_submission_folderid', submission.c.folderid)
 Index('ind_submission_userid_submitid', submission.c.userid, submission.c.submitid)
 Index('ind_submission_userid_folderid_submitid', submission.c.userid, submission.c.folderid, submission.c.submitid, postgresql_where=submission.c.folderid.isnot(None))
-Index('ind_submission_userid_unixtime', submission.c.userid, submission.c.unixtime.desc())
+Index('ind_submission_submitid_critique', submission.c.submitid, postgresql_where=submission.c.critique & ~submission.c.hidden)
 
 
 submission_media_links = Table(
@@ -822,8 +822,8 @@ Index('ind_user_links_userid', user_links.c.userid)
 user_streams = Table(
     'user_streams', metadata,
     Column('userid', Integer(), primary_key=True, nullable=False),
-    Column('start_time', WeasylTimestampColumn(), nullable=False),
-    Column('end_time', WeasylTimestampColumn(), nullable=False),
+    Column('start_time', Integer(), nullable=False),
+    Column('end_time', Integer(), nullable=False),
     default_fkey(['userid'], ['login.userid'], name='user_streams_userid_fkey'),
 )
 

--- a/weasyl/blocktag.py
+++ b/weasyl/blocktag.py
@@ -85,9 +85,6 @@ def insert(userid, title, rating):
 
     select_ids.invalidate(userid)
 
-    from weasyl import index
-    index.template_fields.invalidate(userid)
-
 
 def remove(userid, title):
     d.engine.execute(
@@ -97,6 +94,3 @@ def remove(userid, title):
     )
 
     select_ids.invalidate(userid)
-
-    from weasyl import index
-    index.template_fields.invalidate(userid)

--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -299,7 +299,7 @@ def api_user_view_(request):
         more_submissions = 'characters'
         featured = None
     else:
-        submissions = submission.select_list(userid, rating, 11, otherid=otherid, profile_page_filter=True)
+        submissions = submission.select_list(userid, rating, limit=11, otherid=otherid, profile_page_filter=True)
         more_submissions = 'submissions'
         featured = submission.select_featured(userid, otherid, rating)
 
@@ -352,7 +352,7 @@ def api_user_gallery_(request):
         count = min(count or 100, 100)
 
     submissions = submission.select_list(
-        request.userid, d.get_rating(request.userid), count + 1,
+        request.userid, d.get_rating(request.userid), limit=count + 1,
         otherid=userid, folderid=folderid, backid=backid, nextid=nextid)
     backid, nextid = d.paginate(submissions, backid, nextid, count, 'submitid')
 

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -1,14 +1,12 @@
 import itertools
 
+from pyramid.httpexceptions import HTTPNotFound
 from pyramid.response import Response
-from sqlalchemy.orm import joinedload
 
 from libweasyl import ratings
 from libweasyl import staff
-from libweasyl.media import get_multi_user_media
-from libweasyl.models.site import SiteUpdate
 
-from weasyl import comment, define, index, macro, search, profile, submission
+from weasyl import comment, define, index, macro, search, profile, siteupdate, submission
 
 
 # General browsing functions
@@ -16,6 +14,14 @@ def index_(request):
     page = define.common_page_start(request.userid, title="Home", canonical_url="/")
     page.append(define.render("etc/index.html", index.template_fields(request.userid)))
     return Response(define.common_page_end(request.userid, page))
+
+
+_BROWSE = {
+    'submit': ("Submissions", "Browse Submissions"),
+    'char': ("Characters", "Browse Characters"),
+    'journal': ("Journals", "Browse Journals"),
+    'critique': ("Critique requests", "Browse Critique Requests"),
+}
 
 
 def search_(request):
@@ -29,8 +35,6 @@ def search_(request):
     subcat = request.params.get('subcat')
     backid = request.params.get('backid')
     nextid = request.params.get('nextid')
-
-    page = define.common_page_start(request.userid, title="Browse and search")
 
     if q:
         if find not in ("submit", "char", "journal", "user"):
@@ -67,9 +71,10 @@ def search_(request):
                 backid=meta["backid"],
                 nextid=meta["nextid"])
 
-        page.append(define.render("etc/search.html", [
+        title = "Search results"
+        template_args = (
             # Search method
-            {"method": "search"},
+            "search",
             # Search metadata
             meta,
             # Search results
@@ -79,8 +84,11 @@ def search_(request):
             # Submission subcategories
             macro.MACRO_SUBCAT_LIST,
             search.COUNT_LIMIT,
-        ]))
+        )
     elif find:
+        if find not in ("submit", "char", "journal", "user", "critique"):
+            raise HTTPNotFound()
+
         query = search.browse(
             userid=request.userid,
             rating=rating,
@@ -96,22 +104,25 @@ def search_(request):
             "cat": int(cat) if cat else None,
         }
 
-        page.append(define.render("etc/search.html", [
+        title, browse_header = _BROWSE[find]
+        template_args = (
             # Search method
-            {"method": "browse"},
+            "browse",
             # Search metadata
             meta,
             # Search results
             query,
             0,
             0,
-        ]))
+            None,
+            None,
+            browse_header,
+        )
     else:
-        backid = define.get_int(backid)
-        nextid = define.get_int(nextid)
-        page.append(define.render("etc/search.html", [
+        title = "Browse"
+        template_args = (
             # Search method
-            {"method": "summary"},
+            "summary",
             # Search metadata
             None,
             # Search results
@@ -121,49 +132,42 @@ def search_(request):
                     rating=rating,
                     limit=22,
                     find="submit",
-                    cat=cat,
-                    backid=backid,
-                    nextid=nextid
+                    cat=None,
+                    backid=None,
+                    nextid=None,
                 ),
                 "char": search.browse(
                     userid=request.userid,
                     rating=rating,
                     limit=22,
                     find="char",
-                    cat=cat,
-                    backid=backid,
-                    nextid=nextid
+                    cat=None,
+                    backid=None,
+                    nextid=None,
                 ),
                 "journal": search.browse(
                     userid=request.userid,
                     rating=rating,
                     limit=22,
                     find="journal",
-                    cat=cat,
-                    backid=backid,
-                    nextid=nextid
+                    cat=None,
+                    backid=None,
+                    nextid=None,
                 ),
             },
-        ]))
+        )
 
-    return Response(define.common_page_end(request.userid, page, options={'search'}))
+    return Response(define.webpage(request.userid, "etc/search.html", template_args, options=('search',), title=title))
 
 
 def streaming_(request):
     return Response(define.webpage(request.userid, 'etc/streaming.html',
-                                   (profile.select_streaming(request.userid, 300, order_by="start_time desc"),),
+                                   (profile.select_streaming(request.userid),),
                                    title="Streaming"))
 
 
 def site_update_list_(request):
-    updates = (
-        SiteUpdate.query
-        .order_by(SiteUpdate.updateid.desc())
-        .options(joinedload('owner'))
-        .all()
-    )
-    get_multi_user_media(*[update.userid for update in updates])
-
+    updates = siteupdate.select_list()
     can_edit = request.userid in staff.ADMINS
 
     return Response(define.webpage(request.userid, 'etc/site_update_list.html', (request, updates, can_edit), title="Site Updates"))
@@ -171,7 +175,7 @@ def site_update_list_(request):
 
 def site_update_(request):
     updateid = int(request.matchdict['update_id'])
-    update = SiteUpdate.query.get_or_404(updateid)
+    update = siteupdate.select_view(updateid)
     myself = profile.select_myself(request.userid)
     comments = comment.select(request.userid, updateid=updateid)
 

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -13,7 +13,17 @@ from weasyl import comment, define, index, macro, search, profile, siteupdate, s
 def index_(request):
     page = define.common_page_start(request.userid, title="Home", canonical_url="/")
     page.append(define.render("etc/index.html", index.template_fields(request.userid)))
-    return Response(define.common_page_end(request.userid, page))
+
+    if request.userid == 0:
+        cache_control = "public, max-age=60, stale-while-revalidate=600"
+    else:
+        cache_control = "private, max-age=60"
+
+    return Response(
+        define.common_page_end(request.userid, page),
+        cache_control=cache_control,
+        vary=["Cookie"],  # SFW mode, sign in/out, account changes
+    )
 
 
 _BROWSE = {

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -96,7 +96,7 @@ def search_(request):
             search.COUNT_LIMIT,
         )
     elif find:
-        if find not in ("submit", "char", "journal", "user", "critique"):
+        if find not in ("submit", "char", "journal", "critique"):
             raise HTTPNotFound()
 
         query = search.browse(

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -76,7 +76,7 @@ def profile_(request):
         featured = None
     else:
         submissions = submission.select_list(
-            request.userid, rating, 11, otherid=otherid,
+            request.userid, rating, limit=11, otherid=otherid,
             profile_page_filter=True)
         more_submissions = 'submissions'
         featured = submission.select_featured(request.userid, otherid, rating)

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -11,7 +11,7 @@ from weasyl.error import WeasylError
 from weasyl import (
     api, avatar, banner, blocktag, collection, commishinfo,
     define, emailer, folder, followuser, frienduser, ignoreuser,
-    index, login, oauth2, profile, searchtag, thumbnail, useralias, orm)
+    login, oauth2, profile, searchtag, thumbnail, useralias, orm)
 
 
 # Control panel functions
@@ -353,8 +353,6 @@ def control_editpreferences_post_(request):
 
     profile.edit_preferences(request.userid, timezone=form.timezone,
                              preferences=preferences, jsonb_settings=jsonb_settings)
-    # release the cache on the index page in case the Maximum Viewable Content Rating changed.
-    index.template_fields.invalidate(request.userid)
     raise HTTPSeeOther(location="/control")
 
 
@@ -795,8 +793,6 @@ def sfw_toggle_(request):
 
     currentstate = request.cookies.get('sfwmode', "nsfw")
     newstate = "sfw" if currentstate == "nsfw" else "nsfw"
-    # release the index page's cache so it shows the new ratings if they visit it
-    index.template_fields.invalidate(request.userid)
     response = HTTPSeeOther(location=form.redirect)
     response.set_cookie("sfwmode", newstate, max_age=60 * 60 * 24 * 365)
     return response

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm.attributes import flag_modified
 from weasyl import (
     define,
     emailer,
-    index,
     login,
     moderation,
     profile,
@@ -47,8 +46,6 @@ def signin_post_(request):
                             secure=request.scheme == 'https', httponly=True)
         if form.sfwmode == "sfw":
             response.set_cookie("sfwmode", "sfw", max_age=31536000)
-        # Invalidate cached versions of the frontpage to respect the possibly changed SFW settings.
-        index.template_fields.invalidate(logid)
         return response
     elif logid and logerror == "2fa":
         # Password authentication passed, but user has 2FA set, so verify second factor
@@ -82,8 +79,6 @@ def signin_post_(request):
                             secure=request.scheme == 'https', httponly=True)
         if form.sfwmode == "sfw":
             response.set_cookie("sfwmode", "sfw", max_age=31536000)
-        # Invalidate cached versions of the frontpage to respect the possibly changed SFW settings.
-        index.template_fields.invalidate(logid)
         return response
     elif logerror == "invalid":
         return Response(define.webpage(request.userid, "etc/signin.html", [True, form.referer]))

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -154,6 +154,7 @@ def _compile(template_name):
                 "CSRF": (lambda: ""),
                 "USER_TYPE": user_type,
                 "DATE": convert_date,
+                "ISO8601": iso8601,
                 "ISO8601_DATE": iso8601_date,
                 "TIME": _convert_time,
                 "LOCAL_ARROW": local_arrow,
@@ -521,8 +522,11 @@ def request_timezone(request):
 
 
 def local_arrow(dt):
+    if isinstance(dt, int):
+        dt = arrow.get(dt - _UNIXTIME_OFFSET)
+
     tz = request_timezone(get_current_request())
-    return arrow.Arrow.fromdatetime(tz.localtime(dt))
+    return dt.to(tz.timezone)
 
 
 def convert_to_localtime(target):

--- a/weasyl/ignoreuser.py
+++ b/weasyl/ignoreuser.py
@@ -71,9 +71,6 @@ def insert(userid, ignore):
 
     cached_list_ignoring.invalidate(userid)
 
-    from weasyl import index
-    index.template_fields.invalidate(userid)
-
 
 def remove(userid, ignore):
     if not ignore:
@@ -84,6 +81,3 @@ def remove(userid, ignore):
 
     if result.rowcount:
         cached_list_ignoring.invalidate(userid)
-
-        from weasyl import index
-        index.template_fields.invalidate(userid)

--- a/weasyl/index.py
+++ b/weasyl/index.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import operator
+import random
 
 from libweasyl import ratings
 from libweasyl.cache import region
@@ -10,6 +11,7 @@ from weasyl import character
 from weasyl import define as d
 from weasyl import ignoreuser
 from weasyl import macro as m
+from weasyl import media
 from weasyl import profile
 from weasyl import searchtag
 from weasyl import siteupdate
@@ -39,10 +41,11 @@ def recent_submissions():
 
     submissions.extend(characters)
     submissions.sort(key=operator.itemgetter('unixtime'), reverse=True)
+    media.strip_non_thumbnail_media(submissions)
     return submissions
 
 
-def filter_submissions(userid, submissions, incidence_limit=3):
+def filter_submissions(userid, submissions, incidence_limit=None):
     """
     Filters a list of submissions according to the user's preferences and
     optionally limits the number of items returned from one submitter.
@@ -89,29 +92,33 @@ def partition_submissions(submissions):
         else:
             bucket = s['subtype'] // 1000
         buckets[bucket].append(s)
-    ret = [
+
+    return (
         submissions[:22],
-        d.get_random_set(submissions, 11),
-    ]
-    for bucket in [1, 2, 3, 'char']:
-        ret.append(buckets[bucket][:11])
-    return ret
+        buckets[1][:11],
+        buckets[2][:11],
+        buckets[3][:11],
+        buckets['char'][:11],
+    )
 
 
-@region.cache_on_arguments(expiration_time=60)
 @d.record_timing
 def template_fields(userid):
-    rating = d.get_rating(userid)
     submissions = list(filter_submissions(userid, recent_submissions()))
     ret = partition_submissions(submissions)
 
-    return ret + [
+    critique = submission.select_critique()
+    random.shuffle(critique)
+    critique = list(itertools.islice(filter_submissions(userid, critique, incidence_limit=1), 11))
+    critique.sort(key=lambda sub: sub['submitid'], reverse=True)
+
+    return ret + (
         # Recent site news update
         siteupdate.select_last(),
         # Recent critique submissions
-        submission.select_list(userid, rating, 4, options=["critique"]),
+        critique,
         # Currently streaming users
-        profile.select_streaming(userid, 4),
+        profile.select_streaming_sample(userid),
         # Recently popular submissions
         list(itertools.islice(filter_submissions(userid, submission.select_recently_popular(), incidence_limit=1), 11)),
-    ]
+    )

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -1,6 +1,9 @@
 import os
 
+import sqlalchemy as sa
+
 from libweasyl import ratings
+from libweasyl.models import tables as t
 
 
 MACRO_EMAIL_ADDRESS = "weasyl@weasyl.com"
@@ -10,6 +13,18 @@ MACRO_BCRYPT_ROUNDS = 13
 
 # Example input (userid, "su")
 MACRO_IGNOREUSER = " AND NOT EXISTS (SELECT 0 FROM ignoreuser WHERE (userid, otherid) = (%i, %s.userid))"
+
+
+def not_ignored(otherid_expr):
+    ignore_match = (
+        sa.select()
+        .select_from(t.ignoreuser)
+        .where(t.ignoreuser.c.userid == sa.bindparam('userid'))
+        .where(t.ignoreuser.c.otherid == otherid_expr)
+    )
+
+    return ~ignore_match.exists()
+
 
 # Example input (userid, userid)
 MACRO_BLOCKTAG_SUBMIT = (

--- a/weasyl/media.py
+++ b/weasyl/media.py
@@ -73,3 +73,16 @@ def format_media_link(media, link):
         return define.cdnify_url(media.display_url)
     else:
         return None
+
+
+def strip_non_thumbnail_media(submissions):
+    """
+    Remove all media from a submission dict except what’s necessary to render its thumbnail.
+
+    Useful for reducing the size of JSON in cache.
+    """
+    for sub in submissions:
+        sub_media = sub["sub_media"]
+        sub_media.pop("thumbnail-source", None)
+        sub_media.pop("cover", None)
+        sub_media.pop("submission", None)

--- a/weasyl/moderation.py
+++ b/weasyl/moderation.py
@@ -600,7 +600,7 @@ def removethumbnail(userid, submitid):
     thumbnail.clear_thumbnail(userid, submitid)
     # Thumbnails may be cached on the front page, so invalidate that cache.
     index.recent_submissions.invalidate()
-    index.template_fields.invalidate(userid)
+    submission.select_critique.invalidate(userid)
     otherid = sub.owner.userid
     title = sub.title
     note_about(userid, otherid, 'Thumbnail was removed for ' +

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -392,5 +392,6 @@ def browse(userid, rating, limit, find, cat, backid, nextid):
     elif find == "journal":
         return journal.select_user_list(userid, rating, limit, backid=backid, nextid=nextid)
     else:
-        return submission.select_list(userid, rating, limit, backid=backid, nextid=nextid,
-                                      subcat=d.get_int(cat) if d.get_int(cat) in [1000, 2000, 3000] else None)
+        return submission.select_list(userid, rating, limit=limit, backid=backid, nextid=nextid,
+                                      subcat=d.get_int(cat) if d.get_int(cat) in [1000, 2000, 3000] else None,
+                                      critique_only=find == "critique")

--- a/weasyl/siteupdate.py
+++ b/weasyl/siteupdate.py
@@ -1,40 +1,136 @@
-import arrow
+import sqlalchemy as sa
+from pyramid.httpexceptions import HTTPNotFound
+from sqlalchemy import func
 
 from libweasyl import staff
-from libweasyl.models.site import SiteUpdate
+from libweasyl.cache import region
+from libweasyl.legacy import UNIXTIME_NOW_SQL
+from libweasyl.models import tables as t
 from weasyl import define as d
 from weasyl import media
 from weasyl import welcome
 
 
-def create(userid, title, content, wesley=False):
-    update = SiteUpdate(
-        userid=userid,
-        wesley=wesley,
-        title=title,
-        content=content,
-        unixtime=arrow.utcnow(),
+_SELECT_BASE = (
+    sa.select(
+        t.siteupdate.c.updateid,
+        t.profile.c.userid,
+        t.siteupdate.c.title,
+        t.siteupdate.c.content,
+        sa.type_coerce(t.siteupdate.c.unixtime, sa.Integer()).label('unixtime'),
+        t.profile.c.username,
     )
+    .select_from(
+        t.siteupdate.outerjoin(t.profile, t.profile.c.userid == sa.case(
+            (t.siteupdate.c.wesley, sa.bindparam('wesley', callable_=lambda: staff.WESLEY)),
+            else_=t.siteupdate.c.userid,
+        ))
+    )
+)
 
-    SiteUpdate.dbsession.add(update)
-    SiteUpdate.dbsession.flush()
-    welcome.site_update_insert(update.updateid)
+_SELECT_VIEW = (
+    _SELECT_BASE
+    .add_columns(t.siteupdate.c.wesley)
+    .where(t.siteupdate.c.updateid == sa.bindparam("updateid"))
+)
 
-    return update
+_SELECT_LAST = (
+    _SELECT_BASE
+    .add_columns(
+        sa.select(func.count())
+        .select_from(t.siteupdatecomment)
+        .where(t.siteupdatecomment.c.targetid == t.siteupdate.c.updateid)
+        .where(t.siteupdatecomment.c.hidden_at.is_(None))
+        .label("comment_count"),
+    )
+    .order_by(t.siteupdate.c.updateid.desc())
+    .limit(1)
+).compile()
+
+_SELECT_LIST = (
+    _SELECT_BASE
+    .order_by(t.siteupdate.c.updateid.desc())
+).compile()
+
+_CREATE = (
+    t.siteupdate.insert()
+    .values({
+        "userid": sa.bindparam("userid"),
+        "title": sa.bindparam("title"),
+        "content": sa.bindparam("content"),
+        "wesley": sa.bindparam("wesley"),
+        "unixtime": UNIXTIME_NOW_SQL,
+    })
+    .returning(t.siteupdate.c.updateid)
+).compile()
+
+_EDIT = (
+    t.siteupdate.update()
+    .where(t.siteupdate.c.updateid == sa.bindparam("updateid"))
+    .values({
+        "title": sa.bindparam("title"),
+        "content": sa.bindparam("content"),
+        "wesley": sa.bindparam("wesley"),
+    })
+).compile()
 
 
+@region.cache_on_arguments(should_cache_fn=bool)
+def select_view(updateid):
+    update = d.engine.execute(_SELECT_VIEW, {"updateid": updateid}).one_or_none()
+
+    if update is None:
+        raise HTTPNotFound()
+
+    return {
+        **update,
+        "user_media": media.get_user_media(update.userid),
+    }
+
+
+@region.cache_on_arguments()
 def select_last():
-    last = d.engine.execute("""
-        SELECT
-            up.updateid, pr.userid, pr.username, up.title, up.content, up.unixtime,
-            (SELECT count(*) FROM siteupdatecomment c WHERE c.targetid = up.updateid) AS comment_count
-        FROM siteupdate up
-            LEFT JOIN profile pr ON pr.userid = CASE WHEN up.wesley THEN %(wesley)s ELSE up.userid END
-        ORDER BY updateid DESC
-        LIMIT 1
-    """, wesley=staff.WESLEY).first()
+    last = d.engine.execute(_SELECT_LAST).one_or_none()
 
-    if not last:
+    if last is None:
         return None
 
-    return dict(last, user_media=media.get_user_media(last.userid))
+    return {
+        **last,
+        "user_media": media.get_user_media(last.userid),
+    }
+
+
+def select_list():
+    updates = [row._asdict() for row in d.engine.execute(_SELECT_LIST)]
+    media.populate_with_user_media(updates)
+    return updates
+
+
+def create(*, userid, title, content, wesley):
+    updateid = d.engine.execute(_CREATE, {
+        "userid": userid,
+        "title": title,
+        "content": content,
+        "wesley": wesley,
+    }).scalar_one()
+
+    select_last.invalidate()
+    welcome.site_update_insert(updateid)
+
+    return updateid
+
+
+def edit(*, updateid, title, content, wesley):
+    result = d.engine.execute(_EDIT, {
+        "updateid": updateid,
+        "title": title,
+        "content": content,
+        "wesley": wesley,
+    })
+
+    if result.rowcount != 1:
+        raise HTTPNotFound()
+
+    select_view.invalidate(updateid)
+    select_last.invalidate()

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1077,14 +1077,10 @@ def select_recently_popular():
     """
     query = d.engine.execute("""
         SELECT
-            log(submission.favorites + 1) +
-                log(submission.page_views + 1) / 2 +
-                submission.unixtime / 180000.0 AS score,
             submission.submitid,
             submission.title,
             submission.rating,
             submission.subtype,
-            submission.unixtime,
             submission_tags.tags,
             submission.userid,
             profile.username
@@ -1094,10 +1090,14 @@ def select_recently_popular():
         WHERE
             NOT submission.hidden AND
             NOT submission.friends_only
-        ORDER BY score DESC
+        ORDER BY
+            log(submission.favorites + 1) +
+                log(submission.page_views + 1) / 2 +
+                submission.unixtime / 180000.0
+                DESC
         LIMIT 128
     """)
 
-    submissions = [dict(row, contype=10) for row in query]
+    submissions = [{**row, "contype": 10} for row in query]
     media.populate_with_submission_media(submissions)
     return submissions

--- a/weasyl/templates/admincontrol/siteupdate.html
+++ b/weasyl/templates/admincontrol/siteupdate.html
@@ -1,24 +1,24 @@
 $def with (update)
-$ is_new = not update.updateid
+$ is_new = not update['updateid']
 $:{TITLE("Submit Site Update" if is_new else "Edit Site Update", "Administrator Control Panel", "/admincontrol")}
 
 <div class="content">
-  <form id="submit-form" class="form wide" action="${'/admincontrol/siteupdate' if is_new else '/site-updates/%d' % (update.updateid,)}" method="post">
+  <form id="submit-form" class="form wide" action="${'/admincontrol/siteupdate' if is_new else '/site-updates/%d' % (update['updateid'],)}" method="post">
     $:{CSRF()}
 
     <h3>Content</h3>
 
     <label for="siteupdatetitle">Title</label>
-    <input type="text" class="input" name="title" id="siteupdatetitle" autofocus required value="${update.title}" />
+    <input type="text" class="input" name="title" id="siteupdatetitle" autofocus required value="${update['title']}" />
 
     <label for="siteupdatecontent">Content</label>
-    <textarea class="markdown input expanding last-input" name="content" rows="9" id="siteupdatecontent" required>${update.content}</textarea>
+    <textarea class="markdown input expanding last-input" name="content" rows="9" id="siteupdatecontent" required>${update['content']}</textarea>
     <br />
 
     <h3>Options</h3>
 
     <label class="input-checkbox">
-      <input type="checkbox" name="wesley"$:{' checked' if update.wesley else ''}>
+      <input type="checkbox" name="wesley"$:{' checked' if update['wesley'] else ''}>
       Post as Wesley
     </label>
 

--- a/weasyl/templates/common/thumbnail_grid_item.html
+++ b/weasyl/templates/common/thumbnail_grid_item.html
@@ -86,14 +86,6 @@ $def with (query, notifications=False, lazy_load=True)
         <a href="/~${LOGIN(query['username'])}" class="username">${query['username']}</a>
       </p>
     </figcaption>
-
-    $if 'subcat' in query:
-      $if query['subcat'] in [3010, 3020, 3030]:
-        <span class="icon icon-20 icon-music"></span>
-      $elif 4000 > query['subcat'] >= 3000:
-        <span class="icon icon-20 icon-multi"></span>
-      $elif 3000 > query['subcat'] >= 2000:
-        <span class="icon icon-20 icon-lit"></span>
   </figure>
 
   $if notifications:

--- a/weasyl/templates/common/thumbnail_grid_item.html
+++ b/weasyl/templates/common/thumbnail_grid_item.html
@@ -1,4 +1,4 @@
-$def with (query, notifications=None, lazy_load=True)
+$def with (query, notifications=False, lazy_load=True)
 
 <li class="item">
   $if notifications:
@@ -75,15 +75,14 @@ $def with (query, notifications=None, lazy_load=True)
         $else:
           href="/~${LOGIN(query['username'])}/submissions/${query['submitid']}/${SLUG(query['title'])}">${SUMMARIZE(query['title'], 52)}
       </a></h6>
-      <p class="byline"
-        $if query['contype'] == 40:
-          title="collected by $query['username']"
-        $elif query['contype'] == 20:
-          title="character of $query['username']"
-        $else:
-          title="by $query['username']"
-      >
-        <i>${'collected by' if query['contype'] == 40 else 'character of' if query['contype'] == 20 else 'by'}</i>
+      $code:
+        byline_prefix = (
+          'collected by' if query['contype'] == 40 else
+          'character of' if query['contype'] == 20 else
+          'by'
+        )
+      <p class="byline" title="$:{byline_prefix} ${query['username']}">
+        <i>$:{byline_prefix}</i>
         <a href="/~${LOGIN(query['username'])}" class="username">${query['username']}</a>
       </p>
     </figcaption>

--- a/weasyl/templates/etc/index.html
+++ b/weasyl/templates/etc/index.html
@@ -1,4 +1,4 @@
-$def with (everything, randomized, visual, literary, media, characters, update, critique, streaming, popular=None)
+$def with (everything, visual, literary, media, characters, update, critique, streaming, popular)
 $code:
   def _RATING(target):
     if target == R.MATURE.code:
@@ -9,149 +9,92 @@ $code:
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 <div id="home-art" class="stage">
 
-  <h3 class="pad-left typeface-a color-b">Latest Uploads</h3>
-
-  <ul class="thumbnail-grid large-footprint">
+  <ul class="home-latest thumbnail-grid medium-footprint">
     $# Items that are front and center on the main page, quite close to the top; skip lazy loading entirely.
     $for i in everything:
       $:{_GRID_ITEM(i, lazy_load=False)}
-    </li><li class="clear more"><a class="more" href="/search"><i>Browse</i> <span>Everything</span></a></li>
+    <li class="more"><a class="more" href="/search"><i>Browse</i> <span>Everything</span></a></li>
   </ul>
 
-  <ul id="home-tabs" class="bar clear">
-    $if popular:
-      <li><a class="home-pane-link typeface-a color-c pad-left pad-right current" href="#home-recently-popular">Recently Popular</a></li>
-    <li><a class="home-pane-link typeface-a color-c pad-left pad-right ${'current' if not popular else ''}" href="#home-random-art">Random Art</a></li>
-    <li><a class="home-pane-link typeface-a color-c pad-left pad-right" href="#home-literature">Literature</a></li>
-    <li><a class="home-pane-link typeface-a color-c pad-left pad-right" href="#home-multimedia">Multimedia</a></li>
-    <li><a class="home-pane-link typeface-a color-c pad-left pad-right" href="#home-characters">Characters</a></li>
+  <ul id="home-tabs" class="bar">
+    <li><a class="home-pane-link current" href="#home-recently-popular"><span class="home-tab-collapse">Recently </span>Popular</a></li>
+    <li><a class="home-pane-link" href="#home-critique">Critique<span class="home-tab-collapse"> Wanted</span></a></li>
+    <li><a class="home-pane-link" href="#home-literature">Writing</a></li>
+    <li><a class="home-pane-link" href="#home-multimedia">Multimedia</a></li>
+    <li><a class="home-pane-link" href="#home-characters">Characters</a></li>
   </ul>
 
   <div id="home-panes">
 
-    $if popular:
-      <div id="home-recently-popular" class="pane">
-        <a class="home-pane-link home-disclosure bar pad-left color-a typeface-a" href="#home-recently-popular">Recently Popular <span class="icon icon-20 icon-disclosure"></span></a>
-        <ul class="thumbnail-grid small-footprint current">
-          $for i in popular:
-            $:{_GRID_ITEM(i)}
-          </li><li class="clear more"><a class="more" href="/popular"><i>More</i> <span>Recently Popular</span></a></li>
-        </ul>
-      </div>
-
-    <div id="home-random-art" class="pane">
-      <a class="home-pane-link home-disclosure bar pad-left color-a typeface-a" href="#home-random-art">Random Art <span class="icon icon-20 icon-disclosure"></span></a>
-      <ul class="thumbnail-grid small-footprint ${'current' if not popular else ''}">
-        $for i in randomized:
+    <div id="home-recently-popular" class="pane current">
+      <ul class="thumbnail-grid small-footprint">
+        $for i in popular:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search"><i>More</i> <span>Random Art</span></a></li>
+        <li class="more"><a class="more" href="/popular"><i>More</i> <span>Recently Popular</span></a></li>
+      </ul>
+    </div>
+
+    <div id="home-critique" class="pane">
+      <ul class="thumbnail-grid small-footprint">
+        $for i in critique:
+          $:{_GRID_ITEM(i)}
+        <li class="more"><a class="more" href="/search?find=critique"><i>More</i> <span>Critique Requests</span></a></li>
       </ul>
     </div>
 
     <div id="home-literature" class="pane">
-      <a class="home-pane-link home-disclosure bar pad-left color-a typeface-a" href="#home-literature">Literature <span class="icon icon-20 icon-disclosure"></span></a>
       <ul class="thumbnail-grid small-footprint">
         $for i in literary:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search?find=submit&amp;cat=2000"><i>More</i> <span>Literature</span></a></li>
+        <li class="more"><a class="more" href="/search?find=submit&amp;cat=2000"><i>More</i> <span>Writing</span></a></li>
       </ul>
     </div>
 
     <div id="home-multimedia" class="pane">
-      <a class="home-pane-link home-disclosure bar pad-left color-a typeface-a" href="#home-multimedia">Multimedia <span class="icon icon-20 icon-disclosure"></span></a>
       <ul class="thumbnail-grid small-footprint">
         $for i in media:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search?find=submit&amp;cat=3000"><i>More</i> <span>Multimedia</span></a></li>
+        <li class="more"><a class="more" href="/search?find=submit&amp;cat=3000"><i>More</i> <span>Multimedia</span></a></li>
       </ul>
     </div>
 
     <div id="home-characters" class="pane">
-      <a class="home-pane-link home-disclosure bar pad-left color-a typeface-a" href="#home-characters">Characters <span class="icon icon-20 icon-disclosure"></span></a>
       <ul class="thumbnail-grid small-footprint">
         $for i in characters:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search?find=char"><i>More</i> <span>Characters</span></a></li>
+        <li class="more"><a class="more" href="/search?find=char"><i>More</i> <span>Characters</span></a></li>
       </ul>
     </div>
 
   </div>
 </div>
 
-<div id="home-content" class="content">
+<div id="hc-streams">
+  <h3 class="typeface-a">Streaming Now</h3>
 
-  $if update:
-    <div id="hc-update" class="clear">
-      <h3>${update['title']}</h3>
+  $if streaming.sample:
+    <ul class="streams streams-sample">
+      $for i in streaming.sample:
+        <li>
+          <figure class="stream">
+            <img class="stream-avatar" src="${i['user_media']['avatar'][0]['display_url']}" alt="" width="75" height="75" loading="lazy">
 
-      <figure class="thumbnail thumbnail-left clear">
-        <a class="avatar" href="/~${LOGIN(update['username'])}" title="${update['username']}">
-          $ avatar = update['user_media']['avatar'][0]
-          <img src="${avatar['display_url']}" alt="avatar of ${update['username']}" loading="lazy" />
-        </a>
-        <figcaption class="caption">
-          <h4 class="title"><i>Posted by</i> <a class="username" href="/~${LOGIN(update['username'])}">${update['username']}</a></h4>
-          <h5 class="date">${DATE(update['unixtime'])} <i>at</i> ${TIME(update['unixtime'])}</h5>
-        </figcaption>
-      </figure>
+            <div class="stream-detail">
+              <h4 class="stream-header"><a class="username" href="/~${LOGIN(i['username'])}">${i['username']}</a> since <time datetime="${ISO8601(i['stream_time'])}">${TIME(i['stream_time'])}</time></h4>
+              <p>${i['stream_text']}</p>
+              <p class="stream-link"><a href="${i['stream_url']}">${i['stream_url']}</a></p>
+            </div>
+          </figure>
+        </li>
+    </ul>
 
-      <div class="formatted-content">
-        $:{MARKDOWN(update['content'])}
-      </div>
-
-      $ comment_count = update.get('comment_count')
-      $if comment_count is not None:
-        <a href="/site-updates/${update['updateid']}" class="more more-block"><i>View</i> <span>This Update</span> <i>and</i> <span>${comment_count} Comment${'' if comment_count == 1 else 's'}</span></a>
+    <div class="streams-footer">
+      <a class="streams-all" href="/streaming">${streaming.total} total</a>
     </div>
-
-  <div id="hc-critique" class="clear">
-    <h3>Critique Wanted</h3>
-    $if critique:
-      <ul class="thumbnail-stack">
-        $for i in critique:
-          $code:
-            thumb = THUMB(i)
-            width = thumb['attributes']['width'] if 'attributes' in thumb else ""
-          <li class="clear">
-            <figure class="thumb">
-              <a class="thumb-bounds" href="/submission/${i['submitid']}/${SLUG(i['title'])}" title="${i['title']}">
-                $:{_RATING(i['rating'])}
-                <img src="${thumb['display_url']}" alt="thumbnail" loading="lazy" />
-              </a>
-              <figcaption class="caption">
-                <h6 class="title"><a href="/submission/${i['submitid']}/${SLUG(i['title'])}" title="${i['title']}">${SUMMARIZE(i['title'], 52)}</a></h6>
-                <p class="byline"><i>by</i> <a class="username" href="/~${LOGIN(i['username'])}">${i['username']}</a></p>
-              </figcaption>
-            </figure>
-          </li>
-      </ul>
-    $else:
-      <div class="color-lighter">There are no submissions to display.</div>
-  </div>
-
-  <div id="hc-streams" class="clear">
-    <h3>Streaming Now <a id="view-streams-link" href="/streaming">View All</a></h3>
-
-
-    $if(streaming):
-      <ul>
-        $for i in streaming:
-          <li class="clear">
-            <figure class="thumbnail thumbnail-left">
-              <a class="avatar" href="${i['stream_url']}" title="${i['username']}">
-                $ avatar = i['user_media']['avatar'][0]
-                <img src="${avatar['display_url']}" alt="avatar of ${i['username']}" loading="lazy" />
-              </a>
-              <figcaption class="caption">
-                <h4 class="title"><a class="username" href="/~${LOGIN(i['username'])}">${i['username']}</a> <i>since</i> ${TIME(i['stream_time'])}</h4>
-                <p>${i['stream_text']}</p>
-                <p><a href="${i['stream_url']}">${i['stream_url']}</a></p>
-              </figcaption>
-            </figure>
-          </li>
-      </ul>
-    $else:
-      <div class="color-lighter">There are no streams to display.</div>
-  </div>
-
+  $else:
+    <p class="streams-empty">Nobody is streaming right now.</p>
 </div>
+
+$if update:
+  $ _SITE_UPDATE = COMPILE("etc/site_update.html")
+  $:{_SITE_UPDATE(myself=None, update=update, comments=None)}

--- a/weasyl/templates/etc/popular.html
+++ b/weasyl/templates/etc/popular.html
@@ -10,7 +10,6 @@ $code:
 <div id="search-stage" class="stage clear">
   <ul class="thumbnail-grid">
     $for index, item in enumerate(submissions):
-      <!-- score: ${item['score']} -->
       $if index < 10:
         $:{_GRID_ITEM(item, lazy_load=False)}
       $else:

--- a/weasyl/templates/etc/popular.html
+++ b/weasyl/templates/etc/popular.html
@@ -10,9 +10,6 @@ $code:
 <div id="search-stage" class="stage clear">
   <ul class="thumbnail-grid">
     $for index, item in enumerate(submissions):
-      $if index < 10:
-        $:{_GRID_ITEM(item, lazy_load=False)}
-      $else:
-        $:{_GRID_ITEM(item)}
+      $:{_GRID_ITEM(item, lazy_load=index >= 10)}
   </ul>
 </div>

--- a/weasyl/templates/etc/search.html
+++ b/weasyl/templates/etc/search.html
@@ -91,10 +91,7 @@ $code:
           </p>
         <ul class="thumbnail-grid sectioned">
           $for index, result in enumerate(results):
-            $if index < 10:
-              $:{_GRID_ITEM(result, lazy_load=False)}
-            $else:
-              $:{_GRID_ITEM(result)}
+            $:{_GRID_ITEM(result, lazy_load=index >= 10)}
         </ul>
 
         <div style="padding-top: 1.4em;" class="pad-left pad-right">
@@ -124,10 +121,7 @@ $code:
     $if results:
       <ul class="thumbnail-grid">
         $for index, result in enumerate(results):
-          $if index < 10:
-            $:{_GRID_ITEM(result, lazy_load=False)}
-          $else:
-            $:{_GRID_ITEM(result)}
+          $:{_GRID_ITEM(result, lazy_load=index >= 10)}
       </ul>
 
       <div style="padding-top: 1.4em;" class="pad-left pad-right">

--- a/weasyl/templates/etc/search.html
+++ b/weasyl/templates/etc/search.html
@@ -1,9 +1,10 @@
-$def with (method, meta, results, next_count=0, back_count=0, subcats=None, count_limit=None)
+$def with (method, meta, results, next_count=0, back_count=0, subcats=None, count_limit=None, browse_header=None)
 $#:{TITLE("Weasyl Search")}
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 $code:
   id_fields = {
     'submit': 'submitid',
+    'critique': 'submitid',
     'char': 'charid',
     'journal': 'journalid',
     'user': 'userid',
@@ -11,7 +12,7 @@ $code:
 
 <div id="search-stage" class="stage clear">
 
-  $if method['method'] == "search":
+  $if method == "search":
     <h2 class="page-title">Search Weasyl</h2>
 
     <div id="search-parameters" class="content sectioned-sidebar">
@@ -81,7 +82,7 @@ $code:
     </div>
 
     <div class="sectioned-main clear">
-      <!-- SEARCH RESULTS (user performed a search) -->
+      $# SEARCH RESULTS (user performed a search)
 
       $if results:
         $if meta['find'] == 'user' and len(results) == 100:
@@ -106,12 +107,15 @@ $code:
         <p class="pad-left pad-right" style="padding-top: 2em;">There are no search results to display. You may want to <a class="color-a" href="/search">browse for content</a> or edit your search criteria.</p>
     </div>
 
-  $elif method['method'] == "browse":
-    <h2 class="page-title">Browse Content</h2>
-    <!-- BROWSE RESULTS (user is browsing a specific content type) -->
+  $elif method == "browse":
+    $# BROWSE RESULTS (user is browsing a specific content type)
+    <h2 class="page-title">${browse_header}</h2>
 
-    <div id="browse-search-top" class="content"><!-- there are multiple instances of search-backup-search in this template! -->
+    <div id="browse-search-top" class="content">$# there are multiple instances of search-backup-search in this template!
       <form id="search-backup-search" action="/search" method="GET" class="form">
+        $if meta['find'] not in ('submit', 'critique'):
+          <input type="hidden" name="find" value="${meta['find']}">
+
         <input name="q" placeholder="Search" title="Search Weasyl" type="search" tabindex="2" class="input" />
         <p class="color-lighter tags-help"><i><a href="/help/searching" target="_blank">Search terms help</a></i></p>
       </form>
@@ -131,13 +135,13 @@ $code:
         <a class="button" style="float:right;" href="/search?${QUERY_STRING(dict(meta, nextid=results[-1][id_fields[meta['find']]]))}" rel="next">Next</a>
       </div>
     $else:
-      <p class="pad-left pad-right" style="padding-top: 2em;">There are no search results to display. You may want to <a class="color-a" href="/search">browse for content</a> or edit your search criteria.</p>
+      <p class="pad-left pad-right" style="padding-top: 2em;">There is no more content to display in this category. You may want to <a class="color-a" href="/search">browse all content</a>.</p>
 
   $else:
-    <!-- BROWSE SUMMARY (user hit the "Browse" tab or didn't specify a content type) -->
+    $# BROWSE SUMMARY (user hit the "Browse" tab or didn't specify a content type)
     <h2 class="page-title">Browse Content</h2>
 
-    <div id="browse-search-top" class="content"><!-- there are multiple instances of search-backup-search in this template! -->
+    <div id="browse-search-top" class="content">$# there are multiple instances of search-backup-search in this template!
       <form id="search-backup-search" action="/search" method="GET" class="form">
         <input name="q" placeholder="Search" title="Search Weasyl" type="search" tabindex="2" class="input" />
         <p class="color-lighter tags-help"><i><a href="/help/searching" target="_blank">Search terms help</a></i></p>
@@ -149,7 +153,7 @@ $code:
       <ul class="thumbnail-grid medium-footprint">
         $for i in results['submit']:
           $:{_GRID_ITEM(i, lazy_load=False)}
-        </li><li class="clear more"><a class="more" href="/search?find=submit"><i>More</i> <span>Submissions</span></a></li>
+        <li class="more"><a class="more" href="/search?find=submit"><i>More</i> <span>Submissions</span></a></li>
       </ul>
     $else:
       There are no submissions to display.
@@ -159,7 +163,7 @@ $code:
       <ul class="grid avatar-grid">
         $for i in results['char']:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search?find=char"><i>More</i> <span>Characters</span></a></li>
+        <li class="clear more"><a class="more" href="/search?find=char"><i>More</i> <span>Characters</span></a></li>
       </ul>
     $else:
       There are no characters to display.
@@ -169,7 +173,7 @@ $code:
       <ul class="grid avatar-grid">
         $for i in results['journal']:
           $:{_GRID_ITEM(i)}
-        </li><li class="clear more"><a class="more" href="/search?find=journal"><i>More</i> <span>Journals</span></a></li>
+        <li class="clear more"><a class="more" href="/search?find=journal"><i>More</i> <span>Journals</span></a></li>
       </ul>
     $else:
       There are no journals to display.

--- a/weasyl/templates/etc/site_update.html
+++ b/weasyl/templates/etc/site_update.html
@@ -1,30 +1,38 @@
 $def with (myself, update, comments)
-$ owner = update.get_display_owner()
 <div id="home-content" class="content">
-  <div class="constrained">
-    <h3>${update.title}</h3>
+  <article id="hc-update" class="constrained">
+    <header class="hc-update-header">
+      <h3 class="hc-update-title">${update['title']}</h3>
 
-    <figure class="thumbnail thumbnail-left clear">
-      <a class="avatar" href="/~${owner.login_name}" title="${owner.profile.username}">
-        <img src="${owner.avatar_display_url or resource_path('img/default-avatar.jpg')}" alt="avatar of ${owner.profile.username}" />
-      </a>
-      <figcaption class="caption">
-        <h4 class="title"><i>Posted by</i> <a class="username" href="/~${owner.login_name}">${owner.profile.username}</a></h4>
-        <h5 class="date">${DATE(update.unixtime)} <i>at</i> ${TIME(update.unixtime)}</h5>
-      </figcaption>
-    </figure>
+      <p class="hc-update-attribution">
+        Posted by
+        <a class="username" href="/~${LOGIN(update['username'])}">
+          $ avatar = update['user_media']['avatar'][0]
+          <img src="${avatar['display_url']}" alt="" loading="lazy">
+          ${update['username']}
+        </a>
+        <time datetime="${ISO8601(update['unixtime'])}">${DATE(update['unixtime'])} at ${TIME(update['unixtime'])}</time>
+      </p>
+    </header>
 
-    <div class="formatted-content" style="margin-top: 1em">
-      $:{MARKDOWN(update.content)}
+    <div class="formatted-content">
+      $:{MARKDOWN(update['content'])}
     </div>
-  </div>
 
-  <div id="site-update-comments">
-    $if comments:
-      <div class="constrained"><h3>Comments</h3></div>
-      $:{RENDER("common/comment_thread.html", ["detail_comments", comments, "siteupdate", myself, update.updateid, update.userid])}
-    $if myself:
-      <div class="constrained"><h3>Leave a Comment</h3></div>
-      $:{RENDER("common/comment_form.html", [myself, update.updateid, "siteupdate"])}
-  </div>
+    $if comments is None:
+      <footer class="hc-update-footer">
+        $ comment_count = update['comment_count']
+        <a href="/site-updates/${update['updateid']}" class="more more-block"><i>View</i> <span>This Update</span> <i>and</i> <span>${comment_count} Comment${'' if comment_count == 1 else 's'}</span></a>
+      </footer>
+  </article>
+
+  $if comments is not None:
+    <div id="site-update-comments">
+      $if comments:
+        <div class="constrained"><h3>Comments</h3></div>
+        $:{RENDER("common/comment_thread.html", ["detail_comments", comments, "siteupdate", myself, update['updateid'], update['userid']])}
+      $if myself:
+        <div class="constrained"><h3>Leave a Comment</h3></div>
+        $:{RENDER("common/comment_form.html", [myself, update['updateid'], "siteupdate"])}
+    </div>
 </div>

--- a/weasyl/templates/etc/site_update_list.html
+++ b/weasyl/templates/etc/site_update_list.html
@@ -5,28 +5,27 @@ $:{TITLE("Site Updates")}
     <div class="constrained text-post-list">
         $ last_date = None
         $for update in updates:
-            $ created = LOCAL_ARROW(update.unixtime)
+            $ created = LOCAL_ARROW(update['unixtime'])
             $ date = created.date()
-            $ owner = update.get_display_owner()
             $if date != last_date:
                 $ last_date = date
                 <div class="text-post-group-header">
-                    <time datetime="${date.isoformat()}" title="${created.format()}">${created.format(u"MMMM Do, YYYY")}</time>
+                    <time datetime="${date.isoformat()}">${created.format(u"MMMM Do, YYYY")}</time>
                 </div>
 
             <article class="text-post-item">
-                <img class="text-post-image text-post-image-small" src="${owner.avatar_display_url or resource_path('img/default-avatar.jpg')}" title="${owner.profile.username}" alt="${owner.profile.username}’s avatar" />
+                <img class="text-post-image text-post-image-small" src="${update['user_media']['avatar'][0]['display_url']}" title="${update['username']}" alt="${update['username']}’s avatar" />
 
                 <div class="text-post-text">
                     <h4 class="text-post-title">
-                        <a href="${request.route_path('site_update', update_id=update.updateid)}">${update.title}</a>
+                        <a href="${request.route_path('site_update', update_id=update['updateid'])}">${update['title']}</a>
                         $if can_edit:
                             <span class="text-post-actions">
-                                <a href="${request.route_path('site_update_edit', update_id=update.updateid)}">Edit</a>
+                                <a href="${request.route_path('site_update_edit', update_id=update['updateid'])}">Edit</a>
                             </span>
                     </h4>
 
-                    <p class="text-post-excerpt">${MARKDOWN_EXCERPT(update.content)}</p>
+                    <p class="text-post-excerpt">${MARKDOWN_EXCERPT(update['content'])}</p>
                 </div>
             </article>
 

--- a/weasyl/templates/etc/streaming.html
+++ b/weasyl/templates/etc/streaming.html
@@ -1,29 +1,23 @@
 $def with (streaming)
 
-<div id="home-content" class="content">
+<div id="streams" class="content">
+  <h3>Streaming Now</h3>
 
-  <div id="hc-streams" class="clear fullpage">
-    <h3>Streaming Now</h3>
+  $if streaming:
+    <ul class="streams">
+      $for i in streaming:
+        <li>
+          <figure class="stream">
+            <img class="stream-avatar" src="${i['user_media']['avatar'][0]['display_url']}" alt="" width="75" height="75" loading="lazy">
 
-    $if streaming:
-      <ul>
-        $for i in streaming:
-          <li class="clear">
-            <figure class="thumbnail thumbnail-left">
-              <a class="avatar" href="${i['stream_url']}" title="${i['username']}">
-                $ avatar = i['user_media']['avatar'][0]
-                <img src="${avatar['display_url']}" alt="avatar of ${i['username']}" />
-              </a>
-              <figcaption class="caption">
-                <h4 class="title"><a class="username" href="/~${LOGIN(i['username'])}">${i['username']}</a> <i>since</i> ${TIME(i['stream_time'])}</h4>
-                <p>${i['stream_text']}</p>
-                <p><a href="${i['stream_url']}">${i['stream_url']}</a></p>
-              </figcaption>
-            </figure>
-          </li>
-      </ul>
-    $else:
-      <div class="color-lighter">There are no streams to display.</div>
-  </div>
-
+            <div class="stream-detail">
+              <h4 class="stream-header"><a class="username" href="/~${LOGIN(i['username'])}">${i['username']}</a> since <time datetime="${ISO8601(i['stream_time'])}">${TIME(i['stream_time'])}</time></h4>
+              <p>${i['stream_text']}</p>
+              <p class="stream-link"><a href="${i['stream_url']}">${i['stream_url']}</a></p>
+            </div>
+          </figure>
+        </li>
+    </ul>
+  $else:
+    <p>Nobody is streaming right now.</p>
 </div>

--- a/weasyl/templates/message/submissions_thumbnails.html
+++ b/weasyl/templates/message/submissions_thumbnails.html
@@ -13,10 +13,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
     $if query:
       <ul class="thumbnail-grid">
         $for index, item in enumerate(query):
-          $if index < 10:
-            $:{_GRID_ITEM(item, 1, lazy_load=False)}
-          $else:
-            $:{_GRID_ITEM(item, 1)}
+          $:{_GRID_ITEM(item, notifications=True, lazy_load=index >= 10)}
       </ul>
 
       <div class="notifs-actions sub-notifs-actions clear">

--- a/weasyl/templates/modcontrol/contentbyuser.html
+++ b/weasyl/templates/modcontrol/contentbyuser.html
@@ -1,6 +1,5 @@
 $def with (name, query)
 $:{TITLE("User Content", "Moderator Control Panel", "/modcontrol")}
-$ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 $code:
   def _PARSE_SETTINGS(i):
     names = []

--- a/weasyl/templates/user/characters.html
+++ b/weasyl/templates/user/characters.html
@@ -12,10 +12,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
   $if result.query:
     <ul class="thumbnail-grid">
       $for index, item in enumerate(result.query):
-        $if index < 10:
-          $:{_GRID_ITEM(item, lazy_load=False)}
-        $else:
-          $:{_GRID_ITEM(item)}
+        $:{_GRID_ITEM(item, lazy_load=index >= 10)}
     </ul>
     $:{RENDER("common/page_navigation.html", [result])}
   $else:

--- a/weasyl/templates/user/collections.html
+++ b/weasyl/templates/user/collections.html
@@ -12,10 +12,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
   $if result.query:
     <ul class="thumbnail-grid">
       $for index, item in enumerate(result.query):
-        $if index < 10:
-          $:{_GRID_ITEM(item, lazy_load=False)}
-        $else:
-          $:{_GRID_ITEM(item)}
+        $:{_GRID_ITEM(item, lazy_load=index >= 10)}
     </ul>
     $:{RENDER("common/page_navigation.html", [result])}
   $else:

--- a/weasyl/templates/user/favorites.html
+++ b/weasyl/templates/user/favorites.html
@@ -35,7 +35,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
         <ul class="grid avatar-grid">
           $for i in result['char']:
             $:{_GRID_ITEM(i, lazy_load=False)}
-          </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=char"><i>More</i> <span>Characters</span></a></li>
+          <li class="more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=char"><i>More</i> <span>Characters</span></a></li>
         </ul>
 
       $if(result['submit']):
@@ -44,7 +44,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
         <ul class="thumbnail-grid medium-footprint">
           $for i in result['submit']:
             $:{_GRID_ITEM(i, lazy_load=False)}
-          </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=submit"><i>More</i> <span>Submissions</span></a></li>
+          <li class="more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=submit"><i>More</i> <span>Submissions</span></a></li>
         </ul>
 
       $if(result['journal']):
@@ -53,7 +53,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
         <ul class="grid avatar-grid">
           $for i in result['journal']:
             $:{_GRID_ITEM(i, lazy_load=False)}
-          </li><li class="clear more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=journal"><i>More</i> <span>Journals</span></a></li>
+          <li class="more"><a class="more" href="/favorites?userid=${profile['userid']}&amp;feature=journal"><i>More</i> <span>Journals</span></a></li>
         </ul>
 
     $else:

--- a/weasyl/templates/user/favorites.html
+++ b/weasyl/templates/user/favorites.html
@@ -18,10 +18,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
     $if result.query:
       <ul class="thumbnail-grid">
         $for index, item in enumerate(result.query):
-          $if index < 10:
-            $:{_GRID_ITEM(item, lazy_load=False)}
-          $else:
-            $:{_GRID_ITEM(item)}
+          $:{_GRID_ITEM(item, lazy_load=index >= 10)}
       </ul>
 
       $:{RENDER("common/page_navigation.html", [result])}

--- a/weasyl/templates/user/profile.html
+++ b/weasyl/templates/user/profile.html
@@ -10,7 +10,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
     <ul id="user-thumbs" class="thumbnail-grid small-footprint">
       $for i in submissions:
         $:{_GRID_ITEM(i, lazy_load=False)}
-      </li><li class="clear"><a class="more" href="/${more_submissions}/${LOGIN(profile['username'])}"><span>${profile['username']}'s ${more_submissions.title()}</span></a></li>
+      <li class="more more-joined"><a class="more" href="/${more_submissions}/${LOGIN(profile['username'])}"><span>${profile['username']}'s ${more_submissions.title()}</span></a></li>
     </ul>
 
   $if submissions and favorites:
@@ -20,7 +20,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
     <ul id="fav-thumbs" class="thumbnail-grid tiny-footprint">
       $for i in favorites:
         $:{_GRID_ITEM(i, lazy_load=False)}
-      </li><li class="clear"><a class="more" href="/favorites/${LOGIN(profile['username'])}"><span>${profile['username']}'s Favorites</span></a></li>
+      <li class="more more-joined"><a class="more" href="/favorites/${LOGIN(profile['username'])}"><span>${profile['username']}'s Favorites</span></a></li>
     </ul>
 
 </div></section>

--- a/weasyl/templates/user/submissions.html
+++ b/weasyl/templates/user/submissions.html
@@ -26,10 +26,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
       <div class="${div_class}">
         <ul class="${grid_class}">
           $for index, item in enumerate(result.query):
-            $if index < 10:
-              $:{_GRID_ITEM(item, lazy_load=False)}
-            $else:
-              $:{_GRID_ITEM(item)}
+            $:{_GRID_ITEM(item, lazy_load=index >= 10)}
         </ul>
         <div style="padding-top: 1.4em;" class="pad-left pad-right">
           $:{RENDER("common/page_navigation.html", [result])}

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -139,6 +139,8 @@ def cache_(request):
         wrap=[ThreadCacheProxy],
         replace_existing_backend=True,
     )
+    yield
+    ThreadCacheProxy.zap_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/weasyl/test/web/test_site_updates.py
+++ b/weasyl/test/web/test_site_updates.py
@@ -1,10 +1,8 @@
 import pytest
 
 from libweasyl import staff
-from libweasyl.legacy import UNIXTIME_OFFSET
 from weasyl import errorcode
 from weasyl import siteupdate
-from weasyl.define import sessionmaker
 from weasyl.test import db_utils
 
 
@@ -15,18 +13,17 @@ _FORM = {
 
 
 @pytest.fixture(name='site_updates')
-@pytest.mark.usefixtures('db')
-def _site_updates():
+def _site_updates(db, cache):
     user = db_utils.create_user(username='test_username')
 
     updates = [
-        siteupdate.create(user, u'foo', u'content one'),
-        siteupdate.create(user, u'bar', u'content two'),
-        siteupdate.create(user, u'baz', u'content three'),
+        {'userid': user, 'title': 'foo', 'content': 'content one', 'wesley': False},
+        {'userid': user, 'title': 'bar', 'content': 'content two', 'wesley': False},
+        {'userid': user, 'title': 'baz', 'content': 'content three', 'wesley': False},
     ]
 
     for update in updates:
-        sessionmaker().expunge(update)
+        update['updateid'] = siteupdate.create(**update)
 
     return (user, updates)
 
@@ -43,13 +40,13 @@ def test_select_last(app, site_updates):
 
     selected = siteupdate.select_last()
     assert 'display_url' in selected.pop('user_media')['avatar'][0]
+    assert isinstance(selected.pop('unixtime'), int)
     assert selected == {
-        'updateid': most_recent.updateid,
+        'updateid': most_recent['updateid'],
         'userid': user,
         'username': 'test_username',
-        'title': most_recent.title,
-        'content': most_recent.content,
-        'unixtime': most_recent.unixtime.timestamp + UNIXTIME_OFFSET,
+        'title': most_recent['title'],
+        'content': most_recent['content'],
         'comment_count': 0,
     }
 
@@ -57,7 +54,7 @@ def test_select_last(app, site_updates):
 @pytest.mark.usefixtures('db', 'cache')
 def test_index_empty(app):
     resp = app.get('/')
-    assert resp.html.find(id='home-content') is not None
+    assert resp.html.find(id='hc-streams') is not None
     assert resp.html.find(id='hc-update') is None
 
 
@@ -67,8 +64,8 @@ def test_index(app, site_updates):
     resp = app.get('/')
     update = resp.html.find(id='hc-update')
     assert update is not None
-    assert update.h3.string == updates[-1].title
-    assert update.figure.img['alt'] == u'avatar of test_username'
+    assert update.h3.string == updates[-1]['title']
+    assert list(update.select_one('.hc-update-attribution > .username').stripped_strings) == ['test_username']
 
 
 @pytest.mark.usefixtures('db')
@@ -90,7 +87,7 @@ def test_list(app, monkeypatch, site_updates):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
     resp = app.get('/site-updates/', headers={'Cookie': cookie})
     assert len(resp.html.findAll(None, 'text-post-item')) == 3
-    assert resp.html.find(None, 'text-post-actions').a['href'] == '/site-updates/%d/edit' % (updates[-1].updateid,)
+    assert resp.html.find(None, 'text-post-actions').a['href'] == '/site-updates/%d/edit' % (updates[-1]['updateid'],)
 
 
 @pytest.mark.usefixtures('db')
@@ -183,7 +180,7 @@ def test_edit(app, monkeypatch, site_updates):
     cookie = db_utils.create_session(user)
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, headers={'Cookie': cookie}).follow()
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), _FORM, headers={'Cookie': cookie}).follow()
     assert resp.html.find(id='home-content').h3.string == _FORM['title']
 
 
@@ -196,7 +193,7 @@ def test_edit_strip(app, monkeypatch, site_updates):
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
     resp = app.post(
-        '/site-updates/%d' % (updates[-1].updateid,),
+        '/site-updates/%d' % (updates[-1]['updateid'],),
         dict(_FORM, title=' test title \t '),
         headers={'Cookie': cookie},
     ).follow()
@@ -211,37 +208,37 @@ def test_edit_nonexistent(app, monkeypatch, site_updates):
     cookie = db_utils.create_session(user)
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
-    app.post('/site-updates/%d' % (updates[-1].updateid + 1,), _FORM, headers={'Cookie': cookie}, status=404)
+    app.post('/site-updates/%d' % (updates[-1]['updateid'] + 1,), _FORM, headers={'Cookie': cookie}, status=404)
 
 
 @pytest.mark.usefixtures('db')
 def test_edit_restricted(app, monkeypatch, site_updates):
     _, updates = site_updates
 
-    resp = app.get('/site-updates/%d/edit' % (updates[-1].updateid,), status=403)
+    resp = app.get('/site-updates/%d/edit' % (updates[-1]['updateid'],), status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.unsigned
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, status=403)
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), _FORM, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.unsigned
 
     user = db_utils.create_user()
     cookie = db_utils.create_session(user)
 
-    resp = app.get('/site-updates/%d/edit' % (updates[-1].updateid,), headers={'Cookie': cookie}, status=403)
+    resp = app.get('/site-updates/%d/edit' % (updates[-1]['updateid'],), headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, headers={'Cookie': cookie}, status=403)
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), _FORM, headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
 
     monkeypatch.setattr(staff, 'TECHNICAL', frozenset([user]))
     monkeypatch.setattr(staff, 'MODS', frozenset([user]))
 
-    resp = app.get('/site-updates/%d/edit' % (updates[-1].updateid,), headers={'Cookie': cookie}, status=403)
+    resp = app.get('/site-updates/%d/edit' % (updates[-1]['updateid'],), headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), _FORM, headers={'Cookie': cookie}, status=403)
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), _FORM, headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
 
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
-    resp = app.get('/site-updates/%d/edit' % (updates[-1].updateid,), headers={'Cookie': cookie})
+    resp = app.get('/site-updates/%d/edit' % (updates[-1]['updateid'],), headers={'Cookie': cookie})
     assert resp.html.find(id='error_content') is None
 
 
@@ -253,10 +250,10 @@ def test_edit_validation(app, monkeypatch, site_updates):
     cookie = db_utils.create_session(user)
     monkeypatch.setattr(staff, 'ADMINS', frozenset([user]))
 
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), {'title': u'', 'content': u'Content'}, headers={'Cookie': cookie}, status=422)
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), {'title': u'', 'content': u'Content'}, headers={'Cookie': cookie}, status=422)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.error_messages['titleInvalid']
 
-    resp = app.post('/site-updates/%d' % (updates[-1].updateid,), {'title': u'Title', 'content': u''}, headers={'Cookie': cookie}, status=422)
+    resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), {'title': u'Title', 'content': u''}, headers={'Cookie': cookie}, status=422)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.error_messages['contentInvalid']
 
 


### PR DESCRIPTION
Because when have you ever wanted to see 11 random submissions out of the last 256?

- corrects searching within browse categories
- allows browsing critique requests in chronological order
- splits index cache
- redesigns stream and site update sections based on weasyl2014
- fixes comment hiding on site updates
- makes narrow viewport design use home tabs instead of expandable sections (I fixed section closing and state indication first, but then this was better)
- makes thumbnail layout algorithm do what was originally intended
- removes unnecessarily large padding from thumbnail grids when JavaScript hasn’t run [yet]
- reduces recent submissions on homepage to medium footprint (two rows at max width) and removes their heading to place tabs and part of recently popular above the fold on many common viewport sizes
- limits homepage critique selection to one per person
- allows critique thumbnails to use consistently-sized and WebP thumbnails (plus any future changes)
- probably more

Sorry this is so entangled.