### PR TITLE
Feature/webfinger (1 / X Pull requests for Activitypub support)

### DIFF
--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -17,7 +17,7 @@ from weasyl.controllers import (
     settings,
     two_factor_auth,
     user,
-    weasyl_collections,
+    weasyl_collections, well_known,
 )
 from weasyl import oauth2
 
@@ -346,6 +346,10 @@ routes = (
 
     # Routes for static event pages, such as holidays.
     Route("/events/halloweasyl2014", "events_halloweasyl2014", events.halloweasyl2014_),
+
+    # Routes for activitypub
+    Route("/.well-known/webfinger", "well_known_webfinger", well_known.webfinger),
+    # handled in "profile_" Route("/users/{username}", "activity_pub_user_profile", activitypub.webfinger),
 )
 
 

--- a/weasyl/controllers/well_known.py
+++ b/weasyl/controllers/well_known.py
@@ -24,6 +24,7 @@ def webfinger(request):
     url = define.absolutify_url("")
     domain = url.replace("http://", "").replace("https://", "")
     user = profile.resolve(request.userid, userid, username)
+    # we could also support submissions/journals/collections/characters individually as actors in the future
     userprofile = profile.select_profile(user, viewer=request.userid)
     avatar_url = define.absolutify_url(userprofile['user_media']['avatar'][0]['display_url'])
     if not user:
@@ -45,7 +46,10 @@ def webfinger(request):
             {
                 "rel": "http://webfinger.net/rel/profile-page",
                 "type": "text/html",
-                "href": f"{url}/~{username}"
+                "href": f"{url}/~{username}",
+                "properties": {
+                    "https://www.w3.org/ns/activitystreams#type": "Person"
+                }
             },
             # unsupported, but would be cool?
             # {

--- a/weasyl/controllers/well_known.py
+++ b/weasyl/controllers/well_known.py
@@ -12,7 +12,9 @@ def webfinger(request):
     if not resource or not resource.startswith('acct:'):
         raise WeasylError("Invalid resource parameter")
 
-    if resource.count("@")>2:
+    if resource.count("@") > 2 or resource.count("@") < 1:
+        raise WeasylError("Invalid resource parameter")
+    elif resource.count("@") == 2:
         username = resource.split('@')[1].replace('acct:', '')
     else:
         username = resource.split('@')[0].replace('acct:', '')
@@ -20,18 +22,41 @@ def webfinger(request):
     username = request.matchdict.get('name', username)
     userid = define.get_int(request.params.get('userid'))
     url = define.absolutify_url("")
-    domain = url.replace("http://","").replace("https://","")
+    domain = url.replace("http://", "").replace("https://", "")
     user = profile.resolve(request.userid, userid, username)
+    userprofile = profile.select_profile(user, viewer=request.userid)
+    avatar_url = define.absolutify_url(userprofile['user_media']['avatar'][0]['display_url'])
     if not user:
         raise WeasylError("User not found")
 
     response = {
         "subject": f"acct:{username}@{domain}",
+        "aliases": [
+            f"{url}/user/{username}",
+            f"{url}/profile/{username}",
+            f"{url}/~{username}"
+        ],
         "links": [
             {
                 "rel": "self",
                 "type": "application/activity+json",
                 "href": f"{url}/user/{username}"
+            },
+            {
+                "rel": "http://webfinger.net/rel/profile-page",
+                "type": "text/html",
+                "href": f"{url}/~{username}"
+            },
+            # unsupported, but would be cool?
+            # {
+            #     "rel": "http://schemas.google.com/g/2010#updates-from",
+            #     "type": "application/atom+xml",
+            #     "href": f"{url}/user/{username}.atom"
+            # },
+            {
+                "rel": "http://webfinger.net/rel/avatar",
+                "type": "image/png",
+                "href": f"{avatar_url}"
             }
         ]
     }

--- a/weasyl/controllers/well_known.py
+++ b/weasyl/controllers/well_known.py
@@ -1,0 +1,39 @@
+import json
+
+from pyramid.response import Response
+
+from libweasyl.exceptions import WeasylError
+from weasyl import define, profile
+
+
+def webfinger(request):
+    """Handle WebFinger requests."""
+    resource = request.params.get('resource')
+    if not resource or not resource.startswith('acct:'):
+        raise WeasylError("Invalid resource parameter")
+
+    if resource.count("@")>2:
+        username = resource.split('@')[1].replace('acct:', '')
+    else:
+        username = resource.split('@')[0].replace('acct:', '')
+    define.append_to_log("well_known.webfinger", username=username)
+    username = request.matchdict.get('name', username)
+    userid = define.get_int(request.params.get('userid'))
+    url = define.absolutify_url("")
+    domain = url.replace("http://","").replace("https://","")
+    user = profile.resolve(request.userid, userid, username)
+    if not user:
+        raise WeasylError("User not found")
+
+    response = {
+        "subject": f"acct:{username}@{domain}",
+        "links": [
+            {
+                "rel": "self",
+                "type": "application/activity+json",
+                "href": f"{url}/user/{username}"
+            }
+        ]
+    }
+
+    return Response(json.dumps(response), content_type="application/json", charset="utf-8")


### PR DESCRIPTION
This is the first of probably many pull requests to add activitypub and hopefully activitystream support.

Webfinger will allow another activitypub server like mastodon to see if weasyl can "speak" activitypub it also can be used to lookup users although you will not be able to follow those, yet that will be one of the next pull requests, but all depend on this feature.

> !! we might want to add a config setting for people to opt in to federation feature.

Next steps will be:
- get user profile as json
- ability to follow a user
- outbox implementation so that everything posted on weasyl by a user can be synchronized to the fediverse
    - this is the feature that is very close to RSS feed and could be implemented along with it.

at that point weasyl would be ready to send stuff to the fediverse

inbox features would need to be discussed:
- commenting below a post would be a good post.

I have absolutely no idea how weasyl should render if someone from weasyl wants to follow someone on mastodon, but this isn't possible on wordpress either as far as I'm aware so maybe we don't need it that way.

I leave this as draft until we have discussed the feature here or on gitter.