### PR TITLE
Start adding type annotations to libweasyl

### DIFF
--- a/libweasyl/cache.py
+++ b/libweasyl/cache.py
@@ -9,7 +9,6 @@ project.
 
 import json
 import threading
-from typing import Any
 
 import dogpile.cache
 import dogpile.cache.backends.memcached
@@ -51,7 +50,7 @@ class ThreadCacheProxy(ProxyBackend):
             pass
 
     @property
-    def _dict(self) -> dict[str, Any]:
+    def _dict(self):
         """
         Get the cache dict for the current thread.
 
@@ -62,7 +61,7 @@ class ThreadCacheProxy(ProxyBackend):
             self._local.cache_dict = {}
         return self._local.cache_dict
 
-    def get(self, key: str) -> Any:
+    def get(self, key):
         """
         Proxy a ``get`` call.
 
@@ -87,7 +86,7 @@ class ThreadCacheProxy(ProxyBackend):
             d[key] = ret
         return ret
 
-    def get_multi(self, keys: list[str]) -> list[Any]:
+    def get_multi(self, keys):
         """
         Proxy a ``get_multi`` call.
 
@@ -116,7 +115,7 @@ class ThreadCacheProxy(ProxyBackend):
             d[key] = ret[index] = value
         return ret
 
-    def set(self, key: str, value: Any):
+    def set(self, key, value):
         """
         Proxy a ``set`` call.
 
@@ -130,7 +129,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict[key] = value
         self.proxied.set(key, value)
 
-    def set_multi(self, pairs: dict[str, Any]):
+    def set_multi(self, pairs):
         """
         Proxy a ``set_multi`` call.
 
@@ -144,7 +143,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict.update(pairs)
         self.proxied.set_multi(pairs)
 
-    def delete(self, key: str):
+    def delete(self, key):
         """
         Proxy a ``delete`` call.
 
@@ -157,7 +156,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict.pop(key, None)
         self.proxied.delete(key)
 
-    def delete_multi(self, keys: list[str]):
+    def delete_multi(self, keys):
         """
         Proxy a ``delete_multi`` call.
 
@@ -177,10 +176,10 @@ class JsonClient(pylibmc.Client):
     A pylibmc.Client that stores only dogpile.cache entries, as JSON.
     """
 
-    def serialize(self, value: Any) -> tuple[bytes, int]:
+    def serialize(self, value):
         return json.dumps(value).encode('ascii'), 0
 
-    def deserialize(self, bytestring: bytes, flag) -> CachedValue:
+    def deserialize(self, bytestring, flag):
         payload, metadata = json.loads(bytestring)
         return CachedValue(payload, metadata)
 
@@ -190,7 +189,7 @@ class JsonPylibmcBackend(dogpile.cache.backends.memcached.PylibmcBackend):
     def _imports(self):
         pass
 
-    def _create_client(self) -> JsonClient:
+    def _create_client(self):
         return JsonClient(
             self.url,
             binary=self.binary,

--- a/libweasyl/cache.py
+++ b/libweasyl/cache.py
@@ -9,6 +9,7 @@ project.
 
 import json
 import threading
+from typing import Any
 
 import dogpile.cache
 import dogpile.cache.backends.memcached
@@ -50,7 +51,7 @@ class ThreadCacheProxy(ProxyBackend):
             pass
 
     @property
-    def _dict(self):
+    def _dict(self) -> dict[str, Any]:
         """
         Get the cache dict for the current thread.
 
@@ -61,7 +62,7 @@ class ThreadCacheProxy(ProxyBackend):
             self._local.cache_dict = {}
         return self._local.cache_dict
 
-    def get(self, key):
+    def get(self, key: str) -> Any:
         """
         Proxy a ``get`` call.
 
@@ -86,7 +87,7 @@ class ThreadCacheProxy(ProxyBackend):
             d[key] = ret
         return ret
 
-    def get_multi(self, keys):
+    def get_multi(self, keys: list[str]) -> list[Any]:
         """
         Proxy a ``get_multi`` call.
 
@@ -115,7 +116,7 @@ class ThreadCacheProxy(ProxyBackend):
             d[key] = ret[index] = value
         return ret
 
-    def set(self, key, value):
+    def set(self, key: str, value: Any):
         """
         Proxy a ``set`` call.
 
@@ -129,7 +130,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict[key] = value
         self.proxied.set(key, value)
 
-    def set_multi(self, pairs):
+    def set_multi(self, pairs: dict[str, Any]):
         """
         Proxy a ``set_multi`` call.
 
@@ -143,7 +144,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict.update(pairs)
         self.proxied.set_multi(pairs)
 
-    def delete(self, key):
+    def delete(self, key: str):
         """
         Proxy a ``delete`` call.
 
@@ -156,7 +157,7 @@ class ThreadCacheProxy(ProxyBackend):
         self._dict.pop(key, None)
         self.proxied.delete(key)
 
-    def delete_multi(self, keys):
+    def delete_multi(self, keys: list[str]):
         """
         Proxy a ``delete_multi`` call.
 
@@ -176,10 +177,10 @@ class JsonClient(pylibmc.Client):
     A pylibmc.Client that stores only dogpile.cache entries, as JSON.
     """
 
-    def serialize(self, value):
+    def serialize(self, value: Any) -> tuple[bytes, int]:
         return json.dumps(value).encode('ascii'), 0
 
-    def deserialize(self, bytestring, flag):
+    def deserialize(self, bytestring: bytes, flag) -> CachedValue:
         payload, metadata = json.loads(bytestring)
         return CachedValue(payload, metadata)
 
@@ -189,7 +190,7 @@ class JsonPylibmcBackend(dogpile.cache.backends.memcached.PylibmcBackend):
     def _imports(self):
         pass
 
-    def _create_client(self):
+    def _create_client(self) -> JsonClient:
         return JsonClient(
             self.url,
             binary=self.binary,

--- a/libweasyl/configuration.py
+++ b/libweasyl/configuration.py
@@ -7,14 +7,31 @@ parameterizing modules, but we can't, so this is what we have. It does mean
 that only one libweasyl configuration can exist in a running python process.
 """
 
-from libweasyl.models.media import MediaItem
+from collections.abc import Iterable
+import os
+from typing import Callable, TypedDict
+
+from sqlalchemy.orm import scoped_session
+
+from libweasyl.models.media import MediaItem, SubmissionMediaLink, UserMediaLink
 from libweasyl.models.meta import _configure_dbsession
 from libweasyl.staff import _init_staff
 
 
+StaffConfigDict = TypedDict('StaffConfigDict', {
+    'directors': Iterable[int],
+    'technical_staff': Iterable[int],
+    'admins': Iterable[int],
+    'mods': Iterable[int],
+    'developers': Iterable[int],
+    'wesley': int | None,
+})
+
+
 def configure_libweasyl(
-        dbsession, base_file_path,
-        staff_config_dict, media_link_formatter_callback):
+        dbsession: scoped_session, base_file_path: str | bytes | os.PathLike,
+        staff_config_dict: StaffConfigDict,
+        media_link_formatter_callback: Callable[[MediaItem, SubmissionMediaLink | UserMediaLink], str | None]):
     """
     Configure libweasyl for the current application. This sets up some
     global state around libweasyl.

--- a/libweasyl/defang.py
+++ b/libweasyl/defang.py
@@ -7,6 +7,9 @@ HTML defanging.
 import re
 from urllib.parse import urlparse
 
+from lxml import etree
+
+
 allowed_tags = {
     "section", "nav", "article", "aside",
     "h1", "h2", "h3", "h4", "h5", "h6",
@@ -77,7 +80,7 @@ color: \s* (?:
 """, re.X | re.I)
 
 
-def get_scheme(url):
+def get_scheme(url: str) -> str | None:
     """
     Get the scheme from a URL, if the URL is valid.
 
@@ -94,7 +97,7 @@ def get_scheme(url):
         return None
 
 
-def defang(fragment):
+def defang(fragment: etree._Element):
     """
     Remove potentially harmful attributes and elements from an HTML fragment.
 

--- a/libweasyl/files.py
+++ b/libweasyl/files.py
@@ -2,8 +2,10 @@
 File manipulation and detection.
 """
 
+from collections.abc import Sequence
 import errno
 import os
+from typing import TypeVar
 
 from sanpera.exception import SanperaError
 
@@ -12,7 +14,10 @@ from libweasyl.exceptions import InvalidFileFormat, UnknownFileFormat
 from libweasyl import images
 
 
-def makedirs_exist_ok(path):
+T = TypeVar('T')
+
+
+def makedirs_exist_ok(path: str | bytes | os.PathLike):
     """
     Ensure a directory and all of its parent directories exist.
 
@@ -34,7 +39,7 @@ def makedirs_exist_ok(path):
             raise
 
 
-def fanout(name, fanout):
+def fanout(name: Sequence[T], fanout: Sequence[int]) -> list[T]:
     """
     Generate fanout for a particular name.
 
@@ -64,7 +69,7 @@ def fanout(name, fanout):
     return ret
 
 
-def file_type_for_category(data, category):
+def file_type_for_category(data: bytes, category: Category) -> tuple[str | bytes | None, str]:
     """
     Determine the type of a file, given its contents and a submission category.
 

--- a/libweasyl/flash.py
+++ b/libweasyl/flash.py
@@ -7,7 +7,7 @@ import os
 import zlib
 
 
-def iter_decompressed_zlib(fobj: BytesIO, chunksize=1024) -> Generator[bytes, None, None]:
+def iter_decompressed_zlib(fobj: BytesIO, chunksize=1024) -> Generator[int, None, None]:
     """
     An iterator over the decompressed bytes of a zlib-compressed file object.
 

--- a/libweasyl/flash.py
+++ b/libweasyl/flash.py
@@ -1,11 +1,13 @@
+from io import BytesIO
 import itertools
 import lzma
 import struct
+from typing import Generator, TypedDict
 import os
 import zlib
 
 
-def iter_decompressed_zlib(fobj, chunksize=1024):
+def iter_decompressed_zlib(fobj: BytesIO, chunksize=1024) -> Generator[bytes, None, None]:
     """
     An iterator over the decompressed bytes of a zlib-compressed file object.
 
@@ -33,9 +35,16 @@ SIGNATURE_COMPRESSION = {
     b'CWS': 'zlib',
     b'ZWS': 'lzma',
 }
+FlashHeader = TypedDict('FlashHeader', {
+    'compression': str | None,
+    'version': int,
+    'size': int,
+    'width': int,
+    'height': int,
+})
 
 
-def parse_flash_header(fobj):
+def parse_flash_header(fobj: BytesIO) -> FlashHeader:
     """
     Parse (parts of) the header of a flash object.
 

--- a/libweasyl/html.py
+++ b/libweasyl/html.py
@@ -1,7 +1,8 @@
 import json
+from typing import Any
 
 
-def inline_json(obj):
+def inline_json(obj: Any) -> str:
     """
     Format a python object as JSON for inclusion in HTML.
 

--- a/libweasyl/legacy.py
+++ b/libweasyl/legacy.py
@@ -26,7 +26,7 @@ UNIXTIME_NOW_SQL = func.extract('epoch', func.now()).cast(sa.BigInteger()) + sa.
 _SYSNAME_CHARACTERS = frozenset(string.ascii_lowercase + string.digits)
 
 
-def get_sysname(target):
+def get_sysname(target: str) -> str:
     """
     Convert a username to a login name.
 

--- a/libweasyl/media.py
+++ b/libweasyl/media.py
@@ -1,24 +1,24 @@
 from libweasyl.cache import region
-from libweasyl.models.media import MediaItem, SubmissionMediaLink, UserMediaLink
+from libweasyl.models.media import MediaItem, SerializedMediaItem, SubmissionMediaLink, UserMediaLink
 
 
 @SubmissionMediaLink.register_cache
 @region.cache_multi_on_arguments()
-def get_multi_submission_media(*submitids):
+def get_multi_submission_media(*submitids: int) -> list[dict[str, list[SerializedMediaItem]]]:
     return SubmissionMediaLink.bucket_links(submitids)
 
 
 @UserMediaLink.register_cache
 @region.cache_multi_on_arguments()
-def get_multi_user_media(*userids):
+def get_multi_user_media(*userids: int) -> list[dict[str, list[SerializedMediaItem]]]:
     return UserMediaLink.bucket_links(userids)
 
 
-def get_submission_media(submitid):
+def get_submission_media(submitid: int) -> dict[str, list[SerializedMediaItem]]:
     return get_multi_submission_media(submitid)[0]
 
 
-def get_user_media(userid):
+def get_user_media(userid: int) -> dict[str, list[SerializedMediaItem]]:
     return get_multi_user_media(userid)[0]
 
 

--- a/libweasyl/models/api.py
+++ b/libweasyl/models/api.py
@@ -17,7 +17,7 @@ class OAuthConsumer(Base):
     owner = relationship(Login, backref='oauth_consumers')
 
     @property
-    def client_id(self):
+    def client_id(self) -> str:
         return self.clientid
 
 

--- a/libweasyl/models/helpers.py
+++ b/libweasyl/models/helpers.py
@@ -1,4 +1,5 @@
 import contextlib
+from typing import TypeVar
 
 import json
 import arrow
@@ -11,7 +12,11 @@ from ..legacy import UNIXTIME_OFFSET
 from .. import ratings
 
 
-def reverse_dict(d):
+T = TypeVar('T')
+U = TypeVar('U')
+
+
+def reverse_dict(d: dict[T, U]) -> dict[U, T]:
     return {v: k for k, v in d.items()}
 
 

--- a/libweasyl/models/media.py
+++ b/libweasyl/models/media.py
@@ -27,7 +27,7 @@ class MediaItem(Base):
     __table__ = tables.media
 
     @classmethod
-    def fetch_or_create(cls, data, file_type=None, im=None, attributes=()):
+    def fetch_or_create(cls, data: bytes, file_type: str | None = None, im=None, attributes=()) -> 'MediaItem':
         sha256 = hashlib.sha256(data).hexdigest()
         obj = (cls.query
                .filter(cls.sha256 == sha256)
@@ -70,7 +70,7 @@ class MediaItem(Base):
         ret['display_url'] = self._media_link_formatter_callback(self, link) or self.display_url
         return ret
 
-    def ensure_cover_image(self, source_image):
+    def ensure_cover_image(self, source_image) -> 'MediaItem':
         if self.file_type not in {'jpg', 'png', 'gif'}:
             raise ValueError('can only auto-cover image media items')
 
@@ -85,23 +85,23 @@ class MediaItem(Base):
         return cover_media_item
 
     @property
-    def display_url(self):
+    def display_url(self) -> str:
         # Dodge a silly AdBlock rule
         return self.file_url.replace('media/ad', 'media/ax')
 
     @property
-    def full_file_path(self):
+    def full_file_path(self) -> str:
         return os.path.join(self._base_file_path, *self._file_path_components)
 
     def as_image(self):
         return images.read(self.full_file_path.encode())
 
     @property
-    def _file_path_components(self):
+    def _file_path_components(self) -> list[str]:
         return ['static', 'media'] + fanout(self.sha256, (2, 2, 2)) + ['%s.%s' % (self.sha256, self.file_type)]
 
     @property
-    def file_url(self):
+    def file_url(self) -> str:
         return '/' + '/'.join(self._file_path_components)
 
 
@@ -109,12 +109,12 @@ class _LinkMixin:
     cache_func = None
 
     @classmethod
-    def refresh_cache(cls, identity):
+    def refresh_cache(cls, identity: int):
         if cls.cache_func:
             cls.cache_func.refresh(identity)
 
     @classmethod
-    def clear_link(cls, identity, link_type):
+    def clear_link(cls, identity: int, link_type):
         (cls.query
          .filter(cls.link_type == link_type)
          .filter(getattr(cls, cls._identity) == identity)
@@ -122,7 +122,7 @@ class _LinkMixin:
         cls.refresh_cache(identity)
 
     @classmethod
-    def make_or_replace_link(cls, identity, link_type, media_item):
+    def make_or_replace_link(cls, identity: int, link_type: str, media_item: MediaItem):
         obj = (cls.query
                .filter(cls.link_type == link_type)
                .filter(getattr(cls, cls._identity) == identity)

--- a/libweasyl/models/meta.py
+++ b/libweasyl/models/meta.py
@@ -1,4 +1,5 @@
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session
 
 from libweasyl.models.tables import metadata
 
@@ -8,7 +9,7 @@ Base = declarative_base(
     class_registry=registry, metadata=metadata)
 
 
-def _configure_dbsession(dbsession):
+def _configure_dbsession(dbsession: scoped_session):
     """
     Called by configure_libweasyl to specify the globally-used SQLAlchemy
     session object.

--- a/libweasyl/ratings.py
+++ b/libweasyl/ratings.py
@@ -3,8 +3,8 @@ import functools
 
 @functools.total_ordering
 class Rating:
-    def __init__(self, code, character, name, nice_name, minimum_age, block_text,
-                 additional_description=None):
+    def __init__(self, code: int, character: str, name: str, nice_name: str, minimum_age: int,
+                 block_text: str, additional_description: str | None = None):
 
         self.code = code
         self.character = character
@@ -52,7 +52,7 @@ CHARACTER_MAP = {rating.character: rating for rating in ALL_RATINGS}
 CODE_TO_NAME = {rating.code: rating.name for rating in ALL_RATINGS}
 
 
-def get_ratings_for_age(age):
+def get_ratings_for_age(age: int | None) -> list[Rating]:
     if age is None:
         return ALL_RATINGS
 

--- a/libweasyl/security.py
+++ b/libweasyl/security.py
@@ -10,7 +10,7 @@ secure_random = random.SystemRandom()
 KEY_CHARACTERS = string.ascii_letters + string.digits
 
 
-def generate_key(size, key_characters=KEY_CHARACTERS):
+def generate_key(size: int, key_characters=KEY_CHARACTERS) -> str:
     """
     Generate a cryptographically-secure random key.
 

--- a/libweasyl/staff.py
+++ b/libweasyl/staff.py
@@ -2,6 +2,8 @@
 Sets of Weasyl staff user ids.
 """
 
+from collections.abc import Iterable
+
 DIRECTORS = frozenset()
 """ Directors have the same powers as admins. """
 
@@ -21,7 +23,9 @@ WESLEY = None
 """ The site mascot. Option for the owner of a site update. """
 
 
-def _init_staff(directors=(), technical_staff=(), admins=(), mods=(), developers=(), wesley=None):
+def _init_staff(directors: Iterable[int] = (), technical_staff: Iterable[int] = (),
+                admins: Iterable[int] = (), mods: Iterable[int] = (),
+                developers: Iterable[int] = (), wesley: int | None = None):
     """
     Populates staff members from passed kwargs.
 

--- a/libweasyl/text.py
+++ b/libweasyl/text.py
@@ -297,7 +297,7 @@ def markdown(target: str) -> str:
     return stripped
 
 
-def _itertext_spaced(element: etree._Element) -> Generator[str]:
+def _itertext_spaced(element: etree._Element) -> Generator[str, None, None]:
     if element.text:
         yield element.text
     elif element.tag == "img" and (alt := element.get("alt")):


### PR DESCRIPTION
I focused on adding type annotations to method parameters and return types. `STYLE_GUIDE.md` does not put any constraints on Python type annotation usage, so I went with the following approach:

- For methods that don't return anything, I left the return type unannotated instead of explicitly stating `-> None`.
- Parameters with defaults were left unannotated since the type is implied by the default value, unless the default value doesn't provide enough type information.
- Unused parameters were left unannotated.
- `__dunder__` methods were left unannotated since my understanding is they are well-known by everything (I could be wrong).
- `self` and `cls` were left unannotated since their types are implied.
- I didn't touch test code.
- I didn't touch `kwargs` since it looks like `typing.Unpack` requires Python 3.11, which is too new.

# Ignored portions

- Not touching methods that just do SQLAlchemy stuff or Pyramid stuff per discussion in the developer chatroom.
- Not touching `images`, `images_new`, or most of `models.media` per discussion in the developer chatroom about sanpera and PIL being replaced with a Rust-based imaging component.
- Not touching interface implementations (`cache`, `oauth`) since my understanding is tools will use the parent class for type information (I could be wrong), and my IDE seems to agree.

# Things I am unsure about

- Stuff related to `media` has been a pain. I tried to do my best, but it feels really messy, and I see that higher layers of code add additional key-value pairs onto `MediaItem.serialize`. I am open to feedback on this, even if the feedback is to hit the undo button on this and the associated changes in `models.media`. Part of this also extends to `configuration.configure_libweasyl`, specifically for `media_link_formatter_callback`.

# Closing thoughts

I started with `libweasyl` since it seems like a manageable piece of the project to bite off in one go. Unsure when I would start on `weasyl`, or how many sub-PRs I would break that into, but starting with `libweasyl` allows me to absorb feedback on how to best proceed with this type of change in the future.