### PR TITLE
Fix site preferences to be submittable when rating preference is disabled

### DIFF
--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -337,7 +337,7 @@ def control_editpreferences_post_(request):
         follow_s="", follow_c="", follow_f="", follow_t="",
         follow_j="")
 
-    rating = ratings.CODE_MAP[define.get_int(form.rating)]
+    rating = ratings.CODE_MAP.get(define.get_int(form.rating), ratings.GENERAL)
     jsonb_settings = define.get_profile_settings(request.userid)
     jsonb_settings.disable_custom_thumbs = form.custom_thumbs == "disable"
 


### PR DESCRIPTION
Disabled form fields aren’t submitted.