### PR TITLE
Add post counts to user tabs

### DIFF
--- a/assets/scss/components/_user-tabs.scss
+++ b/assets/scss/components/_user-tabs.scss
@@ -1,0 +1,85 @@
+#user-nav > li {
+    width: 50%;
+    float: left;
+}
+
+#user-nav > li > a {
+    display: block;
+    padding: 0.5em 0;
+    font-size: 14px;
+    font-size: 0.9rem;
+}
+
+.user-nav-with-count {
+    position: relative;
+}
+
+.user-nav-with-count:hover {
+    text-decoration: none;
+}
+
+.user-nav-with-count:hover > .user-nav-label {
+    text-decoration: underline;
+}
+
+$count-selected-background: #006080;
+
+.user-nav-count {
+    background-color: #2a2e2f;
+    border-radius: 4px;
+    color: #999;
+    line-height: 1;
+    margin-left: 6px;
+    margin-top: calc(-0.5em - 4px);
+    padding: 4px 6px;
+    text-decoration: none;
+    top: 50%;
+
+    .current > & {
+        background-color: $count-selected-background;
+        color: scale-color($count-selected-background, $lightness: 75%);
+    }
+}
+
+@media (min-width: 45em) {
+    #user-nav > li {
+        width: 25%;
+    }
+}
+
+@media (min-width: 52em) {
+    #user-nav > li {
+        width: auto;
+        float: left;
+    }
+
+    #user-nav > * + li {
+        padding-left: 2.5em;
+    }
+
+    #user-nav > li > a {
+        padding: 0;
+        height: 48px;
+        height: 3rem;
+        line-height: 48px;
+        line-height: 3rem;
+    }
+}
+
+@media (min-width: 94em) {
+    #user-nav > li {
+        width: 14.28%;
+    }
+
+    #user-nav > * + li {
+        padding-left: 0;
+    }
+
+    #user-nav > li > a {
+        text-align: center;
+    }
+
+    .user-nav-count {
+        position: absolute;
+    }
+}

--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1,6 +1,7 @@
 @import 'reset';
 @import 'components/option';
 @import 'components/text-post-list';
+@import 'components/user-tabs';
 @import 'pages/marketplace';
 
 /* Basic styles
@@ -2545,18 +2546,6 @@ $notifs-color-active: #b9b9b9;
     padding-top: 1rem;
 }
 
-#user-nav li {
-    width: 50%;
-    float: left;
-}
-
-#user-nav li a {
-    display: block;
-    padding: 0.5em 0;
-    font-size: 14px;
-    font-size: 0.9rem;
-}
-
 #uf-image {
     text-align: center;
 }
@@ -2662,10 +2651,6 @@ $notifs-color-active: #b9b9b9;
         padding-top: 4px;
         padding-top: 0.25rem;
         margin-left: 64px;
-    }
-
-    #user-nav li {
-        width: 25%;
     }
 
     #user-stats dl {
@@ -2853,25 +2838,6 @@ $notifs-color-active: #b9b9b9;
     }
 }
 
-@media (min-width: 48em) {
-    #user-nav li {
-        width: auto;
-        float: left;
-    }
-
-    #user-nav li + li {
-        padding-left: 2.5em;
-    }
-
-    #user-nav li a {
-        padding: 0;
-        height: 48px;
-        height: 3rem;
-        line-height: 48px;
-        line-height: 3rem;
-    }
-}
-
 @media (min-width: 53em) {
     #user-info .avatar {
         left: 32px;
@@ -2881,18 +2847,6 @@ $notifs-color-active: #b9b9b9;
     #user-actions .stream-status {
         right: 32px;
         right: 2rem;
-    }
-
-    #user-nav li {
-        width: 14.28%;
-    }
-
-    #user-nav li + li {
-        padding-left: 0;
-    }
-
-    #user-nav li a {
-        text-align: center;
     }
 }
 

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -135,6 +135,7 @@ def create(userid, character, friends, tags, thumbfile, submitfile):
     files.clear_temporary(userid)
 
     define.metric('increment', 'characters')
+    define.cached_posts_count.invalidate(userid)
 
     return charid
 
@@ -396,6 +397,8 @@ def edit(userid, character, friends_only):
             userid, query.userid, 'The following character was edited:',
             '- ' + text.markdown_link(character.char_name, '/character/%s?anyway=true' % (character.charid,)))
 
+    define.cached_posts_count.invalidate(query.userid)
+
 
 def remove(userid, charid):
     ownerid = define.get_ownerid(charid=charid)
@@ -410,6 +413,7 @@ def remove(userid, charid):
 
     if result.rowcount != 0:
         welcome.character_remove(charid)
+        define.cached_posts_count.invalidate(ownerid)
 
     return ownerid
 

--- a/weasyl/collection.py
+++ b/weasyl/collection.py
@@ -224,6 +224,7 @@ def pending_accept(userid, submissions):
         welcome.collectrequest_remove(userid, s[1], s[0])
 
     d._page_header_info.invalidate(userid)
+    d.cached_posts_count.invalidate(userid)
 
 
 def pending_reject(userid, submissions):
@@ -250,3 +251,4 @@ def remove(userid, submissions):
     """, user=userid, submissions=submissions)
 
     welcome.collection_remove(userid, submissions)
+    d.cached_posts_count.invalidate(userid)

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -59,6 +59,7 @@ def create(userid, journal, friends_only=False, tags=None):
                            friends_only=friends_only)
 
     d.metric('increment', 'journals')
+    d.cached_posts_count.invalidate(userid)
 
     return journalid
 
@@ -298,6 +299,8 @@ def edit(userid, journal, friends_only=False):
             userid, query[0], 'The following journal was edited:',
             '- ' + text.markdown_link(journal.title, '/journal/%s?anyway=true' % (journal.journalid,)))
 
+    d.cached_posts_count.invalidate(query[0])
+
 
 def remove(userid, journalid):
     ownerid = d.get_ownerid(journalid=journalid)
@@ -312,5 +315,6 @@ def remove(userid, journalid):
 
     if result.rowcount != 0:
         welcome.journal_remove(journalid)
+        d.cached_posts_count.invalidate(ownerid)
 
     return ownerid

--- a/weasyl/templates/common/user_tabs.html
+++ b/weasyl/templates/common/user_tabs.html
@@ -1,15 +1,16 @@
-$def with (username, current, show_favorites)
+$def with (username, current, show_favorites, post_counts_by_type)
+  $def count(key): <span class="user-nav-count">${format(post_counts_by_type[key], ",")}</span>
   $code:
-    def _CURRENT_(x, y):
-      return "class=\"current\" " if x == y else ""
+    def _CURRENT(x):
+      return "current" if x == current else ""
   $ username = LOGIN(username)
   <nav><ul id="user-nav" class="bar clear pad-left pad-right">
-    <li><a $:{_CURRENT_("profile", current)}href="/~${username}">Profile</a></li>
-    <li><a $:{_CURRENT_("submissions", current)}href="/submissions/${username}">Submissions</a></li>
-    <li><a $:{_CURRENT_("journals", current)}href="/journals/${username}">Journals</a></li>
-    <li><a $:{_CURRENT_("collections", current)}href="/collections/${username}">Collections</a></li>
-    <li><a $:{_CURRENT_("characters", current)}href="/characters/${username}">Characters</a></li>
-    <li><a $:{_CURRENT_("shouts", current)}href="/shouts/${username}">Shouts</a></li>
+    <li><a class="$:{_CURRENT('profile')}" href="/~${username}">Profile</a></li>
+    <li><a class="user-nav-with-count $:{_CURRENT('submissions')}" href="/submissions/${username}"><span class="user-nav-label">Submissions</span> $:{count("submission")}</a></li>
+    <li><a class="user-nav-with-count $:{_CURRENT('journals')}" href="/journals/${username}"><span class="user-nav-label">Journals</span> $:{count("journal")}</a></li>
+    <li><a class="user-nav-with-count $:{_CURRENT('collections')}" href="/collections/${username}"><span class="user-nav-label">Collections</span> $:{count("collection")}</a></li>
+    <li><a class="user-nav-with-count $:{_CURRENT('characters')}" href="/characters/${username}"><span class="user-nav-label">Characters</span> $:{count("character")}</a></li>
+    <li><a class="$:{_CURRENT('shouts')}" href="/shouts/${username}">Shouts</a></li>
     $if show_favorites:
-      <li><a $:{_CURRENT_("favorites", current)}href="/favorites/${username}">Favorites</a></li>
+      <li><a class="$:{_CURRENT('favorites')}" href="/favorites/${username}">Favorites</a></li>
   </ul></nav>

--- a/weasyl/templates/user/characters.html
+++ b/weasyl/templates/user/characters.html
@@ -1,9 +1,9 @@
-$def with (profile, userinfo, relationship, result)
+$def with (profile, userinfo, relationship, result, post_counts_by_type)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <div id="characters_stage" class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "characters", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "characters", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content user-characters">

--- a/weasyl/templates/user/collections.html
+++ b/weasyl/templates/user/collections.html
@@ -1,9 +1,9 @@
-$def with (profile, userinfo, relationship, result)
+$def with (profile, userinfo, relationship, result, post_counts_by_type)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <div id="collections_stage" class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "collections", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "collections", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content user-collections">

--- a/weasyl/templates/user/favorites.html
+++ b/weasyl/templates/user/favorites.html
@@ -1,9 +1,9 @@
-$def with (profile, userinfo, relationship, feature, result)
+$def with (profile, userinfo, relationship, feature, result, post_counts_by_type)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <div id="favorites-stage" class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "favorites", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "favorites", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div id="favorites-content" class="content user-favorites">

--- a/weasyl/templates/user/followed.html
+++ b/weasyl/templates/user/followed.html
@@ -1,8 +1,8 @@
-$def with (profile, userinfo, relationship, query)
+$def with (profile, userinfo, relationship, query, post_counts_by_type)
 
 <div class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content">

--- a/weasyl/templates/user/following.html
+++ b/weasyl/templates/user/following.html
@@ -1,8 +1,8 @@
-$def with (profile, userinfo, relationship, query)
+$def with (profile, userinfo, relationship, query, post_counts_by_type)
 
 <div class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content">

--- a/weasyl/templates/user/friends.html
+++ b/weasyl/templates/user/friends.html
@@ -1,8 +1,8 @@
-$def with (profile, userinfo, relationship, query)
+$def with (profile, userinfo, relationship, query, post_counts_by_type)
 
 <div class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content">

--- a/weasyl/templates/user/journals.html
+++ b/weasyl/templates/user/journals.html
@@ -1,7 +1,7 @@
-$def with (profile, userinfo, relationship, journals)
+$def with (profile, userinfo, relationship, journals, post_counts_by_type)
 <div id="journals_stage" class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "journals", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "journals", profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 
 <div class="content" id="journals-content">

--- a/weasyl/templates/user/profile.html
+++ b/weasyl/templates/user/profile.html
@@ -1,4 +1,4 @@
-$def with (request, profile, userinfo, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends, is_unverified)
+$def with (request, profile, userinfo, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends, is_unverified, post_counts_by_type)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <section><div id="user-header" class="stage clear">
@@ -31,7 +31,7 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 </div></section>
 
-$:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['show_favorites_tab']])}
+$:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['show_favorites_tab'], post_counts_by_type])}
 
 <div id="user-content" class="content clear">
   $# only moderators can see the profiles of unverified users, so no need for additional ability-to-vouch checks

--- a/weasyl/templates/user/shouts.html
+++ b/weasyl/templates/user/shouts.html
@@ -1,7 +1,7 @@
-$def with (profile, userinfo, relationship, myself, shouts, feature)
+$def with (profile, userinfo, relationship, myself, shouts, feature, post_counts_by_type)
 <div id="shouts-stage" class="stage">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], feature, profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], feature, profile['show_favorites_tab'], post_counts_by_type])}
 </div>
 <div id="shouts-content" class="content">
   $if feature == "staffnotes":

--- a/weasyl/templates/user/submissions.html
+++ b/weasyl/templates/user/submissions.html
@@ -1,9 +1,9 @@
-$def with (profile, userinfo, relationship, result, folders, currentfolder)
+$def with (profile, userinfo, relationship, result, folders, currentfolder, post_counts_by_type)
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
 <div id="submissions-stage" class="stage clear">
   $:{RENDER("common/user_tools.html", [profile, userinfo, relationship])}
-  $:{RENDER("common/user_tabs.html", [profile['username'], "submissions", profile['show_favorites_tab']])}
+  $:{RENDER("common/user_tabs.html", [profile['username'], "submissions", profile['show_favorites_tab'], post_counts_by_type])}
 
   <div class="user-submissions">
 


### PR DESCRIPTION
The counts respect the viewer’s rating preference. Sets up for some future changes:

* determining whether SFW mode has an effect when the configured rating preference is the same between SFW mode and non, so we can avoid confusingly showing a toggle that does nothing

* making blocked tag filtering a visible operation on pages of results (which itself sets up for better pagination and performance improvements through caching and lightened database load)

I’d like to provide counts for favorites and individual folders too, but they’re more involved. Ideally, counts would be stored in the database and updated eagerly; PostgreSQL makes it hard.