### PR TITLE
Improve suspension date handling

### DIFF
--- a/assets/scss/mod.scss
+++ b/assets/scss/mod.scss
@@ -1,5 +1,3 @@
-@import 'components/date-picker';
-
 .report-status-review {
     color: #e0a000;
 }

--- a/weasyl/controllers/moderation.py
+++ b/weasyl/controllers/moderation.py
@@ -25,7 +25,7 @@ def modcontrol_suspenduser_get_(request):
 @moderator_only
 @token_checked
 def modcontrol_suspenduser_post_(request):
-    form = request.web_input(userid="", username="", mode="", reason="", day="", month="", year="", datetype="",
+    form = request.web_input(userid="", username="", mode="", reason="", datetype="",
                              duration="", durationunit="")
 
     moderation.setusermode(request.userid, form)

--- a/weasyl/templates/modcontrol/suspenduser.html
+++ b/weasyl/templates/modcontrol/suspenduser.html
@@ -94,32 +94,8 @@ $:{RENDER("common/stage_title.html", ["User Suspensions", "Moderator Control Pan
 
       <label class="input-checkbox"><input type="radio" id="datetype" name="datetype" value="a" /> Release Date</label>
 
-      <div class="form-date clear">
-        <div class="form-date-day">
-          <label for="day" class="color-lighter">Day</label>
-          <input type="number" class="input" id="day" name="day" min="1" max="31" />
-        </div>
-        <div class="form-date-month">
-          <label for="month" class="color-lighter">Month</label>
-          <select class="input" name="month" id="month">
-            <option value="1">January</option>
-            <option value="2">February</option>
-            <option value="3">March</option>
-            <option value="4">April</option>
-            <option value="5">May</option>
-            <option value="6">June</option>
-            <option value="7">July</option>
-            <option value="8">August</option>
-            <option value="9">September</option>
-            <option value="10">October</option>
-            <option value="11">November</option>
-            <option value="12">December</option>
-          </select>
-        </div>
-        <div class="form-date-year">
-          <label for="year" class="color-lighter">Year</label>
-          <input type="number" class="input last-input" id="year" name="year" min="2012" max="2036" />
-        </div>
+      <div class="clear">
+        <input type="date" name="release-date" min="${arrow.utcnow().shift(days=1).date().isoformat()}">
       </div>
 
       <button type="submit" class="button" style="float: right;">Ban / Suspend / Release User</button>


### PR DESCRIPTION
- Use native date picker for release date
- Replace use of server-time-zone-dependent `weasyl.define.convert_unixdate` with consistent UTC 00:00

Separated from #1397.