### PR TITLE
Remove "Back"-esque buttons (#1110)

### DIFF
--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -32,7 +32,6 @@ def submission_(request):
         if we.value in ("UserIgnored", "TagBlocked"):
             we.errorpage_kwargs['links'] = [
                 ("View Submission", "?ignore=false"),
-                ("Return to the Home Page", "/"),
             ]
         raise
 
@@ -149,7 +148,6 @@ def character_(request):
         if we.value in ("UserIgnored", "TagBlocked"):
             we.errorpage_kwargs['links'] = [
                 ("View Character", "?ignore=false"),
-                ("Return to the Home Page", "/"),
             ]
         raise
 
@@ -189,7 +187,6 @@ def journal_(request):
         if we.value in ("UserIgnored", "TagBlocked"):
             we.errorpage_kwargs['links'] = [
                 ("View Journal", "?ignore=false"),
-                ("Return to the Home Page", "/"),
             ]
         raise
 

--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -251,7 +251,6 @@ def control_username_post_(request):
         return Response(define.errorpage(
             request.userid,
             "Your username has been changed.",
-            [["Go Back", "/control/username"], ["Return Home", "/"]],
         ))
     elif request.POST['do'] == 'release':
         login.release_username(
@@ -263,7 +262,6 @@ def control_username_post_(request):
         return Response(define.errorpage(
             request.userid,
             "Your old username has been released.",
-            [["Go Back", "/control/username"], ["Return Home", "/"]],
         ))
     else:
         raise WeasylError("Unexpected")
@@ -304,10 +302,7 @@ def control_editemailpassword_post_(request):
     else:  # Changes were made, so inform the user of this
         message = "**Success!** " + return_message
     # Finally return the message about what (if anything) changed to the user
-    return Response(define.errorpage(
-        request.userid, message,
-        [["Go Back", "/control"], ["Return Home", "/"]])
-    )
+    return Response(define.errorpage(request.userid, message))
 
 
 @login_required

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -141,7 +141,7 @@ def signin_2fa_auth_post_(request):
         if two_factor_auth.get_number_of_recovery_codes(tfa_userid) == 0:
             two_factor_auth.force_deactivate(tfa_userid)
             raise WeasylError('TwoFactorAuthenticationZeroRecoveryCodesRemaining',
-                              links=[["2FA Dashboard", "/control/2fa/status"], ["Return to the Home Page", "/"]])
+                              links=[["2FA Dashboard", "/control/2fa/status"]])
         # Return to the target page, restricting to the path portion of 'ref' per urlparse.
         response = HTTPSeeOther(location=urlparse(ref).path)
         response.set_cookie('WZL', request.weasyl_session.sessionid, max_age=60 * 60 * 24 * 365,
@@ -151,7 +151,7 @@ def signin_2fa_auth_post_(request):
         # Hinder brute-forcing the 2FA token or recovery code by enforcing an upper-bound on 2FA auth attempts.
         login.signout(request)
         raise WeasylError('TwoFactorAuthenticationAuthenticationAttemptsExceeded',
-                          links=[["Sign In", "/signin"], ["Return to the Home Page", "/"]])
+                          links=[["Sign In", "/signin"]])
     else:
         # Log the failed authentication attempt to the session and save
         with define.sessionmaker_future.begin() as tx:
@@ -198,7 +198,7 @@ def signup_post_(request):
         "has been sent to the email address you provided with "
         "information on how to complete the registration process. You "
         "should receive this email within the next hour.",
-        [["Return to the Home Page", "/"]]))
+    ))
 
 
 @guest_required
@@ -208,7 +208,7 @@ def verify_account_(request):
         request.userid,
         "**Success!** Your email address has been verified "
         "and you may now sign in to your account.",
-        [["Sign In", "/signin"], ["Return to the Home Page", "/"]]))
+        [["Sign In", "/signin"]]))
 
 
 @login_required
@@ -218,7 +218,6 @@ def verify_emailchange_get_(request):
     return Response(define.errorpage(
         request.userid,
         "**Success!** Your email address was successfully updated to **" + email + "**.",
-        [["Return to the Home Page", "/"]]
     ))
 
 
@@ -236,7 +235,7 @@ def forgetpassword_post_(request):
     return Response(define.errorpage(
         request.userid,
         "**Success!** Information on how to reset your password has been sent to your email address.",
-        [["Return to the Home Page", "/"]]))
+    ))
 
 
 @guest_required
@@ -253,7 +252,7 @@ def resetpassword_get_(request):
         return Response(define.errorpage(
             request.userid,
             "The e-mail address **%s** is not associated with a Weasyl account." % (reset_target.email,),
-            [["Sign Up", "/signup"], ["Return to the Home Page", "/"]]))
+            [["Sign Up", "/signup"]]))
 
     return Response(define.webpage(request.userid, "etc/resetpassword.html", [token, reset_target], options=("signup",), title="Reset Forgotten Password"))
 
@@ -275,7 +274,7 @@ def resetpassword_post_(request):
     return Response(define.errorpage(
         request.userid,
         "**Success!** Your password has been reset and you may now sign in to your account.",
-        [["Sign In", "/signin"], ["Return to the Home Page", "/"]]))
+        [["Sign In", "/signin"]]))
 
 
 @login_required

--- a/weasyl/controllers/weasyl_collections.py
+++ b/weasyl/controllers/weasyl_collections.py
@@ -46,7 +46,7 @@ def collection_offer_(request):
         request.userid,
         "**Success!** Your collection offer has been sent "
         "and the recipient may now add this submission to their gallery.",
-        [["Go Back", "/submission/%i" % (form.submitid,)], ["Return to the Home Page", "/"]]))
+    ))
 
 
 @login_required
@@ -69,7 +69,7 @@ def collection_request_(request):
         request.userid,
         "**Success!** Your collection request has been sent. "
         "The submission author may approve or reject this request.",
-        [["Go Back", "/submission/%i" % (form.submitid,)], ["Return to the Home Page", "/"]]))
+    ))
 
 
 @login_required

--- a/weasyl/templates/admincontrol/acctverifylink.html
+++ b/weasyl/templates/admincontrol/acctverifylink.html
@@ -3,9 +3,4 @@ $:{RENDER("common/stage_title.html", ["Get Confirmation Link", "Administrator Co
 
 <div id="error_content" class="content">
   <p><a href="/verify/account?token=${token}">https://www.weasyl.com/verify/account?token=${token}</a></p>
-
-  <div id="error_buttons">
-    <a href="javascript:void(0);" onclick="window.history.back();" class="button">Go Back</a>
-    <a href="/" class="button">Return to the Home Page</a>
-  </div>
 </div>

--- a/weasyl/templates/admincontrol/manageuser.html
+++ b/weasyl/templates/admincontrol/manageuser.html
@@ -87,7 +87,6 @@ $:{TITLE("User Management", "Administrator Control Panel", "/admincontrol")}
           <p><input type="checkbox" name="remove_social" value="${site}">Remove</p>
 
     <button type="submit" class="button highlighted" style="float: right;">Save Changes</button>
-    <a class="button" href="/admincontrol">Go Back</a>
     <a class="button" href="/~${LOGIN(profile['username'])}">Profile</a>
   </form>
 </div>

--- a/weasyl/templates/admincontrol/siteupdate.html
+++ b/weasyl/templates/admincontrol/siteupdate.html
@@ -27,7 +27,6 @@ $:{TITLE("Submit Site Update" if is_new else "Edit Site Update", "Administrator 
         $else:
           Save site update
       </button>
-      <a class="button" href="/admincontrol">Go Back</a>
     </div>
   </form>
 </div>

--- a/weasyl/templates/control/2fa/disable.html
+++ b/weasyl/templates/control/2fa/disable.html
@@ -22,7 +22,6 @@ $:{RENDER("common/stage_title.html", ["Disable 2FA", "Two-Factor Authentication"
     </div>
 
     <div style="padding-top: 1em;">
-      <a class="button negative" href="/control/2fa/status">Cancel</a>
       <button class="button positive">Disable 2FA</button>
     </div>
   </form>

--- a/weasyl/templates/control/2fa/generate_recovery_codes.html
+++ b/weasyl/templates/control/2fa/generate_recovery_codes.html
@@ -46,7 +46,6 @@ $:{RENDER("common/stage_title.html", ["Generate Recovery Codes", "Two-Factor Aut
     <label><input class="checkbox" type="checkbox" name="verify" required /> I confirm that I have saved the above new recovery codes.</label>
 
     <div style="padding-top: 1em;">
-      <a class="button negative" href="/control/2fa/status">Cancel</a>
       <button class="button positive">Save New Recovery Codes</button>
     </div>
   </form>

--- a/weasyl/templates/control/2fa/generate_recovery_codes_verify_password.html
+++ b/weasyl/templates/control/2fa/generate_recovery_codes_verify_password.html
@@ -20,7 +20,6 @@ $:{RENDER("common/stage_title.html", ["Generate Recovery Codes: Verify Password"
     <input type="password" id="login-pass" class="input" name="password" placeholder="Password" required />
 
     <div style="padding-top: 1em;">
-      <a class="button negative" href="/control/2fa/status">Cancel</a>
       <button class="button positive">Continue</button>
     </div>
   </form>

--- a/weasyl/templates/control/2fa/init.html
+++ b/weasyl/templates/control/2fa/init.html
@@ -39,7 +39,6 @@ $:{RENDER("common/stage_title.html", ["Enable 2FA: Step 1", "Two-Factor Authenti
       <input type="password" id="login-pass" class="input" name="password" placeholder="Password" required />
 
       <div style="padding-top: 1em;">
-        <a class="button negative" href="/control/2fa/status">Cancel</a>
         <button class="button positive">Continue</button>
       </div>
     </form>

--- a/weasyl/templates/control/2fa/init_qrcode.html
+++ b/weasyl/templates/control/2fa/init_qrcode.html
@@ -28,7 +28,6 @@ $:{RENDER("common/stage_title.html", ["Enable 2FA: Step 2", "Two-Factor Authenti
     <input type="text" id="tfa-init-verify" maxlength="7" name="tfaresponse" placeholder="012345" autocomplete="off" required />
 
     <div style="padding-top: 1em;">
-      <a class="button negative" href="/control/2fa/status">Cancel</a>
       <button class="button positive">Continue</button>
     </div>
   </form>

--- a/weasyl/templates/control/2fa/init_verify.html
+++ b/weasyl/templates/control/2fa/init_verify.html
@@ -53,7 +53,6 @@ $:{RENDER("common/stage_title.html", ["Enable 2FA: Final Step", "Two-Factor Auth
     <label><input class="checkbox" type="checkbox" name="verify" required /> I have printed or saved the above recovery codes and want to enable 2FA.</label>
 
     <div style="padding-top: 1em;">
-      <a class="button negative" href="/control/2fa/status">Cancel</a>
       <button class="button positive">Enable 2FA</button>
     </div>
   </form>

--- a/weasyl/templates/control/edit_emailpassword.html
+++ b/weasyl/templates/control/edit_emailpassword.html
@@ -27,6 +27,5 @@ $:{TITLE("Edit Password and Email Address", "Settings", "/control")}
     <script src="${resource_path('js/zxcvbn-check.js')}" async></script>
 
     <button class="button positive" style="float:right;">Save</button>
-    <a class="button" href="/control">Go Back</a>
   </form>
 </div>

--- a/weasyl/templates/control/edit_preferences.html
+++ b/weasyl/templates/control/edit_preferences.html
@@ -100,7 +100,6 @@ $code:
 
     <div style="padding-top: 1em;">
       <button type="submit" class="button positive" style="float:right;">Save</button>
-      <a class="button" href="/control">Go Back</a>
     </div>
   </form>
 </div>

--- a/weasyl/templates/control/edit_profile.html
+++ b/weasyl/templates/control/edit_profile.html
@@ -142,7 +142,6 @@ $code:
 
     <div class="buttons">
       <button type="submit" class="button positive" style="float: right;">Save</button>
-      <a class="button" href="/control">Return to Settings</a>
     </div>
 
   </form>

--- a/weasyl/templates/control/username.html
+++ b/weasyl/templates/control/username.html
@@ -32,7 +32,6 @@ $:{TITLE("Change Username", "Settings", "/control")}
         $if insufficient_days is not None:
           disabled
         >Change Username</button>
-      <a class="button" href="/control">Go Back</a>
     </div>
   </form>
 

--- a/weasyl/templates/edit/character.html
+++ b/weasyl/templates/edit/character.html
@@ -47,7 +47,6 @@ $code:
 
     <div class="buttons clear" style="padding-top: 1em;">
       <button type="submit" class="button" style="float: right;">Save</button>
-      <a class="button" href="/character/${query['charid']}/${SLUG(query['title'])}">Cancel</a>
     </div>
 
   </form>

--- a/weasyl/templates/edit/journal.html
+++ b/weasyl/templates/edit/journal.html
@@ -37,7 +37,6 @@ $code:
 
     <div class="buttons clear" style="padding-top: 1em;">
       <button type="submit" class="button" style="float: right;">Save</button>
-      <a class="button" href="/journal/${query['journalid']}/${SLUG(query['title'])}">Cancel</a>
     </div>
 
   </form>

--- a/weasyl/templates/edit/submission.html
+++ b/weasyl/templates/edit/submission.html
@@ -70,7 +70,6 @@ $code:
 
     <div class="buttons clear" style="padding-top: 1em;">
       <button type="submit" class="button" style="float: right;">Save</button>
-      <a class="button" href="/submission/${query['submitid']}/${SLUG(query['title'])}">Cancel</a>
     </div>
 
   </form>

--- a/weasyl/templates/error/error.html
+++ b/weasyl/templates/error/error.html
@@ -16,8 +16,5 @@ $:{RENDER("common/stage_title.html", ["System Message"])}
     $if(links):
       $for i in links:
         <a href="${i[1]}" class="button">${i[0]}</a>
-    $else:
-      <a href="javascript:void(0);" onclick="window.history.back();" class="button">Go Back</a>
-      <a href="/" class="button">Return to the Home Page</a>
   </div>
 </div>

--- a/weasyl/templates/error/unverified.html
+++ b/weasyl/templates/error/unverified.html
@@ -13,7 +13,5 @@ $:{RENDER("common/stage_title.html", ["Unverified Account"])}
     $if can_vouch:
       <input type="hidden" name="targetid" value="${targetid}">
       <button class="button positive">Vouch for ${target_username}</button>
-
-    <a href="javascript:;" onclick="history.back()" class="button">Go Back</a>
   </form>
 </div>

--- a/weasyl/templates/etc/forgotpassword.html
+++ b/weasyl/templates/etc/forgotpassword.html
@@ -10,7 +10,6 @@ $:{RENDER("common/stage_title.html", ["Reset Forgotten Password"])}
 
     <div class="form-actions">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a href="/" class="button">Return Home</a>
     </div>
   </form>
 

--- a/weasyl/templates/etc/resetpassword.html
+++ b/weasyl/templates/etc/resetpassword.html
@@ -19,7 +19,6 @@ $:{RENDER("common/stage_title.html", ["Reset Forgotten Password"])}
       <script src="${resource_path('js/zxcvbn-check.js')}" async></script>
 
       <button class="button positive" style="float: right;">Continue</button>
-      <a href="/" class="button">Return Home</a>
 
     </form>
 

--- a/weasyl/templates/etc/signup.html
+++ b/weasyl/templates/etc/signup.html
@@ -32,7 +32,6 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
 
     <div style="padding-top: 1em">
       <button type="submit" class="button positive" style="float: right;">Join Weasyl</button>
-      <a class="button" href="/">Cancel</a>
     </div>
 
     <div id="signup-terms">
@@ -40,7 +39,7 @@ $:{RENDER("common/stage_title.html", ["Create a Weasyl Account"])}
       <a href="/policy/tos">Terms of Service</a> and the <a href="/policy/community">Community Guidelines</a>,
       and that you agree to the terms outlined in the <a href="/policy/privacy">Privacy Policy</a>.
       If you accept these policies and conditions, click the <strong>Join Weasyl</strong> button to register;
-      otherwise, click <strong>Cancel</strong> to continue browsing as a guest.
+      otherwise, you may continue browsing as a guest.
     </div>
 
   </form>

--- a/weasyl/templates/manage/banner.html
+++ b/weasyl/templates/manage/banner.html
@@ -10,6 +10,5 @@ $:{RENDER("common/stage_title.html", ["Edit Banner", "Settings"])}
     <p style="padding: 1em 0 2em 0; color: #f00000;">Do not upload a banner that is not suitable for all audiences, as this content can be viewed by anyone.</p>
 
     <button type="submit" class="button positive" style="float: right;">Continue</button>
-    <a class="button" href="/control">Back to Settings</a>
   </form>
 </div>

--- a/weasyl/templates/manage/collection_options.html
+++ b/weasyl/templates/manage/collection_options.html
@@ -19,7 +19,6 @@ $code:
 
     <div>
       <button class="button positive" style="float:right;">Save</button>
-      <a class="button" href="/control">Go Back</a>
     </div>
   </form>
 </div>

--- a/weasyl/templates/manage/folder_options.html
+++ b/weasyl/templates/manage/folder_options.html
@@ -41,7 +41,6 @@ $code:
       </p>
 
       <button type="submit" class="button positive" style="float: right;">Update Settings</button>
-      <a class="button" href="/manage/folders">Back</a>
     </form>
   </div>
 </div>

--- a/weasyl/templates/manage/following_user.html
+++ b/weasyl/templates/manage/following_user.html
@@ -33,7 +33,6 @@ $code:
       </label>
 
       <button type="submit" class="button positive" style="float: right;">Update Settings</button>
-      <a class="button" href="/manage/following">Cancel</a>
     </form>
   </div>
 </div>

--- a/weasyl/templates/manage/tagfilters.html
+++ b/weasyl/templates/manage/tagfilters.html
@@ -21,7 +21,6 @@ $:{RENDER("common/stage_title.html", ["Tag Filters", "Settings"])}
     <div id="tagfilters_content_buttons" class="clear">
       <button class="button positive" name="do" value="create">Create Filter</button>
       <button class="button negative" name="do" value="remove">Remove Filter</button>
-      <a class="button" href="/control" style="float:right">Cancel</a>
     </div>
 
     <h3>Blacklist Filters</h3>

--- a/weasyl/templates/submit/character.html
+++ b/weasyl/templates/submit/character.html
@@ -73,7 +73,6 @@ $:{RENDER("common/stage_title.html", ["Character Profile", "Submit", "/submit"])
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>

--- a/weasyl/templates/submit/journal.html
+++ b/weasyl/templates/submit/journal.html
@@ -42,7 +42,6 @@ $:{RENDER("common/stage_title.html", ["Journal Entry", "Submit", "/submit"])}
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>

--- a/weasyl/templates/submit/literary.html
+++ b/weasyl/templates/submit/literary.html
@@ -94,7 +94,6 @@ $:{TITLE("Literary Artwork", "Submit", "/submit")}
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>

--- a/weasyl/templates/submit/multimedia.html
+++ b/weasyl/templates/submit/multimedia.html
@@ -98,7 +98,6 @@ $:{TITLE("Multimedia Artwork", "Submit", "/submit")}
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>

--- a/weasyl/templates/submit/reupload_cover.html
+++ b/weasyl/templates/submit/reupload_cover.html
@@ -11,7 +11,6 @@ $:{RENDER("common/stage_title.html", ["Reupload Cover Artwork"])}
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>

--- a/weasyl/templates/submit/reupload_submission.html
+++ b/weasyl/templates/submit/reupload_submission.html
@@ -13,7 +13,6 @@ $:{RENDER("common/stage_title.html", ["Submission File", "Manage"])}
     </div>
 
     <div style="text-align:center;margin-top:2em;">
-      <a class="button" href="/${feature}/${targetid}">Go Back</a>
       <input type="submit" class="button positive" value="Reupload File" />
     </div>
   </form>

--- a/weasyl/templates/submit/visual.html
+++ b/weasyl/templates/submit/visual.html
@@ -93,7 +93,6 @@ $:{TITLE("Visual Artwork", "Submit", "/submit")}
 
     <div class="buttons clear">
       <button type="submit" class="button positive" style="float: right;">Continue</button>
-      <a class="button" href="/">Return Home</a>
     </div>
 
   </form>


### PR DESCRIPTION
I know the original issue (#1110) only talked about removing buttons that acted like `history.back();`, but based on the discussion about preferring people to use the back button in their browser and global site navigation, I looked for and removed many of the "back"-style buttons. Please let me know if this is way too overzealous and I can trim this back.