### PR TITLE
Replace `strip_html` with `markdown_excerpt`

### DIFF
--- a/libweasyl/html.py
+++ b/libweasyl/html.py
@@ -8,39 +8,16 @@ import json
 from html.parser import HTMLParser
 
 
-def strip_html(markdown):
+def strip_html(markdown: str) -> str:
     """
-    Strip HTML tags from a markdown string.
-
-    Entities present in the markdown will be escaped.
-
-    Parameters:
-        markdown: A :term:`native string` to be stripped and escaped.
-
-    Returns:
-        An escaped, stripped :term:`native string`.
+    Strip HTML tags and resolve character references in a markdown string.
     """
-    class Parser(HTMLParser):
-        text_parts = []
-
-        def handle_data(self, data):
-            self.text_parts.append(
-                data
-                .replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace('"', "&quot;")
-            )
-
-        def handle_entityref(self, name):
-            self.text_parts.append("&" + name + ";")
-
-        def handle_charref(self, name):
-            self.text_parts.append("&#" + name + ";")
-
-    parser = Parser()
+    text_parts = []
+    parser = HTMLParser()
+    parser.handle_data = text_parts.append
     parser.feed(markdown)
-    return "".join(parser.text_parts)
+    parser.close()
+    return "".join(text_parts)
 
 
 def inline_json(obj):

--- a/libweasyl/html.py
+++ b/libweasyl/html.py
@@ -1,36 +1,4 @@
-"""
-Utilities for dealing with HTML.
-
-Specifically, utilities for creating HTML and utilities for removing HTML.
-"""
-
 import json
-from html.parser import HTMLParser
-
-
-class _HtmlToText(HTMLParser):
-
-    def __init__(self, handle_data):
-        super().__init__()
-        self.handle_data = handle_data
-
-    def handle_starttag(self, tag, attrs):
-        if tag == "img":
-            alt = next((value for key, value in attrs if key == "alt"), None)
-
-            if alt:
-                self.handle_data(f"[{alt}]")
-
-
-def html_to_text(markdown: str) -> str:
-    """
-    Convert HTML to a plain text representation suitable for summaries.
-    """
-    text_parts = []
-    parser = _HtmlToText(text_parts.append)
-    parser.feed(markdown)
-    parser.close()
-    return " ".join("".join(text_parts).split())
 
 
 def inline_json(obj):

--- a/libweasyl/html.py
+++ b/libweasyl/html.py
@@ -8,16 +8,29 @@ import json
 from html.parser import HTMLParser
 
 
-def strip_html(markdown: str) -> str:
+class _HtmlToText(HTMLParser):
+
+    def __init__(self, handle_data):
+        super().__init__()
+        self.handle_data = handle_data
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "img":
+            alt = next((value for key, value in attrs if key == "alt"), None)
+
+            if alt:
+                self.handle_data(f"[{alt}]")
+
+
+def html_to_text(markdown: str) -> str:
     """
-    Strip HTML tags and resolve character references in a markdown string.
+    Convert HTML to a plain text representation suitable for summaries.
     """
     text_parts = []
-    parser = HTMLParser()
-    parser.handle_data = text_parts.append
+    parser = _HtmlToText(text_parts.append)
     parser.feed(markdown)
     parser.close()
-    return "".join(text_parts)
+    return " ".join("".join(text_parts).split())
 
 
 def inline_json(obj):

--- a/libweasyl/test/test_html.py
+++ b/libweasyl/test/test_html.py
@@ -1,11 +1,13 @@
 from libweasyl import html
 
 
-def test_strip_html():
-    assert html.strip_html('<div style="text-align: center">**foo**</div> <!-- comment -->') == "**foo** ", "`strip_html` should strip HTML tags"
-    assert html.strip_html('1 < 3 > 2 "foo"') == '1 < 3 > 2 "foo"', "the output of `strip_html` should be plain text, not HTML"
-    assert html.strip_html("&copy;") == "©", "`strip_html` should decode named character references"
-    assert html.strip_html("&#xec;") == "ì", "`strip_html` should decode numeric character references"
+def test_html_to_text():
+    assert html.html_to_text('<div style="text-align: center">**foo**</div><!-- comment -->') == "**foo**", "`html_to_text` should strip HTML tags"
+    assert html.html_to_text('1 < 3 > 2 "foo"') == '1 < 3 > 2 "foo"', "the output of `html_to_text` should be plain text, not HTML"
+    assert html.html_to_text("&copy;") == "©", "`html_to_text` should decode named character references"
+    assert html.html_to_text("&#xec;") == "ì", "`html_to_text` should decode numeric character references"
+    assert html.html_to_text('foo <img alt="bar"> baz') == "foo [bar] baz", "`html_to_text` should replace images with their alt text"
+    assert html.html_to_text(" foo\nbar  baz\t") == "foo bar baz", "`html_to_text` should normalize whitespace"
 
 
 def test_inline_json():

--- a/libweasyl/test/test_html.py
+++ b/libweasyl/test/test_html.py
@@ -3,6 +3,9 @@ from libweasyl import html
 
 def test_strip_html():
     assert html.strip_html('<div style="text-align: center">**foo**</div> <!-- comment -->') == "**foo** ", "`strip_html` should strip HTML tags"
+    assert html.strip_html('1 < 3 > 2 "foo"') == '1 < 3 > 2 "foo"', "the output of `strip_html` should be plain text, not HTML"
+    assert html.strip_html("&copy;") == "©", "`strip_html` should decode named character references"
+    assert html.strip_html("&#xec;") == "ì", "`strip_html` should decode numeric character references"
 
 
 def test_inline_json():

--- a/libweasyl/test/test_html.py
+++ b/libweasyl/test/test_html.py
@@ -8,6 +8,7 @@ def test_html_to_text():
     assert html.html_to_text("&#xec;") == "ì", "`html_to_text` should decode numeric character references"
     assert html.html_to_text('foo <img alt="bar"> baz') == "foo [bar] baz", "`html_to_text` should replace images with their alt text"
     assert html.html_to_text(" foo\nbar  baz\t") == "foo bar baz", "`html_to_text` should normalize whitespace"
+    assert html.html_to_text("a<![/b]>c") == "ac", "`html_to_text` shouldn’t throw on invalid HTML"
 
 
 def test_inline_json():

--- a/libweasyl/test/test_html.py
+++ b/libweasyl/test/test_html.py
@@ -1,6 +1,10 @@
 from libweasyl import html
 
 
+def test_strip_html():
+    assert html.strip_html('<div style="text-align: center">**foo**</div> <!-- comment -->') == "**foo** ", "`strip_html` should strip HTML tags"
+
+
 def test_inline_json():
     assert html.inline_json('</script>') == r'"<\/script>"'
     assert html.inline_json('</SCRIPT>') == r'"<\/SCRIPT>"'

--- a/libweasyl/test/test_html.py
+++ b/libweasyl/test/test_html.py
@@ -1,16 +1,6 @@
 from libweasyl import html
 
 
-def test_html_to_text():
-    assert html.html_to_text('<div style="text-align: center">**foo**</div><!-- comment -->') == "**foo**", "`html_to_text` should strip HTML tags"
-    assert html.html_to_text('1 < 3 > 2 "foo"') == '1 < 3 > 2 "foo"', "the output of `html_to_text` should be plain text, not HTML"
-    assert html.html_to_text("&copy;") == "©", "`html_to_text` should decode named character references"
-    assert html.html_to_text("&#xec;") == "ì", "`html_to_text` should decode numeric character references"
-    assert html.html_to_text('foo <img alt="bar"> baz') == "foo [bar] baz", "`html_to_text` should replace images with their alt text"
-    assert html.html_to_text(" foo\nbar  baz\t") == "foo bar baz", "`html_to_text` should normalize whitespace"
-    assert html.html_to_text("a<![/b]>c") == "ac", "`html_to_text` shouldn’t throw on invalid HTML"
-
-
 def test_inline_json():
     assert html.inline_json('</script>') == r'"<\/script>"'
     assert html.inline_json('</SCRIPT>') == r'"<\/SCRIPT>"'

--- a/libweasyl/test/test_text.py
+++ b/libweasyl/test/test_text.py
@@ -13,7 +13,7 @@ user_linking_markdown_tests = [
     ('![](user:spam)![](user:spam)',
      '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"></a>'
      '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"></a>'),
-    ('<!~spam>', '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt="spam"> <span>spam</span></a>'),
+    ('<!~spam>', '<a href="/~spam" class="user-icon"><img src="/~spam/avatar" alt=""> <span>spam</span></a>'),
     ('![user image with alt text](user:example)', '<a href="/~example" class="user-icon"><img src="/~example/avatar"> <span>user image with alt text</span></a>'),
     ('<user:spam>', '<a href="/~spam">spam</a>'),
     ('[link](user:spam)', '<a href="/~spam">link</a>'),

--- a/libweasyl/test/test_text.py
+++ b/libweasyl/test/test_text.py
@@ -173,6 +173,13 @@ markdown_excerpt_tests = [
     (u'single-codepoint graphemes😊😊😊😊', u'single-codepoint graphemes😊😊😊😊'),
     (u'single-codepoint graphemes😊😊😊😊😊', u'single-codepoint graphemes😊😊😊…'),
     (u'test\n - lists\n - of\n - items\n\ntest', u'test lists of items test'),
+    ('<div style="text-align: center">**foo**</div>\n<!-- comment -->', "foo"),
+    ('1 < 3 > 2 "foo"', '1 < 3 > 2 "foo"'),
+    ("&copy;", "©"),
+    ("&#xec;", "ì"),
+    ('foo <!bar> baz', "foo [bar] baz"),
+    (" foo\nbar  baz\t", "foo bar baz"),
+    ("<![/b]>", "<![/b]>"),
 ]
 
 

--- a/libweasyl/text.py
+++ b/libweasyl/text.py
@@ -298,6 +298,8 @@ def markdown(target):
 def _itertext_spaced(element):
     if element.text:
         yield element.text
+    elif element.tag == "img" and (alt := element.get("alt")):
+        yield "[%s]" % (alt,)
 
     for child in element:
         is_block = child.tag in _EXCERPT_BLOCK_ELEMENTS

--- a/libweasyl/text.py
+++ b/libweasyl/text.py
@@ -121,9 +121,11 @@ def create_link(t, username):
 
         image = etree.SubElement(link, u"img")
         image.set(u"src", u"/~{username}/avatar".format(username=get_sysname(username)))
-        image.set(u"alt", username)
 
-        if t != "!":
+        if t == "!":
+            image.set("alt", username)
+        else:
+            image.set("alt", "")
             label = etree.SubElement(link, u"span")
             label.text = username
             image.tail = u" "

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -1,9 +1,8 @@
 from pyramid import httpexceptions
 from pyramid.response import Response
 
-from libweasyl.html import html_to_text
 from libweasyl.models.content import Submission
-from libweasyl.text import slug_for
+from libweasyl.text import markdown_excerpt, slug_for
 from weasyl import (
     character, define, journal, macro, media, profile, searchtag, submission)
 from weasyl.controllers.decorators import moderator_only
@@ -69,7 +68,7 @@ def submission_(request):
     else:
         twitter_meta['title'] = title_with_attribution
 
-    meta_description = define.summarize(html_to_text(item['content']).strip())
+    meta_description = markdown_excerpt(item['content'])
     if meta_description:
         twitter_meta['description'] = ogp['description'] = meta_description
 

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -1,7 +1,7 @@
 from pyramid import httpexceptions
 from pyramid.response import Response
 
-from libweasyl.html import strip_html
+from libweasyl.html import html_to_text
 from libweasyl.models.content import Submission
 from libweasyl.text import slug_for
 from weasyl import (
@@ -69,7 +69,7 @@ def submission_(request):
     else:
         twitter_meta['title'] = title_with_attribution
 
-    meta_description = define.summarize(strip_html(item['content']).strip())
+    meta_description = define.summarize(html_to_text(item['content']).strip())
     if meta_description:
         twitter_meta['description'] = ogp['description'] = meta_description
 

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -2,7 +2,7 @@ from pyramid import httpexceptions
 from pyramid.response import Response
 
 from libweasyl import staff
-from libweasyl.html import html_to_text
+from libweasyl.text import markdown_excerpt
 
 from weasyl import (
     character, collection, commishinfo, define, favorite, folder,
@@ -60,7 +60,7 @@ def profile_(request):
     username = userprofile["username"]
     canonical_path = request.route_path("profile_tilde", name=define.get_sysname(username))
     title = f"{username}’s profile"
-    meta_description = define.summarize(html_to_text(userprofile["profile_text"]).strip())
+    meta_description = markdown_excerpt(userprofile["profile_text"])
     avatar_url = define.absolutify_url(userprofile['user_media']['avatar'][0]['display_url'])
     twitter_meta = {
         "card": "summary",

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -2,7 +2,7 @@ from pyramid import httpexceptions
 from pyramid.response import Response
 
 from libweasyl import staff
-from libweasyl.html import strip_html
+from libweasyl.html import html_to_text
 
 from weasyl import (
     character, collection, commishinfo, define, favorite, folder,
@@ -60,7 +60,7 @@ def profile_(request):
     username = userprofile["username"]
     canonical_path = request.route_path("profile_tilde", name=define.get_sysname(username))
     title = f"{username}’s profile"
-    meta_description = define.summarize(strip_html(userprofile["profile_text"]).strip())
+    meta_description = define.summarize(html_to_text(userprofile["profile_text"]).strip())
     avatar_url = define.absolutify_url(userprofile['user_media']['avatar'][0]['display_url'])
     twitter_meta = {
         "card": "summary",


### PR DESCRIPTION
`markdown_excerpt` is more complete (renders Markdown, normalizes whitespace), correct (produces plain text), and robust (uses `lxml.html`, which doesn’t crash on the same malformed input that `html.parser` does).