### PR TITLE
Remove handling for removed “add more” social links button

### DIFF
--- a/weasyl/controllers/settings.py
+++ b/weasyl/controllers/settings.py
@@ -60,13 +60,6 @@ def control_editprofile_put_(request):
     if len(form.site_names) != len(form.site_values):
         raise WeasylError('Unexpected')
 
-    if 'more' in form:
-        form.username = define.get_display_name(request.userid)
-        form.sorted_user_links = [(name, [value]) for name, value in zip(form.site_names, form.site_values)]
-        form.settings = form.set_commish + form.set_trade + form.set_request
-        form.config = form.profile_display
-        return Response(define.webpage(request.userid, "control/edit_profile.html", [form, form], title="Edit Profile"))
-
     p = orm.Profile()
     p.full_name = form.full_name
     p.catchphrase = form.catchphrase


### PR DESCRIPTION
The button was removed in dbc14312819f7f58c9abe1cd5c3570338678ace9.