### PR TITLE
Separate out (more) CSS specific to signup, help, and moderation pages

### DIFF
--- a/assets/scss/components/_date-picker.scss
+++ b/assets/scss/components/_date-picker.scss
@@ -1,0 +1,10 @@
+.form-date-day, .form-date-year {
+    width: 25%;
+    float: left;
+}
+
+.form-date-month {
+    width: 46%;
+    float: left;
+    padding: 0 2%;
+}

--- a/assets/scss/help.scss
+++ b/assets/scss/help.scss
@@ -31,3 +31,79 @@ kbd, samp {
     font-family: inherit;
     font-weight: bold;
 }
+
+.help-examples table {
+    margin-bottom: 1em;
+}
+
+.help-examples th {
+    font-weight: normal;
+    text-align: left;
+}
+
+.help-examples th,
+.help-examples td {
+    border: 0.1em solid #bbb;
+    padding: 0.4em;
+    vertical-align: top;
+}
+
+.help-examples > h4 {
+    padding-top: 0.6em;
+    padding-bottom: 0.2em;
+}
+
+#comm-guidelines {
+    padding-top: 2em;
+}
+
+#comm-guidelines ul li, #comm-guidelines ol li {
+    padding-bottom: 1.5em;
+}
+
+#comm-guidelines ul ol, #comm-guidelines ul ol li:last-child, #comm-guidelines ol ul, #comm-guidelines ol ul li:last-child {
+    padding-bottom: 0;
+}
+
+.donator-list {
+    column-count: 2;
+    column-gap: 2em;
+    padding: 2em 0;
+    font-size: 1.15em;
+}
+
+.donator-list > li {
+    line-height: 1;
+    overflow-wrap: break-word;
+    padding: 0.25em 0.5em 0.75em 0;
+}
+
+@media (min-width: 45em) {
+    .donator-list {
+        column-count: 4;
+    }
+}
+
+@media (min-width: 55em) {
+    .donator-list {
+        column-count: 5;
+    }
+}
+
+@media (min-width: 65em) {
+    .donator-list {
+        column-count: 6;
+    }
+}
+
+@media (min-width: 72em) {
+    .donator-list {
+        column-count: 7;
+    }
+}
+
+@media (min-width: 80em) {
+    .donator-list {
+        column-count: 8;
+    }
+}

--- a/assets/scss/mod.scss
+++ b/assets/scss/mod.scss
@@ -1,0 +1,134 @@
+@import 'components/date-picker';
+
+.report-status-review {
+    color: #e0a000;
+}
+
+.report-status-open {
+    color: #f00000;
+}
+
+#reports_content {
+    padding-top: 2em;
+}
+
+.reports th {
+    text-align: left;
+}
+
+.reports-column-direct-link {
+    // This column has a fixed set of possible cell values, the widest of which is "View submission".
+    width: 10em;
+}
+
+.reports-column-reporters {
+    // This column is just a number, usually a single digit; it only needs enough room for the header.
+    width: 6em;
+}
+
+#reports_buttons {
+    padding: 2em 0;
+}
+
+.warning {
+    background-color: #f50;
+    color: white;
+    font-weight: bold;
+    margin-bottom: 1em;
+    padding: 1em;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+.warning ul {
+    list-style-type: disc;
+    margin-top: 0.5em;
+    padding-left: 1.8em;
+}
+
+.content-by-user-page {
+    padding-top: 20px;
+}
+
+.content-by-user {
+    width: 100%;
+    table-layout: fixed;
+}
+.content-by-user td {
+    vertical-align: middle;
+}
+
+.content-by-user .checkbox-cell {
+    width: 8%;
+}
+.content-by-user .thumb-cell {
+    width: 30%;
+}
+.content-by-user .title-cell {
+    width: 20%;
+}
+.content-by-user .rating-cell {
+    width: 15%;
+}
+.content-by-user .time-cell {
+    width: 20%;
+}
+.content-by-user .visibility-cell {
+    width: 10%;
+}
+
+/* needed for absolute positioning in firefox */
+.content-by-user .checkbox-cell-wrapper {
+    height: 180px;
+    position: relative;
+}
+.content-by-user label {
+    display: block;
+    width: 1250%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+}
+.content-by-user input[type=checkbox] {
+    position: absolute;
+    left: 0.5em;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 2;
+}
+
+/* h4x */
+.content-by-user .thumb, .content-by-user .journal-thumb, .content-by-user .title, .content-by-user .rating, .content-by-user .time, .content-by-user .visibility {
+    position: relative;
+    z-index: 3;
+}
+.content-by-user .thumb {
+    display: block;
+    margin: auto;
+    max-width: 100%;
+    max-height: 160px;
+}
+.content-by-user .title {
+    display: inline-block;
+    max-width: 100%;
+    padding: 0 10px;
+}
+.content-by-user .rating {
+    border-style: solid;
+    border-bottom-width: 3px;
+}
+
+.content-by-user-actions {
+    padding: 2em 0;
+}
+
+@media (min-width: 45em) {
+    .content-by-user-moderate {
+        float: right;
+    }
+}
+
+#tag-history th {
+    text-align: left;
+}

--- a/assets/scss/signup.scss
+++ b/assets/scss/signup.scss
@@ -1,0 +1,7 @@
+@import 'components/date-picker';
+@import 'components/password-meter';
+
+#signup-terms {
+    clear: both;
+    padding-top: 1.75em;
+}

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1,5 +1,4 @@
 @import 'reset';
-@import 'components/password-meter';
 @import 'components/option';
 @import 'components/text-post-list';
 @import 'pages/marketplace';
@@ -1726,22 +1725,6 @@ $tag-reject-deemphasize-size: 11px;
 
 #login-sfw input {
     margin: 0;
-}
-
-.form-date-day, .form-date-year {
-    width: 25%;
-    float: left;
-}
-
-.form-date-month {
-    width: 46%;
-    float: left;
-    padding: 0 2%;
-}
-
-#signup-terms {
-    clear: both;
-    padding-top: 1.75em;
 }
 
 @media (min-width: 34em) {
@@ -3924,93 +3907,6 @@ img + #detail-art-text {
 }
 
 
-/* ------------------------------------ =moderation -- */
-
-.content-by-user-page {
-    padding-top: 20px;
-}
-
-.content-by-user {
-    width: 100%;
-    table-layout: fixed;
-}
-.content-by-user td {
-    vertical-align: middle;
-}
-
-.content-by-user .checkbox-cell {
-    width: 8%;
-}
-.content-by-user .thumb-cell {
-    width: 30%;
-}
-.content-by-user .title-cell {
-    width: 20%;
-}
-.content-by-user .rating-cell {
-    width: 15%;
-}
-.content-by-user .time-cell {
-    width: 20%;
-}
-.content-by-user .visibility-cell {
-    width: 10%;
-}
-
-/* needed for absolute positioning in firefox */
-.content-by-user .checkbox-cell-wrapper {
-    height: 180px;
-    position: relative;
-}
-.content-by-user label {
-    display: block;
-    width: 1250%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    z-index: 1;
-}
-.content-by-user input[type=checkbox] {
-    position: absolute;
-    left: 0.5em;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 2;
-}
-
-/* h4x */
-.content-by-user .thumb, .content-by-user .journal-thumb, .content-by-user .title, .content-by-user .rating, .content-by-user .time, .content-by-user .visibility {
-    position: relative;
-    z-index: 3;
-}
-.content-by-user .thumb {
-    display: block;
-    margin: auto;
-    max-width: 100%;
-    max-height: 160px;
-}
-.content-by-user .title {
-    display: inline-block;
-    max-width: 100%;
-    padding: 0 10px;
-}
-.content-by-user .rating {
-    border-style: solid;
-    border-bottom-width: 3px;
-}
-
-.content-by-user-actions {
-    padding: 2em 0;
-}
-
-@media (min-width: 45em) {
-    .content-by-user-moderate {
-        float: right;
-    }
-}
-
-
 /* ------------------------------------ =misc -- */
 
 #journals-content {
@@ -4068,84 +3964,6 @@ img + #detail-art-text {
 #notes-content .buttons {
     padding-top: 1em;
 }
-
-#comm-guidelines {
-    padding-top: 2em;
-}
-
-#comm-guidelines ul li, #comm-guidelines ol li {
-    padding-bottom: 1.5em;
-}
-
-#comm-guidelines ul ol, #comm-guidelines ul ol li:last-child, #comm-guidelines ol ul, #comm-guidelines ol ul li:last-child {
-    padding-bottom: 0;
-}
-
-.help-examples table {
-    margin-bottom: 1em;
-}
-
-.help-examples th {
-    font-weight: normal;
-    text-align: left;
-}
-
-.help-examples th,
-.help-examples td {
-    border: 0.1em solid #bbb;
-    padding: 0.4em;
-    vertical-align: top;
-}
-
-.help-examples > h4 {
-    padding-top: 0.6em;
-    padding-bottom: 0.2em;
-}
-
-.donator-list {
-    column-count: 2;
-    column-gap: 2em;
-    padding: 2em 0;
-    font-size: 1.15em;
-}
-
-.donator-list > li {
-    line-height: 1;
-    overflow-wrap: break-word;
-    padding: 0.25em 0.5em 0.75em 0;
-}
-
-@media (min-width: 45em) {
-    .donator-list {
-        column-count: 4;
-    }
-}
-
-@media (min-width: 55em) {
-    .donator-list {
-        column-count: 5;
-    }
-}
-
-@media (min-width: 65em) {
-    .donator-list {
-        column-count: 6;
-    }
-}
-
-@media (min-width: 72em) {
-    .donator-list {
-        column-count: 7;
-    }
-}
-
-@media (min-width: 80em) {
-    .donator-list {
-        column-count: 8;
-    }
-}
-
-.right { text-align: right; }
 
 /* ------------------------------------ =footer -- */
 
@@ -4402,36 +4220,6 @@ body input[type="checkbox"] {
     top: -1px;
 }
 
-/* ---------------------------------------------- reports -- */
-/*
-templates/modcontrol/reports.html
-*/
-
-#reports_content {
-    padding-top: 2em;
-}
-
-#reports_buttons {
-    padding: 2em 0;
-}
-
-/* General
---------------------------------*/
-.warning {
-    background-color: #f50;
-    color: white;
-    font-weight: bold;
-    margin-bottom: 1em;
-    padding: 1em;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-}
-
-.warning ul {
-    list-style-type: disc;
-    margin-top: 0.5em;
-    padding-left: 1.8em;
-}
-
 /* Form
 --------------------------------*/
 .link-button {
@@ -4533,10 +4321,6 @@ a.user-icon:hover > span, a.user-icon:focus > span {
     margin: 1em 0;
     color: #ad322d;
     font-style: italic;
-}
-
-#tag-history th {
-    text-align: left;
 }
 
 .hidden-comment {

--- a/build.js
+++ b/build.js
@@ -282,6 +282,8 @@ const main = async () => {
         sasscFile('scss/site.scss', 'css/site.css', touch, copyImages),
         sasscFile('scss/help.scss', 'css/help.css', touch, copyImages),
         sasscFile('scss/imageselect.scss', 'css/imageselect.css', touch, copyImages),
+        sasscFile('scss/mod.scss', 'css/mod.css', touch, copyImages),
+        sasscFile('scss/signup.scss', 'css/signup.css', touch, copyImages),
         esbuildFile('js/scripts.js', 'js/scripts.js', touch, {}),
         esbuildFile('js/main.js', 'js/main.js', touch, PRIVATE_FIELDS_ESM),
         esbuildFile('js/tags-edit.js', 'js/tags-edit.js', touch, PRIVATE_FIELDS_ESM),

--- a/weasyl/controllers/info.py
+++ b/weasyl/controllers/info.py
@@ -6,6 +6,13 @@ from weasyl.controllers.decorators import login_required
 from weasyl import define, profile, report
 
 
+def _help_page(template, *, title):
+    def respond(request):
+        return Response(define.webpage(request.userid, template, options=("help",), title=title))
+
+    return respond
+
+
 # Policy functions
 
 def staff_(request):
@@ -29,84 +36,26 @@ def staff_(request):
                                    title="Staff"))
 
 
-def thanks_(request):
-    return Response(define.webpage(request.userid, "help/thanks.html",
-                                   title="Awesome People"))
+thanks_ = _help_page("help/thanks.html", title="Awesome People")
 
+policy_community_ = _help_page("help/community.html", title="Community Guidelines")
+policy_copyright_ = _help_page("help/copyright.html", title="Copyright Policy")
+policy_privacy_ = _help_page("help/privacy.html", title="Privacy Policy")
+policy_scoc_ = _help_page("help/scoc.html", title="Staff Code of Conduct")
+policy_tos_ = _help_page("help/tos.html", title="Terms of Service")
 
-def policy_community_(request):
-    return Response(define.webpage(request.userid, "help/community.html",
-                                   title="Community Guidelines"))
-
-
-def policy_copyright_(request):
-    return Response(define.webpage(request.userid, "help/copyright.html",
-                                   title="Copyright Policy"))
-
-
-def policy_privacy_(request):
-    return Response(define.webpage(request.userid, "help/privacy.html",
-                                   title="Privacy Policy"))
-
-
-def policy_scoc_(request):
-    return Response(define.webpage(request.userid, "help/scoc.html",
-                                   title="Staff Code of Conduct"))
-
-
-def policy_tos_(request):
-    return Response(define.webpage(request.userid, "help/tos.html",
-                                   title="Terms of Service"))
-
-
-# Help functions
-def help_(request):
-    return Response(define.webpage(request.userid, "help/help.html",
-                                   title="Help Topics"))
-
-
-def help_about_(request):
-    return Response(define.webpage(request.userid, "help/about.html",
-                                   title="About Weasyl"))
-
-
-def help_collections_(request):
-    return Response(define.webpage(request.userid, "help/collections.html",
-                                   options=("help",),
-                                   title="Collections"))
-
-
-def help_faq_(request):
-    return Response(define.webpage(request.userid, "help/faq.html",
-                                   title="FAQ"))
-
-
-def help_folders_(request):
-    return Response(define.webpage(request.userid, "help/folder-options.html",
-                                   options=("help",),
-                                   title="Folder Options"))
-
-
-def help_gdocs_(request):
-    return Response(define.webpage(request.userid, "help/gdocs.html",
-                                   options=("help",),
-                                   title="Google Docs Embedding"))
-
-
-def help_markdown_(request):
-    return Response(define.webpage(request.userid, "help/markdown.html",
-                                   title="Markdown"))
-
-
-def help_marketplace_(request):
-    return Response(define.webpage(request.userid, "help/marketplace.html",
-                                   options=("help",),
-                                   title="Marketplace"))
-
-
-def help_ratings_(request):
-    return Response(define.webpage(request.userid, "help/ratings.html",
-                                   title="Content Ratings"))
+help_ = _help_page("help/help.html", title="Help Topics")
+help_about_ = _help_page("help/about.html", title="About Weasyl")
+help_collections_ = _help_page("help/collections.html", title="Collections")
+help_faq_ = _help_page("help/faq.html", title="FAQ")
+help_folders_ = _help_page("help/folder-options.html", title="Folder Options")
+help_gdocs_ = _help_page("help/gdocs.html", title="Google Docs Embedding")
+help_markdown_ = _help_page("help/markdown.html", title="Markdown")
+help_marketplace_ = _help_page("help/marketplace.html", title="Marketplace")
+help_ratings_ = _help_page("help/ratings.html", title="Content Ratings")
+help_searching_ = _help_page("help/searching.html", title="Searching")
+help_tagging_ = _help_page("help/tagging.html", title="Tagging")
+help_two_factor_authentication_ = _help_page("help/two_factor_authentication.html", title="Two-Factor Authentication")
 
 
 @login_required
@@ -114,23 +63,6 @@ def help_reports_(request):
     return Response(define.webpage(request.userid, "help/reports.html", [
         report.select_reported_list(request.userid),
     ], title="My Reports"))
-
-
-def help_searching_(request):
-    return Response(define.webpage(request.userid, "help/searching.html",
-                                   title="Searching"))
-
-
-def help_tagging_(request):
-    return Response(define.webpage(request.userid, "help/tagging.html",
-                                   options=("help",),
-                                   title="Tagging"))
-
-
-def help_two_factor_authentication_(request):
-    return Response(define.webpage(request.userid, "help/two_factor_authentication.html",
-                                   options=("help",),
-                                   title="Two-Factor Authentication"))
 
 
 def help_verification_(request):

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -17,7 +17,9 @@ def modcontrol_(request):
 @moderator_only
 def modcontrol_suspenduser_get_(request):
     return Response(define.webpage(request.userid, "modcontrol/suspenduser.html",
-                                   (moderation.BAN_TEMPLATES,), title="User Suspensions"))
+                                   (moderation.BAN_TEMPLATES,),
+                                   options=("mod",),
+                                   title="User Suspensions"))
 
 
 @moderator_only
@@ -39,7 +41,7 @@ def modcontrol_report_(request):
         request.userid,
         r,
         blacklisted_tags,
-    ], title="View Reported " + r.target_type.title()))
+    ], options=("mod",), title="View Reported " + r.target_type.title()))
 
 
 @moderator_only
@@ -51,7 +53,7 @@ def modcontrol_reports_(request):
         # Reports
         report.select_list(request.userid, form),
         macro.MACRO_REPORT_VIOLATION,
-    ], title="Reported Content"))
+    ], options=("mod",), title="Reported Content"))
 
 
 @moderator_only
@@ -78,7 +80,7 @@ def modcontrol_contentbyuser_(request):
     return Response(define.webpage(request.userid, "modcontrol/contentbyuser.html", [
         form.name,
         sorted(submissions + characters + journals, key=lambda item: item['unixtime'], reverse=True),
-    ], title=form.name + "'s Content"))
+    ], options=("mod",), title=form.name + "'s Content"))
 
 
 @moderator_only

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -278,6 +278,7 @@ def control_editemailpassword_get_(request):
         request.userid,
         "control/edit_emailpassword.html",
         (profile_info["email"], profile_info["username"]),
+        options=("signup",),
         title="Edit Password and Email Address"
     ))
 

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -179,7 +179,7 @@ def signout_(request):
 
 @guest_required
 def signup_get_(request):
-    return Response(define.webpage(request.userid, "etc/signup.html", (), title="Create a Weasyl Account"))
+    return Response(define.webpage(request.userid, "etc/signup.html", (), options=("signup",), title="Create a Weasyl Account"))
 
 
 @guest_required
@@ -251,7 +251,7 @@ def resetpassword_get_(request):
             "The e-mail address **%s** is not associated with a Weasyl account." % (reset_target.email,),
             [["Sign Up", "/signup"], ["Return to the Home Page", "/"]]))
 
-    return Response(define.webpage(request.userid, "etc/resetpassword.html", [token, reset_target], title="Reset Forgotten Password"))
+    return Response(define.webpage(request.userid, "etc/resetpassword.html", [token, reset_target], options=("signup",), title="Reset Forgotten Password"))
 
 
 @guest_required

--- a/weasyl/templates/admincontrol/admincontrol.html
+++ b/weasyl/templates/admincontrol/admincontrol.html
@@ -1,6 +1,6 @@
 $:{TITLE("Administrator Control Panel")}
 
-<div id="admincontrol_content" class="content" style="padding-top:2em;">
+<div class="content" style="padding-top:2em;">
   <div class="form skinny">
     <div style="font-size:1.3em;">
       <p><a href="/admincontrol/siteupdate">Submit Site Update</a></p><br />

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -30,6 +30,12 @@ $def with (query, options, extended_options={})
   $if "imageselect" in options:
     <link rel="stylesheet" href="${resource_path('css/imageselect.css')}" />
 
+  $if "mod" in options:
+    <link rel="stylesheet" href="${resource_path('css/mod.css')}" />
+
+  $if "signup" in options:
+    <link rel="stylesheet" href="${resource_path('css/signup.css')}" />
+
   $if 'twitter_card' in extended_options:
     <meta name="twitter:site" content="@weasyl" />
     $for k, v in extended_options['twitter_card'].items():

--- a/weasyl/templates/modcontrol/modcontrol.html
+++ b/weasyl/templates/modcontrol/modcontrol.html
@@ -1,6 +1,6 @@
 $:{RENDER("common/stage_title.html", ["Moderator Control Panel"])}
 
-<div id="modcontrol_content" class="content" style="padding-top:2em;">
+<div class="content" style="padding-top:2em;">
   <div class="form skinny">
     <p style="font-size:1.3em;"><a href="/modcontrol/suspenduser">User Suspensions</a></p>
     <br />

--- a/weasyl/templates/modcontrol/reports.html
+++ b/weasyl/templates/modcontrol/reports.html
@@ -1,9 +1,10 @@
 $def with (method, query, violations)
 $:{RENDER("common/stage_title.html", ["Reported Content", "Moderator Control Panel", "/modcontrol"])}
 $code:
-  _color_map = {
-    'review': ' style="color:#e0a000;"',
-    'open': ' style="color:#f00000;"',
+  _status_class = {
+    'open': 'report-status-open',
+    'review': 'report-status-review',
+    'closed': '',
   }
 
   _context_map = {
@@ -21,19 +22,32 @@ $code:
 
 <div id="reports_content" class="content">
   $if query:
-    <table>
-      <tr>
-        <td style="font-weight:bold;">Title</td>
-        <td style="font-weight:bold;">Direct Link</td>
-        <td style="font-weight:bold;">Content Owner</td>
-        <td style="font-weight:bold;">Violation(s)</td>
-        <td style="font-weight:bold;">Reporters</td>
-        <td style="font-weight:bold;">Opened On</td>
-        <td style="font-weight:bold;text-align:right;">Report Status</td>
-      </tr>
+    <table class="reports">
+      <colgroup>
+        <col>
+        <col class="reports-column-direct-link">
+        <col>
+        <col>
+        <col class="reports-column-reporters">
+        <col>
+        <col>
+      </colgroup>
 
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Direct Link</th>
+          <th>Content Owner</th>
+          <th>Violation(s)</th>
+          <th>Reporters</th>
+          <th>Opened On</th>
+          <th>Report Status</th>
+        </tr>
+      </thead>
+
+      <tbody>
       $for report, report_count, report_violations in query:
-        <tr$:{_color_map.get(report.status, '')}>
+        <tr class="${_status_class.get(report.status)}">
           <td><a href="/modcontrol/report?reportid=${report.reportid}">${report.target.title}</a></td>
           <td>
             <a href="${report.target.legacy_path(mod=True)}">
@@ -48,18 +62,19 @@ $code:
           <td>$:{LOCAL_TIME(report.opened_at, '{date} {time}')}</td>
           $ status = report.status
           $if status == 'review':
-            <td class="right">
+            <td>
               Under review by <a href="/~${report.owner.login_name}">${report.owner.profile.username}</a>
             </td>
           $elif status == 'closed':
-            <td class="right">
+            <td>
               Closed by <a href="/~${report.owner.login_name}">${report.owner.profile.username}</a>
               (${report.closure_reason.value.replace('-', ' ')}
               $:{LOCAL_TIME(report.closed_at, 'on {date} at {time}')})
             </td>
           $else:
-            <td class="right">Open</td>
+            <td>Open</td>
         </tr>
+      </tbody>
 
     </table>
   $else:


### PR DESCRIPTION
Makes the global stylesheet slightly lighter and the source slightly easier to navigate.

Does not move `components/option` to `mod`, because it should be used in more places.