### PR TITLE
Implement friends-only indicator (#1104)

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -1017,6 +1017,19 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     text-indent: 150%;
     z-index: 3;
 }
+.avatar-grid .friends-only {
+    width: 33px;
+    height: 33px;
+    border-style: solid;
+    border-width: 4px 4px 0 0;
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    color: transparent;
+    overflow: hidden;
+    text-indent: 150%;
+    z-index: 3;
+}
 
 
 
@@ -1116,6 +1129,7 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     box-sizing: border-box;
     display: block;
     position: relative;
+    top: 2px; /* make room for friends-only indicator */
 
     img {
         display: block;
@@ -1158,11 +1172,27 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     text-indent: 150%;
     z-index: 3;
 }
+.thumbnail-grid .friends-only {
+    width: 40px;
+    height: 40px;
+    border-style: solid;
+    border-width: 4px 4px 0 0;
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    color: transparent;
+    overflow: hidden;
+    text-indent: 150%;
+    z-index: 3;
+}
 .rating.mature {
     border-color: #ab2;
 }
 .rating.explicit {
     border-color: #b91e23;
+}
+.friends-only {
+    border-color: pink;
 }
 
 .thumbnail-grid .input-checkbox {
@@ -1216,6 +1246,10 @@ a:hover .icon-report, button:hover .icon-report { background-position: -20px -24
     .thumbnail-grid .rating {
         width: 30px;
         height: 30px;
+    }
+    .thumbnail-grid .friends-only {
+        width: 20px;
+        height: 20px;
     }
     .tiny-footprint .item:nth-child(n+2),
     .small-footprint .item:nth-child(n+4),
@@ -3287,11 +3321,26 @@ img + #detail-art-text {
     width: 100%;
     height: 0;
     border-style: solid;
-    border-width: 0 0 2px;
+    border-width: 0 0 2px 0;
     position: absolute;
     right: -2px;
     left: -2px;
     bottom: -2px;
+    color: transparent;
+    overflow: hidden;
+    text-indent: 150%;
+    z-index: 3;
+    opacity: 0.6;
+}
+.detail-folder-nav .friends-only {
+    width: 100%;
+    height: 0;
+    border-style: solid;
+    border-width: 2px 0 0 0;
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    left: -2px;
     color: transparent;
     overflow: hidden;
     text-indent: 150%;
@@ -3344,7 +3393,16 @@ img + #detail-art-text {
         bottom: -0.4em;
         opacity: 0.5;
     }
-    .detail-folder-nav .newer .rating {
+    .detail-folder-nav .friends-only {
+        width: 20px;
+        height: 20px;
+        border-width: 2px 2px 0 0;
+        left: auto;
+        top: -0.4em;
+        right: 0.6em;
+        opacity: 0.5;
+    }
+    .detail-folder-nav .newer .rating, .detail-folder-nav .newer .friends-only {
         right: 4.7em;
     }
     .detail-folder-nav .nav-link {
@@ -3362,7 +3420,7 @@ img + #detail-art-text {
     .detail-folder-nav .nav-link:hover .thumb {
         opacity: 1;
     }
-    .detail-folder-nav .nav-link:hover .rating {
+    .detail-folder-nav .nav-link:hover .rating, .detail-folder-nav .nav-link:hover .friends-only {
         opacity: 0.8;
     }
 }

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -338,7 +338,7 @@ def select_count(userid, rating, otherid=None, backid=None, nextid=None):
 
 
 def select_list(userid, rating, limit, otherid=None, backid=None, nextid=None):
-    statement = ["SELECT ch.charid, ch.char_name, ch.rating, ch.unixtime, ch.userid, pr.username, ch.settings "]
+    statement = ["SELECT ch.charid, ch.char_name, ch.rating, ch.unixtime, ch.userid, pr.username, ch.settings, ch.friends_only "]
     statement.extend(select_query(userid, rating, otherid, backid, nextid))
 
     statement.append(" ORDER BY ch.charid%s LIMIT %i" % ("" if backid else " DESC", limit))
@@ -353,6 +353,7 @@ def select_list(userid, rating, limit, otherid=None, backid=None, nextid=None):
             "unixtime": i[3],
             "userid": i[4],
             "username": i[5],
+            "friends_only": i[7],
             "sub_media": fake_media_items(i[0], i[4], define.get_sysname(i[5]), i[6]),
         })
 

--- a/weasyl/collection.py
+++ b/weasyl/collection.py
@@ -69,7 +69,7 @@ def select_count(userid, rating, *, otherid, pending=False, backid=None, nextid=
 
 def select_list(userid, rating, limit, *, otherid, pending=False, backid=None, nextid=None):
     statement = ["SELECT su.submitid, su.title, su.subtype, su.rating, co.unixtime, "
-                 "su.userid, pr.username, cpr.username, cpr.userid "]
+                 "su.userid, pr.username, cpr.username, cpr.userid, su.friends_only "]
     statement.extend(select_query(userid, rating=rating, otherid=otherid, pending=pending,
                                   backid=backid, nextid=nextid))
     statement.append(" ORDER BY co.unixtime%s LIMIT %i" % ("" if backid else " DESC", limit))
@@ -88,6 +88,7 @@ def select_list(userid, rating, limit, *, otherid, pending=False, backid=None, n
             "username": i[6],  # username of creator
             "collector": i[7],  # username of collector
             "collectorid": i[8],
+            "friends_only": i[9],
             "sub_media": media.get_submission_media(i[0]),
         })
 

--- a/weasyl/favorite.py
+++ b/weasyl/favorite.py
@@ -49,7 +49,7 @@ def select_submit_count(userid, rating, otherid, backid=None, nextid=None):
 
 
 def select_submit(userid, rating, limit, otherid, backid=None, nextid=None):
-    statement = ["SELECT su.submitid, su.title, su.rating, fa.unixtime, su.userid, pr.username, su.subtype"]
+    statement = ["SELECT su.submitid, su.title, su.rating, fa.unixtime, su.userid, pr.username, su.subtype, su.friends_only"]
     statement.extend(select_submit_query(userid, rating, otherid, backid, nextid))
 
     statement.append(" ORDER BY fa.unixtime%s LIMIT %i" % ("" if backid else " DESC", limit))
@@ -63,6 +63,7 @@ def select_submit(userid, rating, limit, otherid, backid=None, nextid=None):
         "userid": i[4],
         "username": i[5],
         "subtype": i[6],
+        "friends_only": i[7],
     } for i in d.execute("".join(statement))]
     media.populate_with_submission_media(query)
 
@@ -71,7 +72,7 @@ def select_submit(userid, rating, limit, otherid, backid=None, nextid=None):
 
 def select_char(userid, rating, limit, otherid, backid=None, nextid=None):
     statement = ["""
-        SELECT ch.charid, ch.char_name, ch.rating, fa.unixtime, ch.userid, pr.username, ch.settings
+        SELECT ch.charid, ch.char_name, ch.rating, fa.unixtime, ch.userid, pr.username, ch.settings, ch.friends_only
         FROM favorite fa
             INNER JOIN character ch ON fa.targetid = ch.charid
             INNER JOIN profile pr ON ch.userid = pr.userid
@@ -113,6 +114,7 @@ def select_char(userid, rating, limit, otherid, backid=None, nextid=None):
         "unixtime": i[3],
         "userid": i[4],
         "username": i[5],
+        "friends_only": i[7],
         "sub_media": character.fake_media_items(i[0], i[4], d.get_sysname(i[5]), i[6]),
     } for i in d.execute("".join(statement))]
 
@@ -121,7 +123,7 @@ def select_char(userid, rating, limit, otherid, backid=None, nextid=None):
 
 def select_journal(userid, rating, limit, otherid, backid=None, nextid=None):
     statement = ["""
-        SELECT jo.journalid, jo.title, jo.rating, fa.unixtime, jo.userid, pr.username, pr.config
+        SELECT jo.journalid, jo.title, jo.rating, fa.unixtime, jo.userid, pr.username, pr.config, jo.friends_only
         FROM favorite fa
             INNER JOIN journal jo ON fa.targetid = jo.journalid
             INNER JOIN profile pr ON jo.userid = pr.userid
@@ -162,6 +164,7 @@ def select_journal(userid, rating, limit, otherid, backid=None, nextid=None):
         "unixtime": i[3],
         "userid": i[4],
         "username": i[5],
+        "friends_only": i[7],
     } for i in d.execute("".join(statement))]
     media.populate_with_user_media(query)
 

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -163,7 +163,7 @@ def select_view_api(userid, journalid, anyway=False, increment_views=False):
 
 def select_user_list(userid, rating, limit, backid=None, nextid=None):
     statement = [
-        "SELECT jo.journalid, jo.title, jo.userid, pr.username, jo.rating, jo.unixtime"
+        "SELECT jo.journalid, jo.title, jo.userid, pr.username, jo.rating, jo.unixtime, jo.friends_only"
         " FROM journal jo"
         " JOIN profile pr ON jo.userid = pr.userid"
         " WHERE NOT jo.hidden"]
@@ -195,6 +195,7 @@ def select_user_list(userid, rating, limit, backid=None, nextid=None):
         "username": i[3],
         "rating": i[4],
         "unixtime": i[5],
+        "friends_only": i[6],
     } for i in d.execute("".join(statement))]
     media.populate_with_user_media(query)
 

--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -117,6 +117,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 pr.username,
                 ch.settings,
                 we.welcomeid,
+                ch.friends_only,
                 0 AS subtype
                 {char_tags_select}
             FROM welcome we
@@ -142,6 +143,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 pr.username,
                 ''::text AS settings,
                 we.welcomeid,
+                su.friends_only,
                 su.subtype
                 {submission_tags_select}
             FROM welcome we
@@ -166,6 +168,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
                 pr.username,
                 ''::text AS settings,
                 we.welcomeid,
+                su.friends_only,
                 su.subtype
                 {submission_tags_select}
             FROM welcome we
@@ -212,6 +215,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
             "userid": i.userid,
             "username": i.username,
             "subtype": i.subtype,
+            "friends_only": i.friends_only,
             "tags": [tag_map[tag] for tag in i.tags],
             "sub_media": _fake_media_items(i),
         } for i in query]
@@ -226,6 +230,7 @@ def select_submissions(userid, limit, include_tags, backtime=None, nexttime=None
             "userid": i.userid,
             "username": i.username,
             "subtype": i.subtype,
+            "friends_only": i.friends_only,
             "sub_media": _fake_media_items(i),
         } for i in query]
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -855,7 +855,7 @@ def select_list(
         "rating", "unixtime", "userid", "username", "subtype", "sub_media"
     """
     statement = "".join((
-        "SELECT su.submitid, su.title, su.rating, su.unixtime, su.userid, pr.username, su.subtype ",
+        "SELECT su.submitid, su.title, su.rating, su.unixtime, su.userid, pr.username, su.subtype, su.friends_only ",
         *_select_query(
             userid=userid,
             rating=rating,
@@ -891,7 +891,7 @@ def select_featured(userid, otherid, rating):
 
 def select_near(userid, rating, limit, otherid, folderid, submitid):
     statement = ["""
-        SELECT su.submitid, su.title, su.rating, su.unixtime, su.subtype
+        SELECT su.submitid, su.title, su.rating, su.unixtime, su.subtype, su.friends_only
           FROM submission su
          WHERE su.userid = %(owner)s
                AND NOT su.hidden
@@ -929,6 +929,7 @@ def select_near(userid, rating, limit, otherid, folderid, submitid):
         "rating": i[2],
         "unixtime": i[3],
         "subtype": i[4],
+        "friends_only": i[5],
     } for i in d.engine.execute(statement, {
         "owner": otherid,
         "submitid": submitid,

--- a/weasyl/templates/common/thumbnail_grid_item.html
+++ b/weasyl/templates/common/thumbnail_grid_item.html
@@ -48,6 +48,9 @@ $def with (query, *, notifications=False, include_byline=True, lazy_load=True)
       $elif query['rating'] == R.EXPLICIT.code:
         <span class="rating explicit">The following submission is rated Explicit:</span>
 
+      $if query.get('friends_only', False):
+        <span class="friends-only">The following submission is for friends only:</span>
+
       $if query['contype'] in (30, 50):
         <img src="${avatar['display_url']}" alt="avatar" />
       $elif webp_thumb is not None:

--- a/weasyl/templates/detail/submission.html
+++ b/weasyl/templates/detail/submission.html
@@ -130,6 +130,8 @@ $code:
               <span class="rating mature">The following submission is rated Mature:</span>
             $elif i['rating'] == R.EXPLICIT.code:
               <span class="rating explicit">The following submission is rated Explicit:</span>
+            $if i['friends_only']:
+              <span class="friends-only">The following submission is for friends only:</span>
             <img src="${thumb['display_url']}" alt="${i['title']}" class="thumb" />
           </a>
 
@@ -149,6 +151,8 @@ $code:
               <span class="rating mature">The following submission is rated Mature:</span>
             $elif i['rating'] == R.EXPLICIT.code:
               <span class="rating explicit">The following submission is rated Explicit:</span>
+            $if i['friends_only']:
+              <span class="friends-only">The following submission is for friends only:</span>
             <img src="${thumb['display_url']}" alt="${i['title']}" class="thumb" />
             <span class="text">Newer &#187;</span>
           </a>


### PR DESCRIPTION
Implements #1104.

Some notes:
- I added the friends-only indicator everywhere the existing mature/explicit indicator exists. The exception is in the critique section of the homepage, since I believe the underlying SQL query there explicitly filters out all friends-only submissions, even if the current user can see them?
- Since this is less important than the mature/explicit indicator, I made the new one about 2/3 the size of the existing one. This also solves a space constraint problem when displaying journals.
- I noticed that a user's journal page (`/journals/username`) doesn't currently show mature/explicit indicators, so I left that page alone. Maybe I could open an issue for that one and take a look into adding indicator support in general as a separate item.
- I chose `pink` instead of eyedropper-picking the existing color for Friends Only because I feel it is too close to the color used by the explicit indicator and could be therefore be confusing.

# Examples of how this looks

![image](https://github.com/user-attachments/assets/4c11ef65-c6a9-451b-b0f3-0b8249c62015)

![image](https://github.com/user-attachments/assets/43343bcd-5566-416c-80e8-6840be204a1d)

![image](https://github.com/user-attachments/assets/50245fa6-718a-4ad6-ada9-1091157f1242)

![image](https://github.com/user-attachments/assets/c00e11f4-485a-4222-a1d1-0dc4974d55a0)
