### PR TITLE
Add OpenSearch description

### DIFF
--- a/assets/opensearch.xml
+++ b/assets/opensearch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>Weasyl</ShortName>
+    <Description>Search Weasyl</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image height="32" width="32" type="image/svg+xml">data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIj8+PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZlcnNpb249IjEuMSIgdmlld0JveD0iMCAwIDE2IDE2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Im01LjYzIDUuNmMtMS40My0yLjI2LTEuNDctMy44LTEuNDctMy44bC0xLjM3IDAuODMzcy0wLjA0MTQgMi4xNCAyLjA0IDMuNjJjLTYuNjUgMS4xOS02LjI3IDguMDIgMC4xNTcgNy43NSAwLjczNy0wLjAzMTctMC44MDYgMC45ODEgMS4yOSAwLjU4MiAzLjgtMC43MyA2LjItMi4wOCA4LjI1LTQuMyAwLjk0Ny0xLjAyLTAuNTIxLTAuNTg5IDAuMDc2NC0xLjM3IDUuNC03LjA3LTYuNDItMTEuMi04Ljk3LTMuMzF6IiBmaWxsPSIjOTcwMDAwIi8+PHBhdGggZD0ibTIuNTggNy41IDEuNzUtMC42NzMgMi44MiA0LjQ1IDAuMDUyMS02Ljg4IDEuMDctMC4zMzEgMy43NCA1LjgyIDAuMDM0Mi02Ljc3IDEuOTEtMC41NjMtMC4yNzkgNy42LTIuMzggMS44OC0yLjY2LTQuMTgtMC4wMTA5IDUuNDctMS45NCAwLjYyM3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4K</Image>
+    <Url type="text/html" template="https://www.weasyl.com/search">
+        <Param name="q" value="{searchTerms}" />
+    </Url>
+    <Url rel="self" type="application/opensearchdescription+xml" template="https://www.weasyl.com/opensearch.xml" />
+    <Contact>support@weasyl.dev</Contact>
+</OpenSearchDescription>

--- a/build.js
+++ b/build.js
@@ -70,6 +70,17 @@ const addFilenameSuffix = (relativePath, suffix) => {
     });
 };
 
+const copyUnversionedStaticFile = (relativePath, touch) => {
+    const inputPath = path.join(ASSETS, relativePath);
+    const outputFullPath = path.join(BUILD, relativePath);
+
+    return {
+        entries: [],
+        work: touch.then(() =>
+            fs.promises.copyFile(inputPath, outputFullPath)),
+    };
+};
+
 const copyStaticFile = (relativePath, touch) => {
     const inputPath = path.join(ASSETS, relativePath);
     const stream = fs.createReadStream(inputPath);
@@ -239,6 +250,7 @@ const main = async () => {
         esbuildFile('js/main.js', 'js/main.js', touch, PRIVATE_FIELDS_ESM),
         esbuildFile('js/tags-edit.js', 'js/tags-edit.js', touch, PRIVATE_FIELDS_ESM),
         copyStaticFiles('img/help', touch),
+        copyUnversionedStaticFile('opensearch.xml', touch),
         copyImages,
 
         // libraries

--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -69,6 +69,12 @@ http {
             return 307 https://cdn.weasyl.com/static/fonts/museo500.css;
         }
 
+        location = /opensearch.xml {
+            add_header Cache-Control "public, max-age=2592000, stale-while-revalidate=86400";
+            types {}
+            default_type application/opensearchdescription+xml;
+        }
+
         location /static/media/ {
             root /weasyl;
             try_files $uri @missing;

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -44,6 +44,8 @@ $def with (query, options, extended_options={})
 
   <script type="module" src="${resource_path('js/main.js')}" async></script>
 
+  <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml">
+
 </head>
 
 <body>


### PR DESCRIPTION
Allows Weasyl search to be added to browsers.

- The icon is assets/img/favicon.svg. Its size as declared in opensearch.xml is 32x32 because current Firefox seems to render it at the declared size, *then* scale, even though it’s an SVG.

- The resource doesn’t have a hash suffix because it needs to self-update.