### PR TITLE
Prevent truncation at NUL in SQL query parameters by replacing psycopg2cffi with psycopg2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Test libweasyl
         env:
-          WEASYL_TEST_SQLALCHEMY_URL: postgresql+psycopg2cffi://weasyl@weasyl-database/weasyl_test
+          WEASYL_TEST_SQLALCHEMY_URL: postgresql+psycopg2://weasyl@weasyl-database/weasyl_test
         run: .venv/bin/coverage run -m pytest libweasyl.test libweasyl.models.test
 
       - name: Test weasyl

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM docker.io/library/python:3.10-alpine3.16 AS bdist
 # libffi-dev, openssl-dev: cryptography
 # libmemcached-dev: pylibmc
 # libxml2-dev, libxslt-dev: lxml
-# postgresql-dev: psycopg2cffi
+# postgresql-dev: psycopg2
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     musl-dev gcc g++ make \

--- a/ci/site.config.txt
+++ b/ci/site.config.txt
@@ -10,7 +10,7 @@ origin = http://weasyl-ci.invalid
 profile_responses = false
 
 [sqlalchemy]
-url = postgresql+psycopg2cffi://weasyl@weasyl-database/weasyl
+url = postgresql+psycopg2://weasyl@weasyl-database/weasyl
 
 [memcached]
 servers = weasyl-memcached

--- a/config/site.config.txt.example
+++ b/config/site.config.txt.example
@@ -10,8 +10,8 @@ origin = http://weasyl.localhost:8080
 profile_responses = false
 
 [sqlalchemy]
-url = postgresql+psycopg2cffi://weasyl@postgres/weasyl
-# url = postgresql+psycopg2cffi:///weasyl
+url = postgresql+psycopg2://weasyl@postgres/weasyl
+# url = postgresql+psycopg2:///weasyl
 
 [memcached]
 servers = memcached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
       args:
         version: '${WEASYL_VERSION:-}'
     environment:
-      WEASYL_TEST_SQLALCHEMY_URL: postgresql+psycopg2cffi://weasyl@postgres/weasyl_test
+      WEASYL_TEST_SQLALCHEMY_URL: postgresql+psycopg2://weasyl@postgres/weasyl_test
     volumes:
       - config:/run/config:ro
       - test-cache:/weasyl/.pytest_cache

--- a/libweasyl/alembic/alembic.ini.example
+++ b/libweasyl/alembic/alembic.ini.example
@@ -15,7 +15,7 @@ script_location = libweasyl:alembic
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql+psycopg2cffi://weasyl@postgres/weasyl
+sqlalchemy.url = postgresql+psycopg2://weasyl@postgres/weasyl
 
 
 # Logging configuration

--- a/libweasyl/conftest.py
+++ b/libweasyl/conftest.py
@@ -11,7 +11,7 @@ from libweasyl import cache
 
 
 engine = sa.create_engine(
-    os.environ.get('WEASYL_TEST_SQLALCHEMY_URL', 'postgresql+psycopg2cffi:///weasyl_test'),
+    os.environ.get('WEASYL_TEST_SQLALCHEMY_URL', 'postgresql+psycopg2:///weasyl_test'),
     connect_args={
         'options': '-c TimeZone=UTC',
     },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1006,18 +1006,22 @@ files = [
 twisted = ["twisted"]
 
 [[package]]
-name = "psycopg2cffi"
-version = "2.9.0"
-description = ".. image:: https://travis-ci.org/chtd/psycopg2cffi.svg?branch=master"
+name = "psycopg2"
+version = "2.9.10"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
-    {file = "psycopg2cffi-2.9.0.tar.gz", hash = "sha256:7e272edcd837de3a1d12b62185eb85c45a19feda9e62fa1b120c54f9e8d35c52"},
+    {file = "psycopg2-2.9.10-cp310-cp310-win32.whl", hash = "sha256:5df2b672140f95adb453af93a7d669d7a7bf0a56bcd26f1502329166f4a61716"},
+    {file = "psycopg2-2.9.10-cp310-cp310-win_amd64.whl", hash = "sha256:c6f7b8561225f9e711a9c47087388a97fdc948211c10a4bccbf0ba68ab7b3b5a"},
+    {file = "psycopg2-2.9.10-cp311-cp311-win32.whl", hash = "sha256:47c4f9875125344f4c2b870e41b6aad585901318068acd01de93f3677a6522c2"},
+    {file = "psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4"},
+    {file = "psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067"},
+    {file = "psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e"},
+    {file = "psycopg2-2.9.10-cp39-cp39-win32.whl", hash = "sha256:9d5b3b94b79a844a986d029eee38998232451119ad653aea42bb9220a8c5066b"},
+    {file = "psycopg2-2.9.10-cp39-cp39-win_amd64.whl", hash = "sha256:88138c8dedcbfa96408023ea2b0c369eda40fe5d75002c0964c78f46f11fa442"},
+    {file = "psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11"},
 ]
-
-[package.dependencies]
-cffi = ">=1.0"
-six = "*"
 
 [[package]]
 name = "publicsuffixlist"
@@ -1284,6 +1288,7 @@ files = [
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+psycopg2 = {version = ">=2.7", optional = true, markers = "extra == \"postgresql\""}
 
 [package.extras]
 aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
@@ -1524,4 +1529,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "beef8af2bb51a4500f3da53b4cd1f7df23648f71a24b64fe8d7b6c23de8494bd"
+content-hash = "b7704e27b58d05c2b05678d51ef44692c7ede33508f4651e2b1565ae0691d87a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ bcrypt = "4.0.1"
 dogpile-cache = "1.2.0"
 oauthlib = "2.1.0"
 pillow = "10.3.0"
-psycopg2cffi = "2.9.0"
-sqlalchemy = "1.4.45"
+sqlalchemy = {version = "1.4.45", extras = ["postgresql"]}
 lxml = "4.9.2"
 prometheus-client = "^0.20.0"
 

--- a/weasyl/test/test_define.py
+++ b/weasyl/test/test_define.py
@@ -154,3 +154,10 @@ def test_viewing_own_profile(db):
 
 def test_sysname():
     assert d.get_sysname("ź") == "z"
+
+
+def test_nul():
+    with pytest.raises(ValueError) as err:
+        d.engine.scalar("SELECT %(test)s", test="foo\x00bar")
+
+    assert err.value.args == ("A string literal cannot contain NUL (0x00) characters.",)


### PR DESCRIPTION
Serious flaw of unknown concrete impact on the app.

Markdown rendering has a similar bug (`libweasyl.text.markdown("foo\x00bar") == "<p>foo</p>\n"`), but I don’t think there’s anywhere on the site it can be used to harmful effect if it can even be triggered at all.

Also, psycopg2cffi is unmaintained now with noisy deprecation warnings, and it didn’t fix the issue that was the main motivation for originally trying it.

Production configuration needs to be changed before deployment (both `site.config.txt` and `alembic.ini`), and development configuration needs to be updated with `wzl configure`.

This security fix is already deployed.