### PR TITLE
Improve tag suggestions

### DIFF
--- a/assets/js/dom.js
+++ b/assets/js/dom.js
@@ -1,0 +1,5 @@
+export const byClass = (class_, within = document) =>
+    within.getElementsByClassName(class_)[0];
+
+export const make = (element, props) =>
+    Object.assign(document.createElement(element), props);

--- a/assets/js/parse-tags.js
+++ b/assets/js/parse-tags.js
@@ -1,0 +1,12 @@
+const getSearchTag = (text) =>
+    text.replace(/[^ \w]/g, '')
+        .toLowerCase()
+        .match(/[0-9a-z]+/g)
+        ?.join('_');
+
+const parseTags = (s) =>
+    s.split(/[\s,]+/)
+        .map(getSearchTag)
+        .filter(Boolean);
+
+export default parseTags;

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -132,12 +132,6 @@
             $('#header-nav, #nav-toggle').toggleClass('open');
         });
 
-        // tags
-        $('.di-tags .modify').on('click', function (ev) {
-            ev.preventDefault();
-            $(this).closest('.di-tags').find('.tags-form, .tags').toggleClass('open');
-        });
-
         // report
         $('#detail-report-button').on('click', function (ev) {
             ev.preventDefault();

--- a/assets/js/tags-edit.js
+++ b/assets/js/tags-edit.js
@@ -1,0 +1,296 @@
+import parseTags from './parse-tags.js';
+import {byClass, make} from './dom.js';
+
+const animateFlash = (element, color) => {
+    element.animate([{color}, {}], {duration: 500});
+};
+
+const hasSuccessStatus = ({status}) =>
+    200 <= status && status < 300;
+
+// The time before showing an in-progress indicator for a background save action, in milliseconds.
+// Makes it less distracting by reducing the number of status updates when the response comes back fast enough.
+const SAVE_PROGRESS_DELAY = 500;
+
+// see `weasyl.searchtag.UNDO_TOKEN_VALIDITY`
+const UNDO_TOKEN_VALIDITY = 60;
+
+const SUCCESS_COLOR = 'green';
+const FAILURE_COLOR = '#e30';
+
+const ACTION_BUTTONS = Symbol();
+const UNDO_TOKEN = Symbol();
+const UNDO_EXPIRE_TIMER = Symbol();
+
+class StatusReporter {
+    #display;
+    #progressDelayTimer;
+
+    constructor(display) {
+        this.#display = display;
+    }
+
+    start() {
+        this.#progressDelayTimer = setTimeout(this.#display.showProgress, SAVE_PROGRESS_DELAY);
+    }
+
+    reportSuccess(...args) {
+        clearTimeout(this.#progressDelayTimer);
+        this.#display.stopProgress();
+        this.#display.showSuccess(...args);
+    }
+
+    reportFailure() {
+        clearTimeout(this.#progressDelayTimer);
+        this.#display.stopProgress();
+        this.#display.showFailure();
+    }
+}
+
+const undoTagAction = (target, tag, actionsFieldset) => {
+    const reporter = new StatusReporter({
+        showProgress: () => {
+            actionsFieldset.classList.add('tag-form-status-saving');
+            actionsFieldset.textContent = 'Undoing…';
+        },
+        stopProgress: () => {
+            actionsFieldset.classList.remove('tag-form-status-saving');
+        },
+        showSuccess: () => {
+            actionsFieldset.disabled = false;
+            actionsFieldset.textContent = '';
+            actionsFieldset.appendChild(actionsFieldset[ACTION_BUTTONS]);
+            actionsFieldset[ACTION_BUTTONS] = null;
+        },
+        showFailure: () => {
+            actionsFieldset[ACTION_BUTTONS] = null;
+            actionsFieldset.textContent = 'Error.';
+            animateFlash(actionsFieldset, FAILURE_COLOR);
+        },
+    });
+
+    actionsFieldset.disabled = true;
+
+    fetch(`/api-unstable/tag-suggestions/${target}/${tag}/status`, {
+        method: 'DELETE',
+        body: actionsFieldset[UNDO_TOKEN],
+    })
+        .then((response) => {
+            if (!hasSuccessStatus(response)) {
+                return Promise.reject({});
+            }
+
+            reporter.reportSuccess();
+        })
+        .catch((err) => {
+            reporter.reportFailure();
+            return Promise.reject(err);
+        });
+
+    clearTimeout(actionsFieldset[UNDO_EXPIRE_TIMER]);
+    actionsFieldset[UNDO_TOKEN] = null;
+    actionsFieldset[UNDO_EXPIRE_TIMER] = null;
+};
+
+const applyTagAction = (target, tag, actionsFieldset, isApproveAction) => {
+    const storeActionButtons = () => {
+        if (!actionsFieldset[ACTION_BUTTONS]) {
+            const actionButtons = actionsFieldset[ACTION_BUTTONS] = document.createDocumentFragment();
+            actionButtons.append(...actionsFieldset.children);
+        }
+    };
+
+    const reporter = new StatusReporter({
+        showProgress: () => {
+            storeActionButtons();
+            actionsFieldset.classList.add('tag-form-status-saving');
+            actionsFieldset.textContent = `${isApproveAction ? 'Approv' : 'Reject'}ing…`;
+        },
+        stopProgress: () => {
+            actionsFieldset.classList.remove('tag-form-status-saving');
+        },
+        showSuccess: (canUndo) => {
+            storeActionButtons();
+
+            const undoButton = make('button', {
+                className: 'link-button',
+                textContent: 'Undo',
+            });
+            undoButton.dataset.tagAction = 'undo';
+
+            actionsFieldset.disabled = false;
+            actionsFieldset.textContent = `Suggestion ${isApproveAction ? 'approv' : 'reject'}ed. `;
+
+            if (canUndo) {
+                actionsFieldset.appendChild(undoButton);
+
+                actionsFieldset[UNDO_EXPIRE_TIMER] = setTimeout(() => {
+                    undoButton.remove();
+                }, UNDO_TOKEN_VALIDITY * 1000);
+            }
+        },
+        showFailure: () => {
+            actionsFieldset[ACTION_BUTTONS] = null;
+            actionsFieldset.textContent = 'Error.';  // don’t imply that the action definitely didn’t go through; prompt refresh at user’s convenience
+            animateFlash(actionsFieldset, FAILURE_COLOR);
+        },
+    });
+
+    actionsFieldset.disabled = true;
+
+    fetch(`/api-unstable/tag-suggestions/${target}/${tag}/status`, {
+        method: 'PUT',
+        body: isApproveAction ? 'approve' : 'reject',
+    })
+        .then(async (response) => {
+            if (!hasSuccessStatus(response)) {
+                return Promise.reject({});
+            }
+
+            const body = new Uint8Array(await response.arrayBuffer());
+            const canUndo = body.length > 1;
+
+            if (canUndo) {
+                actionsFieldset[UNDO_TOKEN] = body.slice(1);
+            }
+
+            reporter.reportSuccess(canUndo);
+        })
+        .catch((err) => {
+            reporter.reportFailure();
+            return Promise.reject(err);
+        });
+};
+
+const tagsWithActions = byClass('tags-with-actions');
+const {tagEditType} = tagsWithActions.dataset;
+
+if (tagEditType !== 'none') {
+    const manage = byClass('tags-manage');
+    const tagsField = byClass('tags-form', manage).elements.tags;
+
+    // `.tag-actions` only exists when there is already an action, so create it if necessary
+    let tagActions = tagsWithActions.lastElementChild;
+    if (!tagActions.classList.contains('tag-actions')) {
+        tagActions = tagsWithActions.appendChild(make('span', {
+            className: 'tag-actions',
+        }));
+    }
+
+    const editButton = make('button', {
+        type: 'button',
+        className: 'link-button',
+        textContent: tagEditType === 'edit' ? 'Edit tags' : '+ Suggest tags',
+    });
+
+    editButton.addEventListener('click', () => {
+        manage.hidden = !manage.hidden;
+
+        if (!manage.hidden) {
+            tagsField.focus();
+        }
+    });
+
+    tagActions.insertAdjacentElement('afterbegin', editButton);
+
+    const tagRejectFeedback = byClass('tag-reject-feedback');
+    const statusOutput = byClass('tag-reject-feedback-status', tagRejectFeedback);
+    let activeTag = null;
+    let abortController = null;
+    let savingTimer = null;
+
+    const feedbackReporter = new StatusReporter({
+        showProgress: () => {
+            statusOutput.classList.add('tag-form-status-saving');
+            statusOutput.value = 'Saving…';
+        },
+        stopProgress: () => {
+            statusOutput.classList.remove('tag-form-status-saving');
+        },
+        showSuccess: () => {
+            statusOutput.value = 'Feedback saved.';
+            animateFlash(statusOutput, SUCCESS_COLOR);
+        },
+        showFailure: () => {
+            statusOutput.value = 'Error saving feedback.';
+            animateFlash(statusOutput, FAILURE_COLOR);
+        },
+    });
+
+    tagRejectFeedback.addEventListener('change', () => {
+        if (abortController !== null) {
+            abortController.abort();
+        }
+        abortController = new AbortController();
+
+        fetch(`/api-unstable/tag-suggestions/${tagRejectFeedback.dataset.target}/${activeTag}/feedback`, {
+            method: 'PUT',
+            body: new URLSearchParams(new FormData(tagRejectFeedback)),
+            signal: abortController.signal,
+        })
+            .then((response) => {
+                if (!hasSuccessStatus(response)) {
+                    return Promise.reject({});
+                }
+
+                feedbackReporter.reportSuccess();
+            })
+            .catch((err) => {
+                if (err.name !== 'AbortError') {
+                    feedbackReporter.reportFailure();
+                    return Promise.reject(err);
+                }
+            });
+        feedbackReporter.start();
+    });
+
+    byClass('suggested-tags', manage).addEventListener('click', (e) => {
+        const {tagAction} = e.target.dataset;
+
+        if (!tagAction) {
+            return;
+        }
+
+        const actionsFieldset = e.target.parentNode;
+        const {tag} = actionsFieldset.parentNode.dataset;
+        const {target} = tagRejectFeedback.dataset;
+
+        switch (tagAction) {
+            case 'approve':
+                if (!parseTags(tagsField.value).includes(tag)) {
+                    tagsField.value += (/(?:^|\s)$/.test(tagsField.value) ? '' : ' ') + tag;
+                }
+
+                applyTagAction(target, tag, actionsFieldset, true);
+                tagRejectFeedback.hidden = true;
+                break;
+
+            case 'reject':
+                activeTag = tag;
+                Object.assign(byClass('tag-suggested', tagRejectFeedback), {
+                    textContent: tag,
+                    href: `/search?q=${tag}`,
+                });
+
+                applyTagAction(target, tag, actionsFieldset, false);
+
+                // TODO: is resetting `<output>` value reliable across browsers?
+                tagRejectFeedback.reset();
+                tagRejectFeedback.hidden = false;
+
+                break;
+
+            case 'undo': {
+                const initialValue = tagsField.value;
+                let valueRemoved;
+                if (initialValue.endsWith(tag) && /(?:^|\s)$/.test(valueRemoved = initialValue.slice(0, -tag.length))) {
+                    tagsField.value = valueRemoved.trimEnd();
+                }
+
+                undoTagAction(target, tag, actionsFieldset);
+                tagRejectFeedback.hidden = true;
+                break;
+            }
+        }
+    });
+}

--- a/assets/js/tags-edit.js
+++ b/assets/js/tags-edit.js
@@ -197,7 +197,6 @@ if (tagEditType !== 'none') {
     const statusOutput = byClass('tag-reject-feedback-status', tagRejectFeedback);
     let activeTag = null;
     let abortController = null;
-    let savingTimer = null;
 
     const feedbackReporter = new StatusReporter({
         showProgress: () => {

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -781,7 +781,7 @@ select.input {
     padding-bottom: 0.3rem;
 }
 
-.input:hover, input:focus {
+.input:hover, .input:focus {
     background-color: #eee;
 }
 
@@ -4310,7 +4310,6 @@ templates/modcontrol/reports.html
 }
 
 .link-button:hover, .link-button:focus {
-    background: none;
     outline: none;
     text-decoration: underline;
 }

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -107,6 +107,7 @@ i, #header-guest {
 --------------------------------*/
 $color-a: #069bc0;
 $color-b: #8cad47;
+$link-color: #336979;
 
 .color-a, .username, .content .username, .page-title, #header-nav .current,
 #user-nav .current,
@@ -119,7 +120,7 @@ a.more span, #header-messages a, .page-title a {
 }
 
 .color-c, .title, .content a {
-    color: #336979;
+    color: $link-color;
 }
 
 .color-on {
@@ -134,8 +135,10 @@ a.more span, #header-messages a, .page-title a {
     color: #943522;
 }
 
+$content-color-lighter: #777;
+
 .content .color-lighter {
-    color: #777;
+    color: $content-color-lighter;
 }
 
 .stage .color-lighter {
@@ -1477,27 +1480,111 @@ blockquote + blockquote {
     width: 100% !important;
 }
 
-.tags a {
-    display: block;
-    float: left;
-    position: relative;
-    height: 28px;
-    height: 1.75rem;
-    line-height: 28px;
+.tags-with-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: center;  // for “(No tags)”
+}
+
+.tags {
+    // fallback if `display: contents` not supported
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+
+    display: contents;
+}
+
+$tag-background: #eee;
+
+.tag {
+    display: inline-block;
     line-height: 1.75rem;
     padding: 0 1em;
-    margin: 0 0.3em 0.3em 0;
     border: 1px solid #ccc;
     border-radius: 4px;
-    background-color: #eee;
+    background-color: $tag-background;
+    font-weight: normal;
 }
 
-.tags a.artist {
-    background-color: #ecc;
+.tag-suggested,
+.content .tag-suggested {
+    background-color: scale-color($tag-background, $alpha: -30%);
+    border-style: dashed;
+    color: scale-color($link-color, $alpha: -20%);
 }
 
-.tags a.artist.removable {
-    background-color: #cec;
+.tag-actions {
+    display: flex;
+    align-items: center;
+    height: 1.75rem;
+    padding-left: 1em;
+    gap: 16px;
+}
+
+.suggested-tags {
+    display: flex;
+    flex-direction: column;
+    margin-top: 16px;
+    gap: 8px;
+
+    > li {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+}
+
+.suggested-tag-actions {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    gap: 4px;
+}
+
+$tag-reject-deemphasize-size: 11px;
+
+.tag-reject-feedback {
+    display: flex;
+    flex-direction: column;
+    margin-top: 16px;
+    gap: 4px;
+
+    > label {
+        display: flex;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    > output {
+        font-size: $tag-reject-deemphasize-size;
+    }
+}
+
+.tag-reject-feedback[hidden] {
+    display: none;
+}
+
+.tag-reject-label {
+    flex: 1;
+
+    > p {
+        font-size: $tag-reject-deemphasize-size;
+        color: $content-color-lighter;
+    }
+}
+
+@keyframes pulse {
+    from {
+    }
+    to {
+        color: #777;
+    }
+}
+
+.tag-form-status-saving {
+    animation: pulse 0.75s linear alternate infinite;
 }
 
 /* ------------------------------------ =forms -- */
@@ -1544,10 +1631,15 @@ blockquote + blockquote {
     max-width: 30em;
 }
 
-.label, .form label:not(.input-checkbox) {
+.label,
+.form label:not(.input-checkbox),
+.form-actions {
     display: block;
     padding: 16px 0 4px;
     padding: 1rem 0 0.25rem;
+}
+
+.label, .form label:not(.input-checkbox) {
     font-size: 14px;
     font-size: 0.9rem;
     font-weight: 700;
@@ -1558,6 +1650,11 @@ blockquote + blockquote {
     font-size: 12px;
     font-size: 0.75rem;
     font-weight: 400;
+}
+
+.optional-indicator {
+    font-weight: normal;
+    color: $content-color-lighter;
 }
 
 .form:not(.wide) .form-2up-1, .form:not(.wide) .form-2up-2 {
@@ -2844,7 +2941,7 @@ $notifs-color-active: #b9b9b9;
         box-shadow: inset 5px 0 15px -5px #b2b2b2;
     }
 
-    #user-content .on-side {
+    .on-side {
         width: 34%;
         float: right;
         clear: right;
@@ -2940,7 +3037,7 @@ $notifs-color-active: #b9b9b9;
         width: 32.5%;
     }
 
-    #user-content .on-side {
+    .on-side {
         width: 30%;
     }
 
@@ -3113,28 +3210,12 @@ img + #detail-art-text {
     font-weight: 400;
 }
 
-.di-tags h3 a.modify, .js .di-tags h3.edit {
-    display: none;
+.tags-manage {
+    margin-top: 12px;
 }
 
-.js .di-tags h3 a {
-    display: inline-block;
-    font-size: 12px;
-    font-size: 0.75rem;
-    padding: 0 1em;
-}
-
-.di-tags .button {
+.tags-actions {
     margin-top: 8px;
-    margin-top: 0.5rem;
-}
-
-.di-tags .tags-form {
-    display: none;
-}
-
-.di-tags .tags-form.open {
-    display: block;
 }
 
 #detail-comments {
@@ -3558,10 +3639,6 @@ img + #detail-art-text {
     margin-bottom: 10px;
     flex-direction: column;  /* Overridden at larger sizes */
     justify-content: space-around;
-}
-
-#commishprices-content .di-tags {
-    width: 100%;
 }
 
 #commishprices-content .commish-row .half {
@@ -4309,8 +4386,7 @@ templates/modcontrol/reports.html
     padding: 0;
 }
 
-.link-button:hover, .link-button:focus {
-    outline: none;
+.link-button:hover {
     text-decoration: underline;
 }
 

--- a/build.js
+++ b/build.js
@@ -220,21 +220,24 @@ const main = async () => {
 
     const copyImages = copyStaticFiles('img', touch);
 
+    const PRIVATE_FIELDS_ESM = {
+        format: 'esm',
+        target: [
+            'chrome84',
+            'firefox90',
+            'ios15',
+            'safari15',
+        ],
+        banner: {},
+    };
+
     const tasks = await Promise.all([
         sasscFile('scss/site.scss', 'css/site.css', touch, copyImages),
         sasscFile('scss/help.scss', 'css/help.css', touch, copyImages),
         sasscFile('scss/imageselect.scss', 'css/imageselect.css', touch, copyImages),
         esbuildFile('js/scripts.js', 'js/scripts.js', touch, {}),
-        esbuildFile('js/main.js', 'js/main.js', touch, {
-            format: 'esm',
-            target: [
-                'chrome84',
-                'firefox90',
-                'ios15',
-                'safari15',
-            ],
-            banner: {},
-        }),
+        esbuildFile('js/main.js', 'js/main.js', touch, PRIVATE_FIELDS_ESM),
+        esbuildFile('js/tags-edit.js', 'js/tags-edit.js', touch, PRIVATE_FIELDS_ESM),
         copyStaticFiles('img/help', touch),
         copyImages,
 

--- a/ci/site.config.txt
+++ b/ci/site.config.txt
@@ -22,3 +22,8 @@ host = localhost
 # This key MUST be changed when in production;
 # See https://cryptography.io/en/latest/fernet/ -- Fernet.generate_key()
 secret_key = 2iY4trxnpmNLlQifnQ21pFF0nb-VlmpxRUI6W_uP1oQ=
+
+# These keys MUST be changed when in production
+[secret_keys]
+# can be generated with `secrets.token_urlsafe(32) + "="`
+suggested_tag_undo = 5Bf8KDzoCGyv6Cfbb7P6wI70bEwYd5EFGiBYa1hdxUc=

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -23,3 +23,8 @@ host = localhost
 # This key MUST be changed when in production;
 # See https://cryptography.io/en/latest/fernet/ -- Fernet.generate_key()
 secret_key = 2iY4trxnpmNLlQifnQ21pFF0nb-VlmpxRUI6W_uP1oQ=
+
+# These keys MUST be changed when in production
+[secret_keys]
+# can be generated with `secrets.token_urlsafe(32) + "="`
+suggested_tag_undo = 5Bf8KDzoCGyv6Cfbb7P6wI70bEwYd5EFGiBYa1hdxUc=

--- a/libweasyl/alembic/versions/6fb56d9a5913_denormalize_tag_suggestion_attribution.py
+++ b/libweasyl/alembic/versions/6fb56d9a5913_denormalize_tag_suggestion_attribution.py
@@ -1,0 +1,32 @@
+"""Denormalize tag suggestion attribution
+
+Revision ID: 6fb56d9a5913
+Revises: 7a52ff794d57
+Create Date: 2023-06-10 08:13:22.369293
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6fb56d9a5913'
+down_revision = '7a52ff794d57'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('searchmapchar', sa.Column('added_by', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'searchmapchar', 'login', ['added_by'], ['userid'], ondelete='SET NULL')
+    op.add_column('searchmapjournal', sa.Column('added_by', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'searchmapjournal', 'login', ['added_by'], ['userid'], ondelete='SET NULL')
+    op.add_column('searchmapsubmit', sa.Column('added_by', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'searchmapsubmit', 'login', ['added_by'], ['userid'], ondelete='SET NULL')
+
+
+def downgrade():
+    op.drop_constraint(None, 'searchmapsubmit', type_='foreignkey')
+    op.drop_column('searchmapsubmit', 'added_by')
+    op.drop_constraint(None, 'searchmapjournal', type_='foreignkey')
+    op.drop_column('searchmapjournal', 'added_by')
+    op.drop_constraint(None, 'searchmapchar', type_='foreignkey')
+    op.drop_column('searchmapchar', 'added_by')

--- a/libweasyl/alembic/versions/9a41d4fa38ba_add_tag_suggestion_feedback.py
+++ b/libweasyl/alembic/versions/9a41d4fa38ba_add_tag_suggestion_feedback.py
@@ -1,0 +1,62 @@
+"""Add tag suggestion feedback
+
+Revision ID: 9a41d4fa38ba
+Revises: 6fb56d9a5913
+Create Date: 2023-06-25 23:20:10.816058
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9a41d4fa38ba'
+down_revision = '6fb56d9a5913'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.create_table('tag_suggestion_feedback_character',
+    sa.Column('targetid', sa.Integer(), nullable=False),
+    sa.Column('tagid', sa.Integer(), nullable=False),
+    sa.Column('userid', sa.Integer(), nullable=False),
+    sa.Column('last_modified', postgresql.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('incorrect', sa.Boolean(), nullable=False),
+    sa.Column('unwanted', sa.Boolean(), nullable=False),
+    sa.Column('abusive', sa.Boolean(), nullable=False),
+    sa.ForeignKeyConstraint(['tagid'], ['searchtag.tagid'], ),
+    sa.ForeignKeyConstraint(['targetid'], ['character.charid'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['userid'], ['login.userid'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('targetid', 'tagid', 'userid')
+    )
+    op.create_table('tag_suggestion_feedback_journal',
+    sa.Column('targetid', sa.Integer(), nullable=False),
+    sa.Column('tagid', sa.Integer(), nullable=False),
+    sa.Column('userid', sa.Integer(), nullable=False),
+    sa.Column('last_modified', postgresql.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('incorrect', sa.Boolean(), nullable=False),
+    sa.Column('unwanted', sa.Boolean(), nullable=False),
+    sa.Column('abusive', sa.Boolean(), nullable=False),
+    sa.ForeignKeyConstraint(['tagid'], ['searchtag.tagid'], ),
+    sa.ForeignKeyConstraint(['targetid'], ['journal.journalid'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['userid'], ['login.userid'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('targetid', 'tagid', 'userid')
+    )
+    op.create_table('tag_suggestion_feedback_submission',
+    sa.Column('targetid', sa.Integer(), nullable=False),
+    sa.Column('tagid', sa.Integer(), nullable=False),
+    sa.Column('userid', sa.Integer(), nullable=False),
+    sa.Column('last_modified', postgresql.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('incorrect', sa.Boolean(), nullable=False),
+    sa.Column('unwanted', sa.Boolean(), nullable=False),
+    sa.Column('abusive', sa.Boolean(), nullable=False),
+    sa.ForeignKeyConstraint(['tagid'], ['searchtag.tagid'], ),
+    sa.ForeignKeyConstraint(['targetid'], ['submission.submitid'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['userid'], ['login.userid'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('targetid', 'tagid', 'userid')
+    )
+
+
+def downgrade():
+    op.drop_table('tag_suggestion_feedback_submission')
+    op.drop_table('tag_suggestion_feedback_journal')
+    op.drop_table('tag_suggestion_feedback_character')

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -551,6 +551,7 @@ searchmapchar = Table(
     Column('tagid', Integer(), primary_key=True, nullable=False),
     Column('targetid', Integer(), primary_key=True, nullable=False),
     Column('settings', String(), nullable=False, server_default=''),
+    Column('added_by', Integer(), ForeignKey('login.userid', ondelete='SET NULL'), nullable=True),
     default_fkey(['targetid'], ['character.charid'], name='searchmapchar_targetid_fkey'),
     default_fkey(['tagid'], ['searchtag.tagid'], name='searchmapchar_tagid_fkey'),
 )
@@ -564,6 +565,7 @@ searchmapjournal = Table(
     Column('tagid', Integer(), primary_key=True, nullable=False),
     Column('targetid', Integer(), primary_key=True, nullable=False),
     Column('settings', String(), nullable=False, server_default=''),
+    Column('added_by', Integer(), ForeignKey('login.userid', ondelete='SET NULL'), nullable=True),
     default_fkey(['targetid'], ['journal.journalid'], name='searchmapjournal_targetid_fkey'),
     default_fkey(['tagid'], ['searchtag.tagid'], name='searchmapjournal_tagid_fkey'),
 )
@@ -579,6 +581,7 @@ searchmapsubmit = Table(
     Column('settings', CharSettingsColumn({
         'a': 'artist-tag',
     }), nullable=False, server_default=''),
+    Column('added_by', Integer(), ForeignKey('login.userid', ondelete='SET NULL'), nullable=True),
     default_fkey(['targetid'], ['submission.submitid'], name='searchmapsubmit_targetid_fkey'),
     default_fkey(['tagid'], ['searchtag.tagid'], name='searchmapsubmit_tagid_fkey'),
 )
@@ -794,6 +797,24 @@ suspension = Table(
     Column('release', Integer(), nullable=False),
     default_fkey(['userid'], ['login.userid'], name='suspension_userid_fkey'),
 )
+
+
+def _tag_suggestion_feedback_table(content_table, id_column):
+    return Table(
+        f'tag_suggestion_feedback_{content_table.name}', metadata,
+        Column('targetid', ForeignKey(id_column, ondelete='CASCADE'), primary_key=True),
+        Column('tagid', ForeignKey(searchtag.c.tagid), primary_key=True),
+        Column('userid', ForeignKey(login.c.userid, ondelete='CASCADE'), primary_key=True),
+        Column('last_modified', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+        Column('incorrect', Boolean(), nullable=False),
+        Column('unwanted', Boolean(), nullable=False),
+        Column('abusive', Boolean(), nullable=False),
+    )
+
+
+tag_suggestion_feedback_submission = _tag_suggestion_feedback_table(submission, submission.c.submitid)
+tag_suggestion_feedback_character = _tag_suggestion_feedback_table(character, character.c.charid)
+tag_suggestion_feedback_journal = _tag_suggestion_feedback_table(journal, journal.c.journalid)
 
 
 tag_updates = Table(

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -107,7 +107,11 @@ def create(userid, character, friends, tags, thumbfile, submitfile):
         raise
 
     # Assign search tags
-    searchtag.associate(userid, tags, charid=charid)
+    searchtag.associate(
+        userid=userid,
+        target=searchtag.CharacterTarget(charid),
+        tag_names=tags,
+    )
 
     # Make submission file
     files.make_character_directory(charid)
@@ -252,7 +256,7 @@ def select_view(userid, charid, rating, ignore=True, anyway=None):
         'comments': comment.select(userid, charid=charid),
         'sub_media': fake_media_items(
             charid, query['userid'], login, query['settings']),
-        'tags': searchtag.select(charid=charid),
+        'tags': searchtag.select_grouped(userid, searchtag.CharacterTarget(charid)),
     }
 
 

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -6,7 +6,12 @@ from libweasyl.models.content import Submission
 from libweasyl.text import slug_for
 from weasyl import (
     character, define, journal, macro, media, profile, searchtag, submission)
+from weasyl.controllers.decorators import moderator_only
 from weasyl.error import WeasylError
+
+
+def _can_edit_tags(userid: int) -> bool:
+    return bool(userid) and define.is_vouched_for(userid)
 
 
 # Content detail functions
@@ -92,6 +97,7 @@ def submission_(request):
         ogp=ogp,
         canonical_url=canonical_path,
         title=item["title"],
+        options=("tags-edit",) if _can_edit_tags(request.userid) else None,
     ))
 
 
@@ -116,6 +122,7 @@ def submission_media_(request):
     ])
 
 
+@moderator_only
 def submission_tag_history_(request):
     submitid = int(request.matchdict['submitid'])
 
@@ -159,7 +166,13 @@ def character_(request):
         [i for i in macro.MACRO_REPORT_VIOLATION if 2000 <= i[0] < 3000],
     ]))
 
-    return Response(define.common_page_end(request.userid, page))
+    return Response(
+        define.common_page_end(
+            request.userid,
+            page,
+            options=("tags-edit",) if _can_edit_tags(request.userid) else None,
+        )
+    )
 
 
 def journal_(request):
@@ -193,4 +206,10 @@ def journal_(request):
         [i for i in macro.MACRO_REPORT_VIOLATION if 3000 <= i[0] < 4000],
     ]))
 
-    return Response(define.common_page_end(request.userid, page))
+    return Response(
+        define.common_page_end(
+            request.userid,
+            page,
+            options=("tags-edit",) if _can_edit_tags(request.userid) else None,
+        )
+    )

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -138,6 +138,16 @@ routes = (
     Route("/submit/comment", "submit_comment", {'POST': content.submit_comment_}),
     Route("/submit/report", "submit_report", {'POST': content.submit_report_}),
     Route("/submit/tags", "submit_tags", {'POST': content.submit_tags_}),
+    Route(
+        "/api-unstable/tag-suggestions/{feature}/{targetid}/{tag}/status",
+        "suggested_tag_status",
+        {
+            "PUT": content.tag_status_put,
+            "DELETE": content.tag_status_delete,
+        },
+    ),
+    Route("/api-unstable/tag-suggestions/{feature}/{targetid}/{tag}/feedback", "suggested_tag_feedback",
+          {'PUT': content.tag_feedback_put}),
     Route("/reupload/submission", "reupload_submission",
           {'GET': content.reupload_submission_get_, 'POST': content.reupload_submission_post_}),
     Route("/reupload/character", "reupload_character",

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -104,6 +104,19 @@ def control_editcommishinfo_(request):
 
     profile.edit_profile_settings(request.userid, set_trade, set_request, set_commission)
     commishinfo.edit_content(request.userid, form.content)
+
+    if "preferred-tags" in request.POST:
+        preferred_tags = searchtag.parse_tags(request.POST["preferred-tags"])
+        optout_tags = searchtag.parse_tags(request.POST["optout-tags"])
+        searchtag.set_commission_preferred_tags(
+            userid=request.userid,
+            tag_names=preferred_tags,
+        )
+        searchtag.set_commission_optout_tags(
+            userid=request.userid,
+            tag_names=optout_tags,
+        )
+
     raise HTTPSeeOther(location="/control/editcommissionsettings")
 
 

--- a/weasyl/forms.py
+++ b/weasyl/forms.py
@@ -1,0 +1,31 @@
+from typing import Iterable, TypeVar
+
+from weasyl.error import WeasylError
+
+
+_T = TypeVar("T")
+
+
+def expect_id(s: str) -> int:
+    if (
+        1 <= len(s) <= 10  # len(str(2**31-1))
+        and (bs := s.encode()).isdigit()
+        and (id_ := int(bs)) > 0
+    ):
+        return id_
+
+    raise WeasylError("Unexpected")
+
+
+def only(iterable: Iterable[_T]) -> _T:
+    try:
+        x = next(iterable)
+    except StopIteration:
+        pass
+    else:
+        try:
+            next(iterable)
+        except StopIteration:
+            return x
+
+    raise WeasylError("Unexpected")

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -48,7 +48,11 @@ def create(userid, journal, friends_only=False, tags=None):
     })
 
     # Assign search tags
-    searchtag.associate(userid, tags, journalid=journalid)
+    searchtag.associate(
+        userid=userid,
+        target=searchtag.JournalTarget(journalid),
+        tag_names=tags,
+    )
 
     # Create notifications
     welcome.journal_insert(userid, journalid, rating=journal.rating.code,
@@ -121,7 +125,7 @@ def select_view(userid, rating, journalid, ignore=True, anyway=None):
         'friends_only': journal['friends_only'],
         'hidden': journal['hidden'],
         'fave_count': favorite.count(journalid, 'journal'),
-        'tags': searchtag.select(journalid=journalid),
+        'tags': searchtag.select_grouped(userid, searchtag.JournalTarget(journalid)),
         'comments': comment.select(userid, journalid=journalid),
     }
 

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -582,11 +582,14 @@ def suggestion_arbitrate(
             case _:
                 raise TypeError()
 
-    undo_token = _undo_token_create(
-        target=target,
-        tagid=tagid,
-        added_by=check.added_by,
-    )
+    if check.added_by is None:
+        undo_token = None
+    else:
+        undo_token = _undo_token_create(
+            target=target,
+            tagid=tagid,
+            added_by=check.added_by,
+        )
 
     match action:
         case SuggestionAction.APPROVE:

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -1,6 +1,13 @@
+import base64
+import enum
 import re
+import secrets
+import time
+from dataclasses import dataclass
+from struct import Struct
 
 import sqlalchemy as sa
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 from sqlalchemy.sql.expression import any_
 
 from libweasyl import staff
@@ -10,7 +17,7 @@ from weasyl import define as d
 from weasyl import files
 from weasyl import ignoreuser
 from weasyl import macro as m
-from weasyl import welcome
+from weasyl.config import config_obj
 from weasyl.error import WeasylError
 
 
@@ -20,47 +27,121 @@ _TAG_DELIMITER = re.compile(r"[\s,]+")
 MAX_PREFERRED_TAGS = 50
 
 
-def select(submitid=None, charid=None, journalid=None):
-    return d.column(d.engine.execute(
-        "SELECT st.title FROM searchtag st"
-        " INNER JOIN searchmap{suffix} sm USING (tagid)"
-        " WHERE sm.targetid = %(target)s"
-        " ORDER BY st.title".format(
-            suffix="submit" if submitid else "char" if charid else "journal",
-        ),
-        target=submitid if submitid else charid if charid else journalid,
-    ))
+class TaggableTarget:
+    __slots__ = ("id",)
+
+    id: int
+
+    def __init__(self, id: int) -> None:
+        self.id = id
 
 
-def select_with_artist_tags(submitid):
+class SubmissionTarget(TaggableTarget):
+    table = "searchmapsubmit"
+    history_table = "tag_updates"
+    feedback_table = "tag_suggestion_feedback_submission"
+    feature = "submit"
+    arg_name = history_id_column = "submitid"
+    path_component = "submission"
+    type_code = b"s"
+
+
+class CharacterTarget(TaggableTarget):
+    table = "searchmapchar"
+    history_table = None
+    feedback_table = "tag_suggestion_feedback_character"
+    feature = "char"
+    arg_name = "charid"
+    path_component = "character"
+    type_code = b"c"
+
+
+class JournalTarget(TaggableTarget):
+    table = "searchmapjournal"
+    history_table = None
+    feedback_table = "tag_suggestion_feedback_journal"
+    feature = "journal"
+    arg_name = "journalid"
+    path_component = "journal"
+    type_code = b"j"
+
+
+_TARGET_TYPES_BY_CODE = {
+    t.type_code: t
+    for t in (
+        SubmissionTarget,
+        CharacterTarget,
+        JournalTarget,
+    )
+}
+
+_TARGET_TYPES_BY_FEATURE = {
+    t.feature: t
+    for t in (
+        SubmissionTarget,
+        CharacterTarget,
+        JournalTarget,
+    )
+}
+
+
+def get_target(feature: str, targetid: int) -> TaggableTarget:
+    t = _TARGET_TYPES_BY_FEATURE.get(feature)
+
+    if t is None:
+        raise WeasylError("Unexpected")
+
+    return t(targetid)
+
+
+def select(submitid=None, charid=None, journalid=None) -> list[str]:
+    target = (
+        SubmissionTarget(submitid) if submitid
+        else CharacterTarget(charid) if charid
+        else JournalTarget(journalid))
+
+    return select_grouped(None, target).artist
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedTags:
+    artist: list[str]
+    suggested: list[str]
+    own_suggested: list[str]
+
+
+def select_grouped(userid: int, target: TaggableTarget) -> GroupedTags:
     # 'a': artist-tag
     tags = d.engine.execute(
-        "SELECT title, settings ~ 'a'"
-        " FROM searchmapsubmit"
+        "SELECT title, settings ~ 'a', added_by"
+        f" FROM {target.table}"
         " INNER JOIN searchtag USING (tagid)"
-        " WHERE targetid = %(sub)s"
-        " ORDER BY title",
-        sub=submitid,
+        " WHERE targetid = %(target)s",
+        target=target.id,
     ).fetchall()
 
-    ret = []
-    artist_tags = set()
-    for tag, is_artist_tag in tags:
-        ret.append(tag)
+    artist = []
+    suggested = []
+    own_suggested = []
+
+    for tag, is_artist_tag, added_by in tags:
         if is_artist_tag:
-            artist_tags.add(tag)
-    return ret, artist_tags
+            artist.append(tag)
+        else:
+            suggested.append(tag)
 
+            if added_by == userid:
+                own_suggested.append(tag)
 
-def can_remove_tags(userid, ownerid):
-    return userid == ownerid or userid in staff.MODS or 'k' not in d.get_config(ownerid)
+    artist.sort()
+    suggested.sort()
+    own_suggested.sort()
 
-
-def removable_tags(userid, ownerid, tags, artist_tags):
-    if not can_remove_tags(userid, ownerid):
-        return [tag for tag in tags if tag not in artist_tags]
-    else:
-        return tags
+    return GroupedTags(
+        artist=artist,
+        suggested=suggested,
+        own_suggested=own_suggested,
+    )
 
 
 def select_list(map_table, targetids):
@@ -103,16 +184,6 @@ def get_ids(names):
         names=list(names))
 
     return {row.title: row.tagid for row in result}
-
-
-def tag_array(tagids):
-    if not tagids:
-        return None
-    st = d.meta.tables['searchtag']
-    return sa.func.array(
-        sa.select([st.c.title])
-        .where(st.c.tagid == any_(list(tagids)))
-        .scalar_subquery())
 
 
 def parse_tags(text):
@@ -176,152 +247,457 @@ def is_tag_restriction_pattern_valid(text):
     return False
 
 
-def associate(userid, tags, submitid=None, charid=None, journalid=None, preferred_tags_userid=None, optout_tags_userid=None):
+def _update_submission_tags(tx, submitid):
+    tx.execute(
+        "WITH t AS ("
+        " SELECT coalesce(array_agg(tagid), ARRAY[]::integer[]) AS tags FROM searchmapsubmit WHERE targetid = %(submission)s)"
+        " INSERT INTO submission_tags (submitid, tags) SELECT %(submission)s, tags FROM t"
+        " ON CONFLICT (submitid) DO UPDATE SET tags = (SELECT tags FROM t)",
+        submission=submitid,
+    )
+
+
+def _target_unpack(type_code: bytes, id: int) -> TaggableTarget:
+    t = _TARGET_TYPES_BY_CODE.get(type_code)
+
+    if t is None:
+        raise WeasylError("Unexpected")
+
+    return t(id)
+
+
+def _get_ownerid(target: TaggableTarget) -> int | None:
+    return d.get_ownerid(**{target.arg_name: target.id})
+
+
+def _set_suggested_tags(
+    *,
+    userid: int,
+    target: TaggableTarget,
+    ownerid: int,
+    tag_names: set[str],
+) -> list[str]:
+    tagging_privileges_revoked = "g" in d.get_config(userid)
+    if tagging_privileges_revoked:
+        raise WeasylError("InsufficientPermissions")
+
+    if ignoreuser.check(ownerid, userid):
+        raise WeasylError("contentOwnerIgnoredYou")
+
+    # Track which tags fail to be added or removed to later notify the user
+    is_restricted_tag = _get_restricted_tag_matcher({
+        *query_user_restricted_tags(ownerid),
+        *query_global_restricted_tags(),
+    })
+    tags_not_added = set(filter(is_restricted_tag, tag_names))
+    apply_tags = tag_names - tags_not_added
+    apply_tagids = [t.tagid for t in add_and_get_searchtags(apply_tags)]
+
+    def transaction(tx):
+        tx.execute(
+            "WITH"
+            f" removed AS (DELETE FROM {target.table}"
+            " WHERE targetid = %(target)s"
+            " AND settings !~ 'a'"
+            " AND added_by = %(user)s"
+            " AND tagid != ALL (%(tags)s) RETURNING tagid),"
+            f" added AS (INSERT INTO {target.table} (targetid, tagid, added_by)"
+            " SELECT %(target)s, tag, %(user)s"
+            " FROM UNNEST (%(tags)s::integer[]) AS tag"
+            " ON CONFLICT DO NOTHING"
+            " RETURNING tagid)"
+            + (
+                f" INSERT INTO {target.history_table} ({target.history_id_column}, userid, added, removed)"
+                if target.history_table else "")
+            + " VALUES (%(target)s, %(user)s,"
+            " (SELECT coalesce(array_agg(title), ARRAY[]::text[]) FROM searchtag INNER JOIN added USING (tagid)),"
+            " (SELECT coalesce(array_agg(title), ARRAY[]::text[]) FROM searchtag INNER JOIN removed USING (tagid)))",
+            target=target.id,
+            user=userid,
+            tags=apply_tagids,
+        )
+
+        if target.feature == "submit":
+            _update_submission_tags(tx, submitid=target.id)
+
+    files.append(
+        "%stag.%s.%s.log" % (m.MACRO_SYS_LOG_PATH, target.feature, d.get_timestamp()),
+        "-%sID %i  -T %i  -UID %i  -X %s\n" % (target.feature[0].upper(), target.id, d.get_time(), userid,
+                                               " ".join(tag_names)))
+    d.serializable_retry(transaction)
+
+    return sorted(tags_not_added)
+
+
+def _set_commission_tags(*, userid: int, tag_names: set[str], table: str) -> None:
+    query = add_and_get_searchtags(tag_names)
+    entered_tagids = [t.tagid for t in query]
+
+    def transaction(tx):
+        tx.execute(
+            f"DELETE FROM {table}"
+            " WHERE targetid = %(user)s"
+            " AND tagid != ALL (%(tags)s)",
+            user=userid,
+            tags=entered_tagids,
+        )
+        tx.execute(
+            f"INSERT INTO {table} (tagid, targetid)"
+            " SELECT tagid, %(user)s FROM UNNEST (%(tags)s::integer[]) AS tagid"
+            " ON CONFLICT DO NOTHING",
+            user=userid,
+            tags=entered_tagids,
+        )
+
+    d.serializable_retry(transaction)
+
+
+def set_commission_preferred_tags(*, userid: int, tag_names: set[str]) -> None:
+    # enforce the limit on artist preference tags
+    if len(tag_names) > MAX_PREFERRED_TAGS:
+        raise WeasylError("tooManyPreferenceTags")
+
+    _set_commission_tags(userid=userid, tag_names=tag_names, table="artist_preferred_tags")
+
+
+def set_commission_optout_tags(*, userid: int, tag_names: set[str]) -> None:
+    _set_commission_tags(userid=userid, tag_names=tag_names, table="artist_optout_tags")
+
+
+def associate(*, userid: int, target: TaggableTarget, tag_names: set[str]) -> list[str]:
     """
-    Associates searchtags with a content item.
+    Associates tags with a content item.
 
     Parameters:
         userid: The userid of the user associating tags
-        tags: A set of tags
-        submitid: The ID number of a submission content item to associate
-        ``tags`` to. (default: None)
-        charid: The ID number of a character content item to associate
-        ``tags`` to. (default: None)
-        journalid: The ID number of a journal content item to associate
-        ``tags`` to. (default: None)
-        preferred_tags_userid: The ID number of a user to associate
-        ``tags`` to for Preferred tags. (default: None)
-        optout_tags_userid: The ID number of a user to associate
-        ``tags`` to for Opt-Out tags. (default: None)
+        target: The content item to associate ``tags`` to
+        tag_names: A set of tags
 
     Returns:
-        A dict containing two elements. 1) ``add_failure_restricted_tags``, which contains a space separated
-        string of tag titles which failed to be added to the content item due to the user or global restricted
-        tag lists; and 2) ``remove_failure_owner_set_tags``, which contains a space separated string of tag
-        titles which failed to be removed from the content item due to the owner of the aforementioned item
-        prohibiting users from removing tags set by the content owner.
-
-        If an element does not have tags, the element is set to None. If neither elements are set,
-        the function returns None.
+        A list of tag names that weren't added because they were on the owner's or the global restricted tag list.
     """
-    targetid = d.get_targetid(submitid, charid, journalid)
+    ownerid = _get_ownerid(target)
 
-    # Assign table, feature, ownerid
-    if submitid:
-        table, feature = "searchmapsubmit", "submit"
-        ownerid = d.get_ownerid(submitid=targetid)
-    elif charid:
-        table, feature = "searchmapchar", "char"
-        ownerid = d.get_ownerid(charid=targetid)
-    elif journalid:
-        table, feature = "searchmapjournal", "journal"
-        ownerid = d.get_ownerid(journalid=targetid)
-    elif preferred_tags_userid:
-        table, feature = "artist_preferred_tags", "user"
-        targetid = ownerid = preferred_tags_userid
-    elif optout_tags_userid:
-        table, feature = "artist_optout_tags", "user"
-        targetid = ownerid = optout_tags_userid
-    else:
-        raise WeasylError("Unexpected")
-
-    # Check permissions and invalid target
     if not ownerid:
         raise WeasylError("TargetRecordMissing")
-    elif userid != ownerid and ("g" in d.get_config(userid) or preferred_tags_userid or optout_tags_userid):
-        # disallow if user is forbidden from tagging, or trying to set artist tags on someone other than themselves
-        raise WeasylError("InsufficientPermissions")
-    elif ignoreuser.check(ownerid, userid):
-        raise WeasylError("contentOwnerIgnoredYou")
+    # TODO: check if target deleted
 
-    # Determine previous tagids, titles, and settings
-    existing = d.engine.execute(
-        "SELECT tagid, title, settings FROM {} INNER JOIN searchtag USING (tagid) WHERE targetid = %(target)s".format(table),
-        target=targetid).fetchall()
+    if userid != ownerid and userid not in staff.MODS:
+        return _set_suggested_tags(
+            userid=userid,
+            target=target,
+            ownerid=ownerid,
+            tag_names=tag_names,
+        )
 
     # Retrieve tag titles and tagid pairs, for new (if any) and existing tags
-    query = add_and_get_searchtags(tags)
+    query = add_and_get_searchtags(tag_names)
+    entered_tagids = [t.tagid for t in query]
 
-    existing_tagids = {t.tagid for t in existing}
-    entered_tagids = {t.tagid for t in query}
+    def transaction(tx):
+        tx.execute(
+            "WITH"
+            f" removed AS (DELETE FROM {target.table}"
+            " WHERE targetid = %(target)s"
+            " AND settings ~ 'a'"
+            " AND tagid != ALL (%(tags)s) RETURNING tagid),"
+            f" added AS (INSERT INTO {target.table} AS ct (targetid, tagid, settings, added_by)"
+            " SELECT %(target)s, tag, 'a', %(user)s"
+            " FROM UNNEST (%(tags)s::integer[]) AS tag"
+            " ON CONFLICT (targetid, tagid) DO UPDATE SET settings = ct.settings || 'a', added_by = %(user)s WHERE ct.settings !~ 'a'"
+            " RETURNING tagid)"
+            + (
+                f" INSERT INTO {target.history_table} ({target.history_id_column}, userid, added, removed)"
+                if target.history_table else "")
+            + " VALUES (%(target)s, %(user)s,"
+            " (SELECT coalesce(array_agg(title), ARRAY[]::text[]) FROM searchtag INNER JOIN added USING (tagid)),"
+            " (SELECT coalesce(array_agg(title), ARRAY[]::text[]) FROM searchtag INNER JOIN removed USING (tagid)))",
+            target=target.id,
+            user=userid,
+            tags=entered_tagids,
+        )
 
-    # Assign added and removed
-    added = entered_tagids - existing_tagids
-    removed = existing_tagids - entered_tagids
-
-    # enforce the limit on artist preference tags
-    if preferred_tags_userid and (len(added) - len(removed) + len(existing)) > MAX_PREFERRED_TAGS:
-        raise WeasylError("tooManyPreferenceTags")
-
-    # Track which tags fail to be added or removed to later notify the user (Note: These are tagids at this stage)
-    add_failure_restricted_tags = None
-    remove_failure_owner_set_tags = None
-
-    # If the modifying user is not the owner of the object, and is not staff, check user/global restriction lists
-    if userid != ownerid and userid not in staff.MODS:
-        user_rtags = set(query_user_restricted_tags(ownerid))
-        global_rtags = set(query_global_restricted_tags())
-        add_failure_restricted_tags = remove_restricted_tags(user_rtags | global_rtags, query)
-        added -= add_failure_restricted_tags
-        if len(add_failure_restricted_tags) == 0:
-            add_failure_restricted_tags = None
-
-    # Check removed artist tags
-    if not can_remove_tags(userid, ownerid):
-        existing_artist_tags = {t.tagid for t in existing if 'a' in t.settings}
-        remove_failure_owner_set_tags = removed & existing_artist_tags
-        removed.difference_update(existing_artist_tags)
-        entered_tagids.update(existing_artist_tags)
-        # Submission items use a different method of tag protection for artist tags; ignore them
-        if submitid or len(remove_failure_owner_set_tags) == 0:
-            remove_failure_owner_set_tags = None
-
-    # Remove tags
-    if removed:
-        d.engine.execute(
-            "DELETE FROM {} WHERE targetid = %(target)s AND tagid = ANY (%(removed)s)".format(table),
-            target=targetid, removed=list(removed))
-
-    if added:
-        d.engine.execute(
-            "INSERT INTO {} SELECT tag, %(target)s FROM UNNEST (%(added)s) AS tag".format(table),
-            target=targetid, added=list(added))
-
-        # preference/optout tags can only be set by the artist, so this settings column does not apply
-        if userid == ownerid and not (preferred_tags_userid or optout_tags_userid):
-            d.engine.execute(
-                "UPDATE {} SET settings = settings || 'a' WHERE targetid = %(target)s AND tagid = ANY (%(added)s)".format(table),
-                target=targetid, added=list(added))
-
-    if submitid:
-        d.engine.execute(
-            'INSERT INTO submission_tags (submitid, tags) VALUES (%(submission)s, %(tags)s) '
-            'ON CONFLICT (submitid) DO UPDATE SET tags = %(tags)s',
-            submission=submitid, tags=list(entered_tagids))
-
-        db = d.connect()
-        db.execute(
-            d.meta.tables['tag_updates'].insert()
-            .values(submitid=submitid, userid=userid,
-                    added=tag_array(added), removed=tag_array(removed)))
-        if userid != ownerid:
-            welcome.tag_update_insert(ownerid, submitid)
+        if target.feature == "submit":
+            _update_submission_tags(tx, submitid=target.id)
 
     files.append(
-        "%stag.%s.%s.log" % (m.MACRO_SYS_LOG_PATH, feature, d.get_timestamp()),
-        "-%sID %i  -T %i  -UID %i  -X %s\n" % (feature[0].upper(), targetid, d.get_time(), userid,
-                                               " ".join(tags)))
+        "%stag.%s.%s.log" % (m.MACRO_SYS_LOG_PATH, target.feature, d.get_timestamp()),
+        "-%sID %i  -T %i  -UID %i  -X %s\n" % (target.feature[0].upper(), target.id, d.get_time(), userid,
+                                               " ".join(tag_names)))
+    d.serializable_retry(transaction)
 
-    # Return dict with any tag titles as a string that failed to be added or removed
-    if add_failure_restricted_tags or remove_failure_owner_set_tags:
-        if add_failure_restricted_tags:
-            add_failure_restricted_tags = " ".join({tag.title for tag in query if tag.tagid in add_failure_restricted_tags})
-        if remove_failure_owner_set_tags:
-            remove_failure_owner_set_tags = " ".join({tag.title for tag in existing if tag.tagid in remove_failure_owner_set_tags})
-        return {"add_failure_restricted_tags": add_failure_restricted_tags,
-                "remove_failure_owner_set_tags": remove_failure_owner_set_tags}
-    else:
-        return None
+    return []
+
+
+@enum.unique
+class SuggestionAction(enum.Enum):
+    REJECT = enum.auto()
+    APPROVE = enum.auto()
+
+
+@dataclass(frozen=True, slots=True)
+class SuggestionActionFailure:
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class SuggestionActionSuccess:
+    undo_token: bytes | None
+
+
+SuggestionActionResult = (
+    SuggestionActionFailure
+    | SuggestionActionSuccess
+)
+
+
+_undo_key = ChaCha20Poly1305(base64.urlsafe_b64decode(config_obj.get("secret_keys", "suggested_tag_undo")))
+"""
+The secret key used to ensure the secrecy (suggestions are anonymous) and authenticity (the suggestion attribution that will be restored on undo is stored in the token) of the data in undo tokens.
+
+Fernet is almost good enough for this (even though its tokens are needlessly long for short messages, and it forces base64), but it doesn’t expose AEAD, and additional authenticated data is something that makes sense when the PUT and DELETE requests use the same path.
+"""
+
+_UNDO_TOKEN_MAX_CLOCK_SKEW = 2
+"""The maximum acceptable time into the future of token timestamps, in seconds. Weasyl server clocks should be in sync to well within this."""
+
+_UNDO_TOKEN_VALIDITY = 60
+"""The time the undo token for approval/rejection of a suggested tag remains valid, in seconds."""
+
+_UNDO_ENCRYPTED_PART = Struct("<I")
+"""
+The structure of the encrypted part of an undo token:
+
+- user id of suggester
+"""
+
+_POLY1305_TAG_SIZE = 16
+_UNDO_TOKEN_NONCE_SIZE = 12
+_UNDO_HEADER = Struct(f"<{_UNDO_TOKEN_NONCE_SIZE}sI")
+_UNDO_AAD = Struct("<IIIc")
+"""
+The structure of the serialized additional associated data for an undo token:
+
+- unsigned timestamp (revisit before 2106-02)
+- target id
+- tag id
+- target type ('s', 'c', or 'j')
+"""
+
+
+class UndoExpired(Exception):
+    pass
+
+
+def _undo_token_create(*, target: TaggableTarget, tagid: int, added_by: int) -> bytes:
+    nonce = secrets.token_bytes(_UNDO_TOKEN_NONCE_SIZE)
+    now = int(time.time())
+    aad = _UNDO_AAD.pack(now, target.id, tagid, target.type_code)
+
+    return _UNDO_HEADER.pack(nonce, now) + _undo_key.encrypt(
+        nonce,
+        _UNDO_ENCRYPTED_PART.pack(added_by),
+        aad,
+    )
+
+
+def _undo_token_validate(
+    *,
+    target: TaggableTarget,
+    tagid: int,
+    undo_token: bytes,
+) -> int:
+    """
+    Validates a tag suggestion action undo token, returning the user id of the suggester to restore.
+
+    Throws `UndoExpired` when the undo token has expired.
+
+    Throws `WeasylError("Unexpected")` or `cryptography.exceptions.InvalidTag` on unexpected conditions.
+    """
+    if len(undo_token) != _UNDO_HEADER.size + _UNDO_ENCRYPTED_PART.size + _POLY1305_TAG_SIZE:
+        raise WeasylError("Unexpected")
+
+    nonce, timestamp = _UNDO_HEADER.unpack_from(undo_token)
+    now = int(time.time())
+
+    if timestamp < now - _UNDO_TOKEN_VALIDITY:
+        raise UndoExpired()
+
+    if timestamp > now + _UNDO_TOKEN_MAX_CLOCK_SKEW:
+        raise WeasylError("Unexpected")
+
+    aad = _UNDO_AAD.pack(timestamp, target.id, tagid, target.type_code)
+    decrypted = _undo_key.decrypt(nonce, undo_token[_UNDO_HEADER.size:], aad)
+    (added_by,) = _UNDO_ENCRYPTED_PART.unpack(decrypted)
+
+    return added_by
+
+
+def suggestion_arbitrate(
+    *,
+    userid: int,
+    target: TaggableTarget,
+    tag_name: str,
+    action: SuggestionAction,
+) -> SuggestionActionResult:
+    """
+    Approve or reject a suggested tag.
+    """
+    ownerid = _get_ownerid(target)
+
+    if not ownerid:
+        raise WeasylError("TargetRecordMissing")
+
+    if userid != ownerid and userid not in staff.MODS:
+        raise WeasylError("InsufficientPermissions")
+
+    tagid = get_or_create(tag_name)
+
+    # there are inherent concurrency issues we’re calling acceptable with the undo token approach, so don’t bother with a transaction
+    check = d.engine.execute(
+        "SELECT added_by, settings"
+        f" FROM {target.table}"
+        " WHERE (targetid, tagid) = (%(target)s, %(tag)s)",
+        target=target.id,
+        tag=tagid,
+    ).first()
+
+    if check is None:
+        # never suggested, or already rejected
+        match action:
+            case SuggestionAction.APPROVE:
+                return SuggestionActionFailure()
+            case SuggestionAction.REJECT:
+                return SuggestionActionSuccess(undo_token=None)
+            case _:
+                raise TypeError()
+
+    if "a" in check.settings:
+        # already approved
+        match action:
+            case SuggestionAction.APPROVE:
+                return SuggestionActionSuccess(undo_token=None)
+            case SuggestionAction.REJECT:
+                return SuggestionActionFailure()
+            case _:
+                raise TypeError()
+
+    undo_token = _undo_token_create(
+        target=target,
+        tagid=tagid,
+        added_by=check.added_by,
+    )
+
+    match action:
+        case SuggestionAction.APPROVE:
+            d.engine.execute(
+                f"UPDATE {target.table}"
+                " SET settings = settings || 'a', added_by = %(user)s"
+                " WHERE (targetid, tagid) = (%(target)s, %(tag)s)"
+                " AND settings !~ 'a'",
+                target=target.id,
+                tag=tagid,
+                user=userid,
+            )
+
+        case SuggestionAction.REJECT:
+            with d.engine.begin() as tx:
+                tx.execute(
+                    f"DELETE FROM {target.table}"
+                    " WHERE (targetid, tagid) = (%(target)s, %(tag)s)",
+                    target=target.id,
+                    tag=tagid,
+                )
+                tx.execute(
+                    f"INSERT INTO {target.feedback_table} (targetid, tagid, userid, incorrect, unwanted, abusive)"
+                    " VALUES (%(target)s, %(tag)s, %(user)s, FALSE, FALSE, FALSE)"
+                    " ON CONFLICT (targetid, tagid, userid) DO NOTHING",
+                    target=target.id,
+                    tag=tagid,
+                    user=userid,
+                )
+
+        case _:
+            raise TypeError()
+
+    return SuggestionActionSuccess(undo_token=undo_token)
+
+
+def suggestion_action_undo(
+    *,
+    userid: int,
+    target: TaggableTarget,
+    tag_name: str,
+    undo_token: bytes,
+) -> None:
+    tagid = get_or_create(tag_name)
+
+    restore_added_by = _undo_token_validate(
+        target=target,
+        tagid=tagid,
+        undo_token=undo_token,
+    )
+
+    ownerid = _get_ownerid(target)
+
+    # sanity check + limit the damage of a compromised key to the authenticated account
+    if not ownerid or (userid != ownerid and userid not in staff.MODS):
+        raise WeasylError("Unexpected")
+
+    with d.engine.begin() as tx:
+        tx.execute(
+            f"INSERT INTO {target.table} AS ct (targetid, tagid, added_by)"
+            " VALUES (%(target)s, %(tag)s, %(restore)s)"
+            " ON CONFLICT (tagid, targetid) DO UPDATE SET settings = replace(ct.settings, 'a', ''), added_by = %(restore)s"
+            " WHERE (ct.targetid, ct.tagid) = (%(target)s, %(tag)s)",
+            target=target.id,
+            tag=tagid,
+            restore=restore_added_by,
+        )
+        tx.execute(
+            f"DELETE FROM {target.feedback_table}"
+            " WHERE (targetid, tagid, userid) = (%(target)s, %(tag)s, %(user)s)",
+            target=target.id,
+            tag=tagid,
+            user=userid,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SuggestionFeedback:
+    incorrect: bool
+    unwanted: bool
+    abusive: bool
+
+
+def set_tag_feedback(
+    *,
+    userid: int,
+    target: TaggableTarget,
+    tag_name: int,
+    feedback: SuggestionFeedback,
+) -> None:
+    ownerid = _get_ownerid(target)
+
+    if userid != ownerid and userid not in staff.MODS:
+        raise WeasylError("Unexpected")
+
+    tagid = get_or_create(tag_name)
+
+    d.engine.execute(
+        f"INSERT INTO {target.feedback_table}"
+        " (targetid, tagid, userid, incorrect, unwanted, abusive)"
+        " VALUES (%(target)s, %(tag)s, %(user)s, %(incorrect)s, %(unwanted)s, %(abusive)s)"
+        " ON CONFLICT (targetid, tagid, userid) DO UPDATE SET"
+        " incorrect = %(incorrect)s, unwanted = %(unwanted)s, abusive = %(abusive)s,"
+        " last_modified = now()",
+        target=target.id,
+        tag=tagid,
+        user=userid,
+        incorrect=feedback.incorrect,
+        unwanted=feedback.unwanted,
+        abusive=feedback.abusive,
+    )
 
 
 def tag_history(submitid):
@@ -507,20 +883,5 @@ def query_global_restricted_tags():
     return [tag.title for tag in query]
 
 
-def remove_restricted_tags(patterns, tags):
-    """
-    Determines what, if any, new search tags match tags that are on the user or global
-      restricted tag list.
-
-    Parameters:
-        patterns: The result of ``query_user_restricted_tags(ownerid) + query_global_restricted_tags()``.
-        Consists of a list of titles of patterns which match a restricted tag.
-
-        tags: The reused SQL query result from ``associate()`` which consists of tagids
-        and titles for tags passed to the function.
-
-    Returns:
-        A set of tagids which have been restricted.
-    """
-    regex = r"(?:%s)\Z" % ("|".join(pattern.replace("*", ".*") for pattern in patterns),)
-    return {tag.tagid for tag in tags if re.match(regex, tag.title)}
+def _get_restricted_tag_matcher(patterns):
+    return re.compile("|".join(pattern.replace("*", ".*") for pattern in patterns)).fullmatch

--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -337,17 +337,13 @@ def tag_history(submitid):
 
 def add_and_get_searchtags(tags):
     """
-    Handles addition of--and getting existing--searchtags, abstracting the logic
-    for addition of such from editing functions. Serves to consolidate otherwise
-    duplicated code.
+    Get tag ids for the provided tag names, creating ids for new tags as necessary.
 
     Parameters:
-        tags: A set of tags.
+        tags: A set of tag names, already validated and normalized.
 
     Returns:
-        query: The results of a SQL query which contains tagids and titles for
-        tags which either currently exist, or were added as a result
-        of this function.
+        A list of `(tagid, title)` `RowProxy` objects: one for each tag name.
     """
     # Get the tag titles/ids out of the searchtag table
     query = d.engine.execute("""

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -249,7 +249,11 @@ def create_visual(userid, submission,
             submitid, 'thumbnail-custom', thumb_custom_media_item)
 
     # Assign search tags
-    searchtag.associate(userid, tags, submitid=submitid)
+    searchtag.associate(
+        userid=userid,
+        target=searchtag.SubmissionTarget(submitid),
+        tag_names=tags,
+    )
 
     # Create notifications
     if create_notifications:
@@ -340,7 +344,11 @@ def create_literary(userid, submission, embedlink=None, friends_only=False, tags
         db.execute(q)
 
     # Assign search tags
-    searchtag.associate(userid, tags, submitid=submitid)
+    searchtag.associate(
+        userid=userid,
+        target=searchtag.SubmissionTarget(submitid),
+        tag_names=tags,
+    )
 
     if submit_media_item:
         orm.SubmissionMediaLink.make_or_replace_link(submitid, 'submission', submit_media_item)
@@ -444,7 +452,11 @@ def create_multimedia(userid, submission, embedlink=None, friends_only=None,
     submitid = db.scalar(q)
 
     # Assign search tags
-    searchtag.associate(userid, tags, submitid=submitid)
+    searchtag.associate(
+        userid=userid,
+        target=searchtag.SubmissionTarget(submitid),
+        tag_names=tags,
+    )
 
     if submit_media_item:
         orm.SubmissionMediaLink.make_or_replace_link(submitid, 'submission', submit_media_item)
@@ -602,7 +614,7 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
     if query[11] == 'google-drive':
         google_doc_embed = get_google_docs_embed_url(submitid)
 
-    tags, artist_tags = searchtag.select_with_artist_tags(submitid)
+    grouped_tags = searchtag.select_grouped(userid, searchtag.SubmissionTarget(submitid))
     settings = d.get_profile_settings(query[0])
 
     sub_media = media.get_submission_media(submitid)
@@ -641,10 +653,7 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
         "google_doc_embed": google_doc_embed,
 
 
-        "tags": tags,
-        "artist_tags": artist_tags,
-        "removable_tags": searchtag.removable_tags(userid, query[0], tags, artist_tags),
-        "can_remove_tags": searchtag.can_remove_tags(userid, query[0]),
+        "tags": grouped_tags,
         "folder_more": select_near(userid, rating, 1, query[0], query[2], submitid),
         "folder_title": query[13] if query[13] else "Root",
 

--- a/weasyl/templates/common/detail_tag_form.html
+++ b/weasyl/templates/common/detail_tag_form.html
@@ -1,11 +1,99 @@
-$def with (targetid, feature, query)
-<form class="tags-form" action="/submit/tags" method="post">
-  <input type="hidden" name="${feature}id" value="${targetid}" />
+$def with (targetid, feature, query, myself)
+<div class="di-tags">
+  <h3>Tags</h3>
 
-  <label for="detail_tag_form_content">Add or Remove Tags:</label><br />
-  <textarea class="input tags-textarea" name="tags">${" ".join(query)}</textarea>
+  $code:
+    edit_type = 'none'
 
-  <div id="detail_tag_form_buttons">
-    <button class="button" type="submit">Submit</button>
+    if not myself:
+      pass
+    elif query['mine'] or myself['userid'] in staff.MODS:
+      edit_type = 'edit'
+    elif myself['is_verified']:
+      # TODO: also check if has permission to suggest tags?
+      edit_type = 'suggest'
+
+    tags = query['tags']
+
+  <div class="tags-with-actions clear" data-tag-edit-type="${edit_type}">
+    $if tags.artist or tags.suggested:
+      <ul class="tags">
+        $for tag in tags.artist:
+          <li><a class="tag" href="/search?q=${tag}" rel="tag">${tag}</a></li>
+        $if myself:
+          $for tag in tags.suggested:
+            <li><a class="tag tag-suggested" href="/search?q=${tag}" rel="tag">${tag}</a></li>
+      </ul>
+    $else:
+      <p class="color-lighter">(No tags)</p>
+
+    $if feature == 'submit' and myself and myself['userid'] in staff.MODS:
+      <span class="tag-actions">
+        <a class="typeface-default color-c" href="/submission/tag-history/${query['submitid']}">History</a>
+      </span>
   </div>
-</form>
+
+  $if edit_type != 'none':
+    <div class="tags-manage" hidden>
+      <form class="tags-form" action="/submit/tags" method="POST">
+        <input type="hidden" name="${feature}id" value="${targetid}" />
+
+        <textarea class="input tags-textarea" name="tags">${" ".join(tags.artist if edit_type == 'edit' else tags.own_suggested)}</textarea>
+
+        <div class="tags-actions">
+          <button class="button">Save tags</button>
+        </div>
+      </form>
+
+      $if edit_type == 'edit':
+        <ul class="suggested-tags">
+          $for tag in tags.suggested:
+            <li data-tag="${tag}">
+              <a class="tag tag-suggested" href="/search?q=${tag}">${tag}</a>
+              <fieldset class="suggested-tag-actions">
+                <button class="button positive" data-tag-action="approve">Approve</button>
+                <button class="button negative" data-tag-action="reject">Reject</button>
+                $#Suggestion rejected. <button class="link-button" data-tag-action="undo">Undo</button>
+              </fieldset>
+            </li>
+        </ul>
+
+        <form class="tag-reject-feedback" data-target="${feature}/${targetid}" hidden>
+          <h4>Rejection feedback on <a class="tag tag-suggested"></a> <span class="optional-indicator">(optional)</span></h4>
+
+          <label>
+            <input id="tag-reject-reason-incorrect" type="checkbox" name="reason" value="incorrect">
+
+            <span class="tag-reject-label">
+              Incorrect
+
+              <p>People <strong>searching for</strong> or <strong>blocking</strong> the tag won’t expect to find or block this.</p>
+            </span>
+          </label>
+
+          <label>
+            <input id="tag-reject-reason-unwanted" type="checkbox" name="reason" value="unwanted">
+
+            <span class="tag-reject-label">
+              Unwanted
+
+              <p>The tag could be accurate, but I don’t want to use it.</p>
+            </span>
+          </label>
+
+          <label>
+            <input id="tag-reject-reason-abusive" type="checkbox" name="reason" value="abusive">
+
+            <span class="tag-reject-label">
+              Abusive
+
+              <p>The tag was added maliciously; report it to Weasyl staff.</p>
+            </span>
+          </label>
+
+          <output class="tag-reject-feedback-status" role="status" for="tag-reject-reason-incorrect tag-reject-reason-unwanted tag-reject-reason-abusive">
+            Feedback will be saved automatically.
+          </output>
+        </form>
+    </div>
+</div>

--- a/weasyl/templates/common/page_end.html
+++ b/weasyl/templates/common/page_end.html
@@ -76,5 +76,8 @@ $if options and "imageselect" in options:
 $if options and 'search' in options:
   <script src="${resource_path('js/search.js')}"></script>
 
+$if options and 'tags-edit' in options:
+  <script type="module" src="${resource_path('js/tags-edit.js')}" async></script>
+
 </body>
 </html>

--- a/weasyl/templates/control/edit_commissionsettings.html
+++ b/weasyl/templates/control/edit_commissionsettings.html
@@ -10,13 +10,9 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Settings", "Settings"])}
     <p>Information about commissioning you and preferences for commission content</p>
     <div class="commish-row">
       <div class="info">
-        <form name="controleditcommishtext" action="/control/editcommishinfo" method="post" class="clear">
+        <form action="/control/editcommishinfo" method="post" class="clear">
           <!-- Copied from edit_profile.html. TODO(hyena): Only put this in one place, probably here. -->
           <label for="editprofile-setcommish">Commissions</label>
-          <p>
-            You will not appear in <a href="/marketplace">Marketplace</a> results unless your commission status
-            is "currently accepting" or "may sometimes accept".
-          </p>
           <select id="editprofile-setcommish" class="input" name="set_commish">
             <option value="o"${_SELECTED(0, 'o')}>I am currently accepting commissions</option>
             <option value="s"${_SELECTED(0, 's')}>I may sometimes accept commissions</option>
@@ -24,6 +20,7 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Settings", "Settings"])}
             <option value="c"${_SELECTED(0, 'c')}>I am not accepting commissions right now</option>
             <option value="e"${_SELECTED(0, 'e')}>This is not applicable to me</option>
           </select>
+          <p class="color-lighter tags-help"><i>You will appear in <a href="/marketplace">Marketplace</a> results if your commission status is “currently accepting” or “may sometimes accept”.</i></p>
 
           <label for="editprofile-settrade">Trades</label>
           <select id="editprofile-settrade" class="input" name="set_trade">
@@ -44,65 +41,39 @@ $:{RENDER("common/stage_title.html", ["Edit Commission Settings", "Settings"])}
           <textarea class="markdown input last-input expanding" name="content" rows="8" id="commish-info">${query['content'] if query['content'] else ''}</textarea>
           <br />
 
-          <button type="submit" class="button positive" style="float: right;">Save Info</button>
+          <div class="commish-tags">
+            <label for="preferred-tags">Preferred Tags</label>
+            <textarea id="preferred-tags" name="preferred-tags" class="input tags-textarea">${' '.join(query['tags'])}</textarea>
+            <p class="color-lighter tags-help"><i>Use these tags to indicate subject matter you prefer to create, making it easier for commissioners to find you.</i></p>
+
+            <label for="optout-tags">Opt-Out Tags</label>
+            <textarea id="optout-tags" name="optout-tags" class="input tags-textarea">${' '.join(query['opt_out'])}</textarea>
+            <p class="color-lighter tags-help"><i>You will not appear in results for commission searches containing these tags.</i></p>
+          </div>
+
+          <div class="form-actions">
+            <button type="submit" class="button positive" style="float: right;">Save Info</button>
+          </div>
         </form>
       </div>
-      <div class="commish-tags">
-        <div class="di-tags">
-          <h3>Preferred Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-          <p>
-            Use these tags to indicate subject matter you prefer to create, making it easier for
-            commissioners to find you.
-          </p>
-
-          <div class="tags open clear">
-            $if query['tags']:
-              $for tag in query['tags']:
-                <a href="/marketplace?q=${tag}">${tag}</a>
-            $else:
-              <p class="color-lighter">You have not defined any preferred tags.</p>
-          </div>
-
-          <h3 class="edit">Edit Tags</h3>
-          $:{RENDER("common/detail_tag_form.html", [query['userid'], "preferred_tags_user", query['tags']])}
-
-        </div>
-        <div class="di-tags">
-          <h3>Opt-Out Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-          <p>
-            You will not appear in results for commission searches containing these tags.
-          </p>
-
-          <div class="tags open clear">
-            $if query['opt_out']:
-              $for tag in query['opt_out']:
-                <a class="artist" href="/marketplace?q=${tag}">${tag}</a>
-            $else:
-              <p class="color-lighter">You have not defined any opt-out tags.</p>
-          </div>
-
-          <h3 class="edit">Edit Tags</h3>
-          $:{RENDER("common/detail_tag_form.html", [query['userid'], "optout_tags_user", query['opt_out']])}
-        </div>
-        <div id="user-commissions" class="clear on-side">
-          <h3>Preview</h3>
-          $for i in query['class']:
-            <h4 class="color-c">${i['title']}</h4>
-            <dl class="leaders">
-            $for j in query['price']:
-              $if(j['classid'] == i['classid'] and 'a' not in j['settings']):
-                <dt>${j['title']}</dt>
-                <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
-                $if(j['amount_max']):
-                  <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
-            $for j in query['price']:
-              $if(j['classid'] == i['classid'] and 'a' in j['settings']):
-                <dt><i>add &#160;</i>${j['title']}</dt>
-                <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
-                $if(j['amount_max']):
-                  <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
-            </dl>
-        </div>
+      <div id="user-commissions" class="clear on-side">
+        <h3>Preview</h3>
+        $for i in query['class']:
+          <h4 class="color-c">${i['title']}</h4>
+          <dl class="leaders">
+          $for j in query['price']:
+            $if(j['classid'] == i['classid'] and 'a' not in j['settings']):
+              <dt>${j['title']}</dt>
+              <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
+              $if(j['amount_max']):
+                <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
+          $for j in query['price']:
+            $if(j['classid'] == i['classid'] and 'a' in j['settings']):
+              <dt><i>add &#160;</i>${j['title']}</dt>
+              <dd>$:{'<i>from </i>' if j['amount_max'] else ''}${SYMBOL(j['settings'])} ${PRICE(j['amount_min'])}</dd>
+              $if(j['amount_max']):
+                <dd><i>to </i>${SYMBOL(j['settings'])} ${PRICE(j['amount_max'])}</dd>
+          </dl>
       </div>
     </div>
   </div>

--- a/weasyl/templates/control/edit_preferences.html
+++ b/weasyl/templates/control/edit_preferences.html
@@ -36,10 +36,7 @@ $code:
 
     <label>Custom Profile Settings</label>
 
-    <label class="input-checkbox">
-      <input type="checkbox" name="tagging"$:{_CHECKED("k")} />
-      Prevent other users from removing tags I place on my content
-    </label>
+    <input type="hidden" name="tagging"$:{_CHECKED("k")} />
 
     <label class="input-checkbox">
       <input type="checkbox" name="hideprofile"$:{_CHECKED("h")} />

--- a/weasyl/templates/detail/character.html
+++ b/weasyl/templates/detail/character.html
@@ -118,22 +118,7 @@ $def with (myself, query, violations)
         </form>
       </div>
 
-
-    <div class="di-tags">
-      <h3>Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-
-      <div class="tags open clear">
-        $if query['tags']:
-          $for i in query['tags']:
-            <a href="/search?q=${i}">${i}</a>
-        $else:
-          <p class="color-lighter">There are no tags associated with this character</p>
-      </div>
-
-      <h3 class="edit">Edit Tags</h3>
-
-      $:{RENDER("common/detail_tag_form.html", [query['charid'], "char", query['tags']])}
-    </div>
+    $:{RENDER("common/detail_tag_form.html", [query['charid'], "char", query, myself])}
 
   </div>
 

--- a/weasyl/templates/detail/journal.html
+++ b/weasyl/templates/detail/journal.html
@@ -99,21 +99,7 @@ $def with (myself, query, violations)
         </form>
       </div>
 
-    <div class="di-tags">
-      <h3>Tags <a class="modify typeface-default color-c" href="#">Modify</a></h3>
-
-      <div class="tags open clear">
-        $if query['tags']:
-          $for i in query['tags']:
-            <a href="/search?find=journal&amp;q=${i}">${i}</a>
-        $else:
-          <p class="color-lighter">There are no tags associated with this journal</p>
-      </div>
-
-      <h3 class="edit">Edit Tags</h3>
-
-      $:{RENDER("common/detail_tag_form.html", [query['journalid'], "journal", query['tags']])}
-    </div>
+    $:{RENDER("common/detail_tag_form.html", [query['journalid'], "journal", query, myself])}
 
   </div>
 

--- a/weasyl/templates/detail/submission.html
+++ b/weasyl/templates/detail/submission.html
@@ -297,7 +297,8 @@ $code:
           $for i in query['tags']:
             <a href="/search?q=${i}"
                class="${'artist' if i in query['artist_tags'] else ''}
-                      ${'removable' if query['can_remove_tags'] else ''}">
+                      ${'removable' if query['can_remove_tags'] else ''}"
+               rel="tag">
               ${i}
             </a>
         $else:

--- a/weasyl/templates/detail/submission.html
+++ b/weasyl/templates/detail/submission.html
@@ -284,31 +284,7 @@ $code:
         </form>
       </div>
 
-
-    <div class="di-tags">
-      <h3>
-        Tags
-        <a class="modify typeface-default color-c" href="#">Modify</a>
-        <a class="typeface-default color-c" href="/submission/tag-history/${query['submitid']}">History</a>
-      </h3>
-
-      <div class="tags open clear">
-        $if query['tags']:
-          $for i in query['tags']:
-            <a href="/search?q=${i}"
-               class="${'artist' if i in query['artist_tags'] else ''}
-                      ${'removable' if query['can_remove_tags'] else ''}"
-               rel="tag">
-              ${i}
-            </a>
-        $else:
-          <p class="color-lighter">There are no tags associated with this submission</p>
-      </div>
-
-      <h3 class="edit">Edit Tags</h3>
-
-      $:{RENDER("common/detail_tag_form.html", [query['submitid'], "submit", query['removable_tags']])}
-    </div>
+    $:{RENDER("common/detail_tag_form.html", [query['submitid'], "submit", query, myself])}
 
   </div>
 

--- a/weasyl/templates/message/notifications.html
+++ b/weasyl/templates/message/notifications.html
@@ -155,8 +155,7 @@ $:{RENDER("common/stage_title.html", ["Notifications", "Messages", 0])}
               $:{item_user} favorited your journal titled $:{item_link}.
             $elif i['type'] == 3140:
               $# tag update
-              <a href="/submission/tag-history/${i['submitid']}">The tags were changed</a>
-              on your submission $:{item_link}.
+              Tags were suggested on your submission $:{item_link}.
             $elif i['type'] == 3150:
               <a href="/site-updates/${i['updateid']}">${i['title']}</a>
             $elif i['type'] == 4010:

--- a/weasyl/test/searchtag/test_associate.py
+++ b/weasyl/test/searchtag/test_associate.py
@@ -1,10 +1,10 @@
 import pytest
 
 from libweasyl import staff
-from libweasyl.models.helpers import CharSettings
 
 from weasyl import profile, searchtag
 from weasyl.error import WeasylError
+from weasyl.searchtag import GroupedTags
 from weasyl.test import db_utils
 
 # Tag sets for testing
@@ -16,17 +16,23 @@ tags_two = searchtag.parse_tags("omega_ruby, alpha_sapphire, diamond")
 def test_TargetRecordMissing_WeasylError_if_item_record_missing_or_invalid():
     userid_tag_adder = db_utils.create_user()
 
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, submitid=666)
-    assert err.value.value == "TargetRecordMissing"
+    targets = [
+        f(666)
+        for f in (
+            searchtag.SubmissionTarget,
+            searchtag.CharacterTarget,
+            searchtag.JournalTarget,
+        )
+    ]
 
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, charid=666)
-    assert err.value.value == "TargetRecordMissing"
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, journalid=666)
-    assert err.value.value == "TargetRecordMissing"
+    for target in targets:
+        with pytest.raises(WeasylError) as err:
+            searchtag.associate(
+                userid=userid_tag_adder,
+                target=target,
+                tag_names=tags,
+            )
+        assert err.value.value == "TargetRecordMissing"
 
 
 @pytest.mark.usefixtures('db')
@@ -39,18 +45,20 @@ def test_InsufficientPermissions_WeasylError_if_user_does_not_have_tagging_permi
     charid = db_utils.create_character(userid_owner)
     submitid = db_utils.create_submission(userid_owner)
     profile.do_manage(admin, userid_tag_adder, permission_tag=False)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
 
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    assert err.value.value == "InsufficientPermissions"
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, charid=charid)
-    assert err.value.value == "InsufficientPermissions"
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-    assert err.value.value == "InsufficientPermissions"
+    for target in targets:
+        with pytest.raises(WeasylError) as err:
+            searchtag.associate(
+                userid=userid_tag_adder,
+                target=target,
+                tag_names=tags,
+            )
+        assert err.value.value == "InsufficientPermissions"
 
 
 @pytest.mark.usefixtures('db')
@@ -62,18 +70,20 @@ def test_contentOwnerIgnoredYou_WeasylError_if_user_ignored_by_item_owner():
     charid = db_utils.create_character(userid_owner)
     submitid = db_utils.create_submission(userid_owner)
     db_utils.create_ignoreuser(userid_owner, userid_tag_adder)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
 
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    assert err.value.value == "contentOwnerIgnoredYou"
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, charid=charid)
-    assert err.value.value == "contentOwnerIgnoredYou"
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-    assert err.value.value == "contentOwnerIgnoredYou"
+    for target in targets:
+        with pytest.raises(WeasylError) as err:
+            searchtag.associate(
+                userid=userid_tag_adder,
+                target=target,
+                tag_names=tags,
+            )
+        assert err.value.value == "contentOwnerIgnoredYou"
 
 
 @pytest.mark.usefixtures('db')
@@ -83,19 +93,19 @@ def test_adding_tags_when_no_tags_previously_existed():
     journalid = db_utils.create_journal(userid_owner)
     charid = db_utils.create_character(userid_owner)
     submitid = db_utils.create_submission(userid_owner)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
 
-    searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    searchtag.associate(userid_tag_adder, tags, charid=charid)
-    searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-
-    submission_tags = searchtag.select(submitid=submitid)
-    assert tags == set(submission_tags)
-
-    character_tags = searchtag.select(charid=charid)
-    assert tags == set(character_tags)
-
-    journal_tags = searchtag.select(journalid=journalid)
-    assert tags == set(journal_tags)
+        assert set(searchtag.select_grouped(userid_owner, target).suggested) == tags
 
 
 @pytest.mark.usefixtures('db')
@@ -105,23 +115,27 @@ def test_removing_tags():
     journalid = db_utils.create_journal(userid_owner)
     charid = db_utils.create_character(userid_owner)
     submitid = db_utils.create_submission(userid_owner)
-    searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    searchtag.associate(userid_tag_adder, tags, charid=charid)
-    searchtag.associate(userid_tag_adder, tags, journalid=journalid)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
 
     # Remove the 'pearl' tag
-    searchtag.associate(userid_tag_adder, tags_two, submitid=submitid)
-    searchtag.associate(userid_tag_adder, tags_two, charid=charid)
-    searchtag.associate(userid_tag_adder, tags_two, journalid=journalid)
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags_two,
+        )
 
-    submission_tags = searchtag.select(submitid=submitid)
-    assert tags_two == set(submission_tags)
-
-    character_tags = searchtag.select(charid=charid)
-    assert tags_two == set(character_tags)
-
-    journal_tags = searchtag.select(journalid=journalid)
-    assert tags_two == set(journal_tags)
+        assert set(searchtag.select_grouped(userid_owner, target).suggested) == tags_two
 
 
 @pytest.mark.usefixtures('db')
@@ -131,24 +145,31 @@ def test_clearing_all_tags():
     journalid = db_utils.create_journal(userid_owner)
     charid = db_utils.create_character(userid_owner)
     submitid = db_utils.create_submission(userid_owner)
-    searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    searchtag.associate(userid_tag_adder, tags, charid=charid)
-    searchtag.associate(userid_tag_adder, tags, journalid=journalid)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
 
     # Clear all tags now that they were initially set
-    empty_tags = set()
-    searchtag.associate(userid_tag_adder, empty_tags, submitid=submitid)
-    searchtag.associate(userid_tag_adder, empty_tags, charid=charid)
-    searchtag.associate(userid_tag_adder, empty_tags, journalid=journalid)
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=set(),
+        )
 
-    submitid_tags = searchtag.select(submitid=submitid)
-    assert submitid_tags == []
-
-    charid_tags = searchtag.select(charid=charid)
-    assert charid_tags == []
-
-    journalid_tags = searchtag.select(journalid=journalid)
-    assert journalid_tags == []
+        assert searchtag.select_grouped(userid_owner, target) == GroupedTags(
+            artist=[],
+            suggested=[],
+            own_suggested=[],
+        )
 
 
 @pytest.mark.usefixtures('db')
@@ -163,20 +184,20 @@ def test_attempt_setting_tags_when_some_tags_have_been_restricted():
     submitid = db_utils.create_submission(userid_owner)
     restricted_tag = searchtag.parse_restricted_tags("pearl")
     searchtag.edit_user_tag_restrictions(userid_owner, restricted_tag)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
 
-    searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    searchtag.associate(userid_tag_adder, tags, charid=charid)
-    searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-
-    # Verify that the "pearl" tag was not added
-    submission_tags = searchtag.select(submitid=submitid)
-    assert tags_two == set(submission_tags)
-
-    character_tags = searchtag.select(charid=charid)
-    assert tags_two == set(character_tags)
-
-    journal_tags = searchtag.select(journalid=journalid)
-    assert tags_two == set(journal_tags)
+        # Verify that the "pearl" tag was not added
+        assert set(searchtag.select_grouped(userid_owner, target).suggested) == tags_two
 
 
 @pytest.mark.usefixtures('db')
@@ -194,10 +215,17 @@ def test_moderators_and_above_can_add_restricted_tags_successfully(monkeypatch):
     submitid = db_utils.create_submission(userid_owner)
     restricted_tag = searchtag.parse_restricted_tags("pearl")
     searchtag.edit_user_tag_restrictions(userid_owner, restricted_tag)
-
-    searchtag.associate(mod_tag_adder, tags, submitid=submitid)
-    searchtag.associate(mod_tag_adder, tags, charid=charid)
-    searchtag.associate(mod_tag_adder, tags, journalid=journalid)
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        searchtag.associate(
+            userid=mod_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
 
     # Verify that all tags were added successfully. 'pearl' is restricted.
     submission_tags = searchtag.select(submitid=submitid)
@@ -213,90 +241,46 @@ def test_moderators_and_above_can_add_restricted_tags_successfully(monkeypatch):
 @pytest.mark.usefixtures('db')
 def test_associate_return_values():
     """
-    ``associate()`` returns a dict, of the following format:
-    return {"add_failure_restricted_tags": add_failure_restricted_tags,
-            "remove_failure_owner_set_tags": remove_failure_owner_set_tags}
-    /OR/ None
-
-    add_failure_restricted_tags is None if no tags failed to be added during the associate call,
-    when due to a tag being on the user or globally restricted tags list. Otherwise, it contains
-    a space-separated list of tags which failed to be added to the content item.
-
-    remove_failure_owner_set_tags is None if no tags failed to be removed during the associate call.
-    Otherwise, it contains the same space-separated list as above, however containing tags which the
-    content owner added and has opted to not permit others to remove.
-
-    If neither element of the dict is set, ``associate()`` returns None.
+    ``associate()`` returns a list of tags that were not added because of restrictions.
     """
-    config = CharSettings({'disallow-others-tag-removal'}, {}, {})
-    userid_owner = db_utils.create_user(config=config)
+    userid_owner = db_utils.create_user()
     userid_tag_adder = db_utils.create_user()
     submitid = db_utils.create_submission(userid_owner)
     journalid = db_utils.create_journal(userid_owner)
     charid = db_utils.create_character(userid_owner)
 
-    """ Test the None result (no failures), then manually clear the tags afterwards. """
-    result = searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    assert result is None
-    result = searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-    assert result is None
-    result = searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-    assert result is None
-    searchtag.associate(userid_tag_adder, set(), submitid=submitid)
-    searchtag.associate(userid_tag_adder, set(), journalid=journalid)
-    searchtag.associate(userid_tag_adder, set(), journalid=journalid)
+    """ Test the empty result (no failures), then manually clear the tags afterwards. """
+    targets = (
+        searchtag.SubmissionTarget(submitid),
+        searchtag.CharacterTarget(charid),
+        searchtag.JournalTarget(journalid),
+    )
+    for target in targets:
+        result = searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
+        assert result == []
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=set(),
+        )
 
-    """ Test the result:None variant (restricted tags added, no tags removed) """
+    """ Test restricted tags added. """
     restricted_tag = searchtag.parse_restricted_tags("pearl")
     searchtag.edit_user_tag_restrictions(userid_owner, restricted_tag)
-    result = searchtag.associate(userid_tag_adder, tags, submitid=submitid)
-    assert "pearl" in result["add_failure_restricted_tags"]
-    assert result["remove_failure_owner_set_tags"] is None
-    result = searchtag.associate(userid_tag_adder, tags, charid=charid)
-    assert "pearl" in result["add_failure_restricted_tags"]
-    assert result["remove_failure_owner_set_tags"] is None
-    result = searchtag.associate(userid_tag_adder, tags, journalid=journalid)
-    assert "pearl" in result["add_failure_restricted_tags"]
-    assert result["remove_failure_owner_set_tags"] is None
-    searchtag.associate(userid_owner, set(), submitid=submitid)
-    searchtag.associate(userid_owner, set(), charid=charid)
-    searchtag.associate(userid_owner, set(), journalid=journalid)
+    for target in targets:
+        result = searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=tags,
+        )
+        assert "pearl" in result
+        searchtag.associate(
+            userid=userid_tag_adder,
+            target=target,
+            tag_names=set(),
+        )
     searchtag.edit_user_tag_restrictions(userid_owner, set())
-
-    """Test the None:result variant (no restricted tags added, tag removal blocked)
-    - Submission items will return None in this case (different method of preventing tag removal)
-    - Character and journal items should return the None:result variant, as expected"""
-    searchtag.associate(userid_owner, tags, submitid=submitid)
-    searchtag.associate(userid_owner, tags, charid=charid)
-    searchtag.associate(userid_owner, tags, journalid=journalid)
-    result = searchtag.associate(userid_tag_adder, tags_two, submitid=submitid)
-    assert result is None
-    result = searchtag.associate(userid_tag_adder, tags_two, charid=charid)
-    assert result["add_failure_restricted_tags"] is None
-    assert "pearl" in result["remove_failure_owner_set_tags"]
-    result = searchtag.associate(userid_tag_adder, tags_two, journalid=journalid)
-    assert result["add_failure_restricted_tags"] is None
-    assert "pearl" in result["remove_failure_owner_set_tags"]
-    searchtag.associate(userid_owner, set(), submitid=submitid)
-    searchtag.associate(userid_owner, set(), charid=charid)
-    searchtag.associate(userid_owner, set(), journalid=journalid)
-
-    """Test the result:result variant (restricted tags added, tag removal blocked)
-    - Submission items will behave in the result:None variant
-    - Character/Journal items will behave in the result:result manner"""
-    restricted_tag = searchtag.parse_restricted_tags("profanity")
-    searchtag.edit_user_tag_restrictions(userid_owner, restricted_tag)
-    searchtag.associate(userid_owner, tags, submitid=submitid)
-    searchtag.associate(userid_owner, tags, charid=charid)
-    searchtag.associate(userid_owner, tags, journalid=journalid)
-    # Effect upon adding this set: Remove user-set tag "pearl"; add restricted tag "profanity"
-    tags_three = tags_two | {"profanity"}
-    result = searchtag.associate(userid_tag_adder, tags_three, submitid=submitid)
-    assert "profanity" in result["add_failure_restricted_tags"]
-    assert result["remove_failure_owner_set_tags"] is None
-    result = searchtag.associate(userid_tag_adder, tags_three, charid=charid)
-    assert "profanity" in result["add_failure_restricted_tags"]
-    assert "pearl" in result["remove_failure_owner_set_tags"]
-    result = searchtag.associate(userid_tag_adder, tags_three, journalid=journalid)
-    assert "profanity" in result["add_failure_restricted_tags"]
-    assert "pearl" in result["remove_failure_owner_set_tags"]

--- a/weasyl/test/test_marketplace.py
+++ b/weasyl/test/test_marketplace.py
@@ -62,12 +62,12 @@ def test_commish_search(args, result_order):
 
     # user open for commissions, with blacklisted tags
     u4 = create_commish_searchable_user("u4", submittime=arrow.utcnow() - datetime.timedelta(days=2))
-    searchtag.associate(u4, optout_tags_userid=u4, tags={'cat'})
+    searchtag.set_commission_optout_tags(userid=u4, tag_names={'cat'})
 
     # user with a different commish class and a preference tag
     u5 = create_commish_searchable_user("u5", commishclass="sketch",
                                         submittime=arrow.utcnow() - datetime.timedelta(days=3))
-    searchtag.associate(u5, preferred_tags_userid=u5, tags={'cat'})
+    searchtag.set_commission_preferred_tags(userid=u5, tag_names={'cat'})
 
     # user with a different price
     create_commish_searchable_user("u6", minprice="100.0", maxprice="100.0",

--- a/weasyl/welcome.py
+++ b/weasyl/welcome.py
@@ -1,4 +1,3 @@
-import arrow
 import sqlalchemy as sa
 
 from libweasyl.models import content, site, users
@@ -469,24 +468,6 @@ def frienduseraccept_insert(userid, otherid):
 def frienduseraccept_remove(userid, otherid):
     d.execute("DELETE FROM welcome WHERE userid IN (%i, %i) AND otherid IN (%i, %i) AND type = 3085",
               [userid, otherid, userid, otherid])
-
-
-# notifications
-#   3140 tags updated
-
-def tag_update_insert(userid, submitid):
-    we = d.meta.tables['welcome']
-    db = d.connect()
-    q = sa.select([sa.exists(
-        sa.select([1])
-        .where(we.c.userid == userid)
-        .where(we.c.otherid == submitid)
-        .where(we.c.type == 3140))])
-    if db.scalar(q):
-        return
-    db.execute(
-        we.insert()
-        .values(userid=userid, otherid=submitid, unixtime=arrow.utcnow(), type=3140))
 
 
 # notifications


### PR DESCRIPTION
- stops showing "Modify" to people who aren't logged in
- removes public tagging history and notifications to encourage suggesting tags
- removes the option to suggest tag removal
- adds approve/reject with feedback options for suggested tags

Undo tokens might be a temporary measure while all content types gain history tables, or they might become permanent, in which case improved secret management (separate storage, key rotation with `MultiFernet`) can be implemented later.

A list of tags that have been rejected for being abusive isn’t exposed anywhere yet, but I’ll check for them manually while the project to redo the entire mod UI is in progress.

Migration should run before web servers are switched over.