### PR TITLE
Upload coverage to Codecov with API token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,3 +86,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov wants us to use their v4 action and corresponding new uploader, which is terribly designed and doesn’t work at all on Alpine anymore; it now rate limits tokenless uploads to the point that Codecov effectively hasn’t worked for the last month.

Let’s see if providing the token to the v3 action (despite it only being documented to be required for private repos for that version of the action) helps.