### PR TITLE
Clean up leftover signup birthdate logic and database column

### DIFF
--- a/libweasyl/alembic/versions/63baa2713e72_remove_signup_birthdate_column.py
+++ b/libweasyl/alembic/versions/63baa2713e72_remove_signup_birthdate_column.py
@@ -1,0 +1,22 @@
+"""Remove signup birthdate column
+
+Revision ID: 63baa2713e72
+Revises: 57171ee9e989
+Create Date: 2024-08-21 23:50:18.122609
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '63baa2713e72'
+down_revision = '57171ee9e989'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('logincreate', 'birthday')
+
+
+def downgrade():
+    op.add_column('logincreate', sa.Column('birthday', sa.INTEGER(), autoincrement=False, nullable=True))

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -350,7 +350,6 @@ logincreate = Table(
     Column('login_name', String(length=40), nullable=False, unique=True),
     Column('hashpass', String(length=100), nullable=False),
     Column('email', String(length=100), nullable=False, unique=True),
-    Column('birthday', WeasylTimestampColumn(), nullable=True),
     Column('created_at', TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
     # Used to determine if a record is invalid for purposes of plausible deniability of email addresses
     #   AKA, create a logincreate entry if an in-use email address is provided, thus preserving the effect of

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -186,8 +186,7 @@ def signup_get_(request):
 @token_checked
 def signup_post_(request):
     form = request.web_input(
-        username="", password="", email="",
-        day="", month="", year="")
+        username="", password="", email="")
 
     login.create(form)
     return Response(define.errorpage(

--- a/weasyl/login.py
+++ b/weasyl/login.py
@@ -1,7 +1,6 @@
 import os
 from io import open
 
-import arrow
 import bcrypt
 from publicsuffixlist import PublicSuffixList
 from sqlalchemy.sql.expression import select
@@ -204,27 +203,11 @@ def create(form):
     # Normalize form data
     username = clean_display_name(form.username)
     sysname = d.get_sysname(username)
-
     email = emailer.normalize_address(form.email)
-
-    # TODO: remove birth date check after checkbox-only form has been deployed for a while
     password = form.password
-    if form.day and form.month and form.year:
-        try:
-            birthday = arrow.Arrow(int(form.year), int(form.month), int(form.day))
-        except ValueError:
-            raise WeasylError("birthdayInvalid")
-
-        if d.age_in_years(birthday) < 13:
-            raise WeasylError("birthdayInvalid")
-    else:
-        birthday = None
-
-    if "age" in form and form.age != "13+":
-        raise WeasylError("birthdayInvalid")
 
     # Check invalid form data
-    if birthday is None and "age" not in form:
+    if "age" not in form or form.age != "13+":
         raise WeasylError("birthdayInvalid")
     if not password_secure(password):
         raise WeasylError("passwordInsecure")
@@ -251,7 +234,6 @@ def create(form):
             "login_name": sysname,
             "hashpass": passhash(password),
             "email": email,
-            "birthday": birthday,
         })
 
         # Send verification email
@@ -268,7 +250,6 @@ def create(form):
             "login_name": sysname,
             "hashpass": passhash(password),
             "email": token,
-            "birthday": None,
             "invalid": True,
             # So we have a way for admins to determine which email address collided in the View Pending Accounts Page
             "invalid_email_addr": email,
@@ -320,7 +301,6 @@ def verify(token, ip_address=None):
         })
         db.execute(d.meta.tables["userinfo"].insert(), {
             "userid": userid,
-            "birthday": query.birthday,
         })
 
         # Update logincreate records

--- a/weasyl/test/login/test_get_account_verification_token.py
+++ b/weasyl/test/login/test_get_account_verification_token.py
@@ -1,5 +1,4 @@
 import pytest
-import arrow
 
 from weasyl import login
 from weasyl import define as d
@@ -21,7 +20,6 @@ def test_acct_verif_token_returned_if_email_provided_to_function():
         "login_name": user_name,
         "hashpass": login.passhash(raw_password),
         "email": email_addr,
-        "birthday": arrow.Arrow(2000, 1, 1),
     })
     acct_verification_token = login.get_account_verification_token(email=email_addr, username=None)
     assert token == acct_verification_token
@@ -35,7 +33,6 @@ def test_acct_verif_token_returned_if_username_provided_to_function():
         "login_name": user_name,
         "hashpass": login.passhash(raw_password),
         "email": email_addr,
-        "birthday": arrow.Arrow(2000, 1, 1),
     })
     acct_verification_token = login.get_account_verification_token(email=None, username=user_name)
     assert token == acct_verification_token

--- a/weasyl/test/login/test_verify.py
+++ b/weasyl/test/login/test_verify.py
@@ -1,5 +1,4 @@
 import pytest
-import arrow
 
 from weasyl import login
 from weasyl import define as d
@@ -18,7 +17,6 @@ def _create_pending_account(invalid=False):
         "login_name": username,
         "hashpass": login.passhash('0123456789'),
         "email": email,
-        "birthday": arrow.Arrow(2000, 1, 1),
         "invalid": invalid,
     })
 


### PR DESCRIPTION
The removal has been deployed for a while now, so nobody should be inconvenienced by breaking postback of the old version of the form.

Migration runs after deployment.