### PR TITLE
Separate metrics for retrieving notification counts from overall request metrics

### DIFF
--- a/weasyl/metrics.py
+++ b/weasyl/metrics.py
@@ -2,6 +2,8 @@ import functools
 import threading
 import time
 
+from pyramid.threadlocal import get_current_request
+
 
 class CachedMetric:
     """
@@ -41,3 +43,29 @@ class CachedMetric:
             return func(*args, **kwargs)
 
         return wrapped
+
+
+def separate_timing(func):
+    """
+    Exclude the timing information for a function that runs during request processing from the overall request’s metrics, allowing them to be recorded separately.
+    """
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        request = get_current_request()
+
+        outer_sql_times = request.sql_times
+        outer_memcached_times = request.memcached_times
+        request.sql_times = []
+        request.memcached_times = []
+
+        start = time.perf_counter()
+        ret = func(*args, **kwargs)
+        duration = time.perf_counter() - start
+
+        request.sql_times = outer_sql_times
+        request.memcached_times = outer_memcached_times
+        request.excluded_time += duration
+
+        return ret
+
+    return wrapped

--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -174,10 +174,11 @@ def db_timer_tween_factory(handler, registry):
 
     def db_timer_tween(request):
         started_at = time.perf_counter()
+        request.excluded_time = 0.0
         request.sql_times = []
         request.memcached_times = []
         resp = handler(request)
-        time_total = time.perf_counter() - started_at
+        time_total = time.perf_counter() - started_at - request.excluded_time
         request_duration.labels(route=request.matched_route.name if request.matched_route is not None else "none").observe(time_total, exemplar={
             "sql_queries": "%d" % (len(request.sql_times),),
             "sql_seconds": "%.3f" % (sum(request.sql_times),),


### PR DESCRIPTION
Uncached notification count queries can be triggered unpredictably by almost every page and take a highly variable amount of time depending on the user (up to 7 seconds). Keeping this separate should make individual route metrics more useful.