### PR TITLE
Improve homepage’s display of recently popular submissions

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -2256,7 +2256,7 @@ $notifs-color-active: #b9b9b9;
 
 /* ------------------------------------ =homepage --*/
 
-.home-latest {
+.home-top {
     margin: 8px 0;
 }
 

--- a/libweasyl/alembic/versions/7f0c979aeaeb_index_submissions_on_new_popularity_.py
+++ b/libweasyl/alembic/versions/7f0c979aeaeb_index_submissions_on_new_popularity_.py
@@ -1,0 +1,30 @@
+"""Index submissions on new popularity score
+
+Revision ID: 7f0c979aeaeb
+Revises: 63baa2713e72
+Create Date: 2024-08-15 02:45:29.390391
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7f0c979aeaeb'
+down_revision = '63baa2713e72'
+
+from alembic import op
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ind_submission_score2 ON submission (
+                (
+                    log(favorites)
+                        + unixtime / 180000.0
+                )
+            ) WHERE favorites > 0
+        """)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ind_submission_score2")

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -757,6 +757,14 @@ submission = Table(
                 + unixtime / 180000.0
         )"""),
     ),
+    Index(
+        'ind_submission_score2',
+        text("""(
+            log(favorites)
+                + unixtime / 180000.0
+        )"""),
+        postgresql_where=text("favorites > 0"),
+    ),
 )
 
 Index('ind_submission_folderid', submission.c.folderid)

--- a/weasyl/index.py
+++ b/weasyl/index.py
@@ -101,7 +101,7 @@ def partition_submissions(submissions):
         buckets[bucket].append(s)
 
     return (
-        submissions[:22],
+        submissions[:11],
         buckets[1][:11],
         buckets[2][:11],
         buckets[3][:11],
@@ -127,5 +127,5 @@ def template_fields(userid):
         # Currently streaming users
         profile.select_streaming_sample(userid),
         # Recently popular submissions
-        list(itertools.islice(filter_submissions(userid, submission.select_recently_popular(), incidence_limit=1), 11)),
+        list(itertools.islice(filter_submissions(userid, submission.select_recently_popular(), incidence_limit=1), 22)),
     )

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -1068,12 +1068,10 @@ def select_recently_popular():
 
     To calculate scores, this method performs the following evaluation:
 
-    item_score = log(item_fave_count + 1) + log(item_view_counts) / 2 + submission_time / 180000
+    item_score = log(item_fave_count) + submission_time / 180000
 
     180000 is roughly two days. So intuitively an item two days old needs an order of
-    magnitude more favorites/views compared to a fresh one. Also the favorites are
-    quadratically more influential than views. The result is that this algorithm favors
-    recent, heavily favorited items.
+    magnitude more favorites compared to a fresh one.
 
     :return: A list of submission dictionaries, in score-rank order.
     """
@@ -1092,9 +1090,9 @@ def select_recently_popular():
         WHERE
             NOT submission.hidden
             AND NOT submission.friends_only
+            AND submission.favorites > 0
         ORDER BY
-            log(submission.favorites + 1) +
-                log(submission.page_views + 1) / 2 +
+            log(submission.favorites) +
                 submission.unixtime / 180000.0
                 DESC
         LIMIT 128

--- a/weasyl/templates/etc/index.html
+++ b/weasyl/templates/etc/index.html
@@ -9,15 +9,15 @@ $code:
 $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 <div id="home-art" class="stage">
 
-  <ul class="home-latest thumbnail-grid medium-footprint">
+  <ul class="home-top thumbnail-grid medium-footprint">
     $# Items that are front and center on the main page, quite close to the top; skip lazy loading entirely.
-    $for i in everything:
+    $for i in popular:
       $:{_GRID_ITEM(i, lazy_load=False)}
-    <li class="more"><a class="more" href="/search"><i>Browse</i> <span>Everything</span></a></li>
+    <li class="more"><a class="more" href="/popular"><i>More</i> <span>Recently Popular</span></a></li>
   </ul>
 
   <ul id="home-tabs" class="bar">
-    <li><a class="home-pane-link current" href="#home-recently-popular"><span class="home-tab-collapse">Recently </span>Popular</a></li>
+    <li><a class="home-pane-link current" href="#home-latest">Latest<span class="home-tab-collapse"> Posts</span></a></li>
     <li><a class="home-pane-link" href="#home-critique">Critique<span class="home-tab-collapse"> Wanted</span></a></li>
     <li><a class="home-pane-link" href="#home-literature">Writing</a></li>
     <li><a class="home-pane-link" href="#home-multimedia">Multimedia</a></li>
@@ -26,11 +26,11 @@ $ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
 
   <div id="home-panes">
 
-    <div id="home-recently-popular" class="pane current">
+    <div id="home-latest" class="pane current">
       <ul class="thumbnail-grid small-footprint">
-        $for i in popular:
+        $for i in everything:
           $:{_GRID_ITEM(i)}
-        <li class="more"><a class="more" href="/popular"><i>More</i> <span>Recently Popular</span></a></li>
+        <li class="more"><a class="more" href="/search"><i>Browse</i> <span>Everything</span></a></li>
       </ul>
     </div>
 

--- a/weasyl/test/test_submission.py
+++ b/weasyl/test/test_submission.py
@@ -204,6 +204,7 @@ class SelectListTestCase(unittest.TestCase):
             submission.select_view(owner, s, ratings.GENERAL.code)['tags'],
             GroupedTags(artist=['kale'], suggested=['tomato'], own_suggested=[]))
 
+    @pytest.mark.usefixtures('cache')
     def test_recently_popular(self):
         owner = db_utils.create_user()
         now = arrow.utcnow()
@@ -213,9 +214,11 @@ class SelectListTestCase(unittest.TestCase):
         sub3 = db_utils.create_submission(owner, rating=ratings.GENERAL.code, unixtime=now - datetime.timedelta(days=2))
         sub4 = db_utils.create_submission(owner, rating=ratings.GENERAL.code, unixtime=now)
         tag = db_utils.create_tag('tag')
+        favoriter = db_utils.create_user()
 
         for s in [sub1, sub2, sub3, sub4]:
             db_utils.create_submission_tag(tag, s)
+            db_utils.create_favorite(favoriter, submitid=s, unixtime=now)
 
         for i in range(100):
             favoriter = db_utils.create_user()

--- a/weasyl/test/web/test_blacklist.py
+++ b/weasyl/test/web/test_blacklist.py
@@ -22,21 +22,21 @@ def test_blacklist_homepage(app):
     cookie = db_utils.create_session(viewing_user)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 2
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 2
 
     app.post('/manage/tagfilters',
              {'title': 'walrus', 'rating': str(ratings.GENERAL.code), 'do': 'create'},
              headers={'Cookie': cookie}, status=303)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 1
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 1
 
     app.post('/manage/tagfilters',
              {'title': 'walrus', 'rating': str(ratings.GENERAL.code), 'do': 'remove'},
              headers={'Cookie': cookie}, status=303)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 2
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 2
 
 
 @pytest.mark.usefixtures('db', 'cache')
@@ -54,18 +54,18 @@ def test_block_user_homepage(app):
     cookie = db_utils.create_session(viewing_user)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 2
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 2
 
     app.post('/ignoreuser',
              {'userid': str(submitting_user1), 'action': 'ignore'},
              headers={'Cookie': cookie}, status=303)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 1
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 1
 
     app.post('/ignoreuser',
              {'userid': str(submitting_user1), 'action': 'unignore'},
              headers={'Cookie': cookie}, status=303)
 
     resp = app.get('/', headers={'Cookie': cookie})
-    assert len(resp.html.select('#home-art > .thumbnail-grid .thumb')) == 2
+    assert len(resp.html.select('#home-latest > .thumbnail-grid .thumb')) == 2


### PR DESCRIPTION
- #### Remove view count from recently-popular score calculation

    If two submissions have the same number of favorites, is the more viewed one more popular? If a submission accumulates views by virtue of being in Recently Popular without also accumulating favorites, is that a positive signal? I don’t think so.

    Views are a very flawed metric anyway, especially as currently implemented. (Also, with Weasyl’s current low traffic level, an advantage of 25 views can outweigh a 40% advantage in favorites near the top of Recently Popular.)

    Migration runs before deployment.

- #### Switch latest posts with recently popular on home page

    Recently Popular tends to be more appealing(!) and less risky viewing. Maybe in the future, we can exclude people the viewing user already follows, to make it still useful for discovering new artists.

    This is also good for cache hit rates.