### PR TITLE
Ensure shared Docker Compose images are never pulled, even when running without anything built

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
 
   web:
     image: weasyl
+    pull_policy: never
     build: &weasyl-build
       context: .
       args:
@@ -147,6 +148,7 @@ services:
   migrate:
     profiles: [ migrate ]
     image: weasyl
+    pull_policy: never
     build: *weasyl-build
     command:
       - ash
@@ -181,6 +183,7 @@ services:
   revision:
     profiles: [ revision ]
     image: weasyl
+    pull_policy: never
     build: *weasyl-build
     entrypoint:
       - ash


### PR DESCRIPTION
This must be a recent change to Docker Compose (since this happens on a clean `./wzl up -d`, which has been documented in the README as the preferred way to get started for a while), but I haven’t found a corresponding entry in the release notes with a quick look.

To be honest, I don’t know exactly what name it tries to pull in this situation (`_/weasyl`?), and whether there’s a corresponding security issue. I’ve registered the “weasyl” name on Docker Hub in case that ever closes a hole.

I really dislike Docker.