### PR TITLE
Don't copy root comment box's text to reply (#1106)

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -846,6 +846,7 @@
             // Remove the original form’s non-functional Markdown preview and warning elements
             contentField.parentNode.removeChild(contentField.nextSibling);
             contentField.parentNode.removeChild(contentField.nextSibling);
+            contentField.value = '';
 
             if (!children || children.nodeName !== 'UL') {
                 children = document.createElement('ul');


### PR DESCRIPTION
Fixes #1106 by ensuring newly-created comment reply boxes do not contain what the user typed into the root comment box. This prevents `addMarkdownPreview` from trying to update the Markdown preview of a reply box that has not actually had its Markdown preview initialized.