### PR TITLE
Bring CodeQL GitHub Actions workflow more in line with defaults

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,14 +12,17 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     permissions:
+      actions: read
+      contents: read
       security-events: write
 
     strategy:
       fail-fast: false
       matrix:
         language:
-          - javascript
+          - javascript-typescript
           - python
 
     steps:


### PR DESCRIPTION
Newer defaults and not permissions I intentionally removed, I think?