### PR TITLE
bug: wzl: correct invocation of docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 Requirements:
 
 - [Docker][docker]
-- [docker-compose][] (included with Docker on Windows and macOS)
+- [docker compose][] (included with Docker on Windows and macOS)
 
 
 [docker]: https://docs.docker.com/get-docker/
-[docker-compose]: https://docs.docker.com/compose/install/
+[docker compose]: https://docs.docker.com/compose/install/
 
 
 ### Get the sample database

--- a/wzl
+++ b/wzl
@@ -4,8 +4,16 @@ set -eu
 export DOCKER_BUILDKIT=1
 export WEASYL_VERSION="$(git rev-parse --short HEAD)"
 
+{ # Try -- Current versions of Docker have compose as a plugin to docker
+docker compose version
+WZL_DOCKER_COMPOSE_EXECUTABLE="docker compose"
+} || { # Catch -- At some point the old v1 docker-compose might break with future changes;
+       # until that point, left in for now for backwards compatibility
+WZL_DOCKER_COMPOSE_EXECUTABLE="docker-compose"
+}
+
 if test $# -eq 0; then
-    exec docker-compose
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE
 fi
 
 head="$1"
@@ -16,26 +24,26 @@ check_nobuild() {
         return 0
     fi
 
-    docker-compose build "$1" || exit $?
+    $WZL_DOCKER_COMPOSE_EXECUTABLE build "$1" || exit $?
     return 1
 }
 
 case "$head" in
 
 assets)
-    docker-compose create "$@" build-assets
-    docker-compose cp ./assets build-assets:/weasyl-build/
-    container_id="$(docker-compose ps -a --format=json build-assets | grep -o '"ID":"[^"]*"' | cut -d '"' -f 4)"
+    $WZL_DOCKER_COMPOSE_EXECUTABLE create "$@" build-assets
+    $WZL_DOCKER_COMPOSE_EXECUTABLE cp ./assets build-assets:/weasyl-build/
+    container_id="$($WZL_DOCKER_COMPOSE_EXECUTABLE ps -a --format=json build-assets | grep -o '"ID":"[^"]*"' | cut -d '"' -f 4)"
     exec docker start -ai "$container_id"
     ;;
 
 check)
     if check_nobuild flake8 "${1:-}"; then shift; fi
-    exec docker-compose run --rm -T flake8 "$@"
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE run --rm -T flake8 "$@"
     ;;
 
 configure)
-    c='docker-compose run --rm -T configure'
+    c="$WZL_DOCKER_COMPOSE_EXECUTABLE run --rm -T configure"
     set -x
     $c "$@" alembic.ini < libweasyl/alembic/alembic.ini.example
     $c "$@" site.config.txt < config/site.config.txt.example
@@ -45,17 +53,17 @@ configure)
 
 migrate)
     if check_nobuild migrate "${1:-}"; then shift; fi
-    exec docker-compose run --rm -T migrate "$@"
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE run --rm -T migrate "$@"
     ;;
 
 revision)
     if check_nobuild revision "${1:-}"; then shift; fi
-    exec docker-compose run --rm -T revision "$@" | tar x libweasyl/alembic/versions
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE run --rm -T revision "$@" | tar x libweasyl/alembic/versions
     ;;
 
 test)
     if check_nobuild test "${1:-}"; then shift; fi
-    exec docker-compose run --rm test "$@"
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE run --rm test "$@"
     ;;
 
 test-coverage)
@@ -70,7 +78,7 @@ test-coverage)
         '
     fi
 
-    exec docker-compose run --rm test "$@"
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE run --rm test "$@"
     ;;
 
 poetry)
@@ -106,6 +114,6 @@ push-templates)
     ;;
 
 *)
-    exec docker-compose "$head" "$@"
+    exec $WZL_DOCKER_COMPOSE_EXECUTABLE "$head" "$@"
 
 esac


### PR DESCRIPTION
Docker changed to have docker compose as a plugin, and the command docker-compose no longer is default; a backwards-compatible check was created to allow older versions to still execute the script correctly (for the moment, at least).

Raised as an issue at: https://github.com/Weasyl/weasyl/pull/1372#issuecomment-1627634230