### PR TITLE
Add rel="me" to profile links

### DIFF
--- a/weasyl/templates/user/profile.html
+++ b/weasyl/templates/user/profile.html
@@ -93,11 +93,11 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
           <dt>${name}</dt>
           $ info = M.SOCIAL_SITES_BY_NAME.get(name, {})
           $if value.startswith(('http://', 'https://')):
-            <dd><a href="${value}" rel="nofollow ugc">${value}</a></dd>
+            <dd><a href="${value}" rel="me nofollow ugc">${value}</a></dd>
           $elif value.startswith('mailto:'):
             <dd><a href="${value}">${value.partition('mailto:')[2]}</a></dd>
           $elif info.get("url"):
-            <dd><a href="${info["url"] % value}">${value}</a></dd>
+            <dd><a href="${info["url"] % value}" rel="me">${value}</a></dd>
           $else:
             <dd>${value}</dd>
       </dl>


### PR DESCRIPTION
Per discussion in the developer chatroom.

Includes a new, parametrized test for making sure `rel="me"` appears if and only if the given contact info creates a URL link.