### PR TITLE
Confirm more 'destructive' actions

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1295,20 +1295,4 @@
             savedTab.click();
         }
     })();
-
-    // Confirm removing friends
-    (function () {
-        var hasUnfriend = $('input[name="action"][value="unfriend"]')[0];
-        if (!hasUnfriend) {
-            return;
-        }
-
-        $('form[name="frienduser"]').on('submit', function (e) {
-            var shouldUnfriend = confirm('Are you sure you wish to remove this friend?');
-
-            if (!shouldUnfriend) {
-                e.preventDefault();
-            }
-        });
-    })();
 })();

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1194,41 +1194,27 @@
                 return;
             }
 
-            var rq = new XMLHttpRequest();
-
-            rq.open('POST', favoriteActionBase + favoriteAction.value, true);
-            rq.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
-
-            rq.onreadystatechange = function () {
-                if (rq.readyState !== 4) {
-                    return;
-                }
-
-                if (rq.status === 200) {
-                    var success;
-
-                    try {
-                        success = JSON.parse(rq.responseText).success;
-                    } catch (e) {}
-
-                    if (success) {
-                        favoriteButton.classList.remove('pending');
-
-                        var newState = favoriteButton.classList.toggle('active');
-                        favoriteButton.replaceChild(document.createTextNode(newState ? ' Favorited' : ' Favorite'), favoriteButton.lastChild);
-                        favoriteAction.value = newState ? 'unfavorite' : 'favorite';
-
-                        return;
-                    }
-                }
-
-                // If there was any error, resubmit the form so the user can see it in full.
-                favoriteForm.submit();
-            };
-
-            rq.send(null);
-
             favoriteButton.classList.add('pending');
+
+            fetch(favoriteActionBase + favoriteAction.value, { method: 'POST' })
+                .then(response => {
+                    if (response.status !== 200)
+                        return Promise.reject({});
+
+                    return response.json();
+                })
+                .then(data => {
+                    if (!data.success)
+                        return Promise.reject({});
+
+                    favoriteButton.classList.remove('pending');
+
+                    var newState = favoriteButton.classList.toggle('active');
+                    favoriteButton.replaceChild(document.createTextNode(newState ? ' Favorited' : ' Favorite'), favoriteButton.lastChild);
+                    favoriteAction.value = newState ? 'unfavorite' : 'favorite';
+                })
+                // If there was any error, resubmit the form so the user can see it in full.
+                .catch(error => favoriteForm.submit());
 
             e.preventDefault();
         }, false);

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1189,7 +1189,10 @@
         var favoriteAction = favoriteForm.querySelector('input[name="action"]');
 
         favoriteForm.addEventListener('submit', function (e) {
-            if (favoriteButton.classList.contains('pending')) {
+            if (
+                favoriteButton.classList.contains('pending')
+                || favoriteAction.value === 'unfavorite' && !confirm('Are you sure you wish to remove this submission from your favorites?')
+            ) {
                 e.preventDefault();
                 return;
             }

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1164,7 +1164,7 @@
         favoriteForm.addEventListener('submit', function (e) {
             if (
                 favoriteButton.classList.contains('pending')
-                || favoriteAction.value === 'unfavorite' && !confirm('Are you sure you wish to remove this submission from your favorites?')
+                || (favoriteAction.value === 'unfavorite' && !confirm('Are you sure you wish to remove this submission from your favorites?'))
             ) {
                 e.preventDefault();
                 return;
@@ -1173,15 +1173,15 @@
             favoriteButton.classList.add('pending');
 
             fetch(favoriteActionBase + favoriteAction.value, { method: 'POST' })
-                .then(response => {
-                    if (response.status !== 200)
-                        return Promise.reject({});
-
-                    return response.json();
-                })
+                .then(response =>
+                    response.ok
+                        ? response.json()
+                        : Promise.reject()
+                )
                 .then(data => {
-                    if (!data.success)
-                        return Promise.reject({});
+                    if (!data.success) {
+                        return Promise.reject();
+                    }
 
                     favoriteButton.classList.remove('pending');
 
@@ -1190,7 +1190,9 @@
                     favoriteAction.value = newState ? 'unfavorite' : 'favorite';
                 })
                 // If there was any error, resubmit the form so the user can see it in full.
-                .catch(error => favoriteForm.submit());
+                .catch(error => {
+                    favoriteForm.submit();
+                });
 
             e.preventDefault();
         });

--- a/weasyl/templates/common/user_tools.html
+++ b/weasyl/templates/common/user_tools.html
@@ -54,7 +54,10 @@ $def with (profile, userinfo, relationship)
               <button type="submit"><span class="icon icon-20 icon-star"></span> Follow</button>
           </form></li>
 
-          <li><form name="frienduser" action="/frienduser" method="post">
+          <li><form name="frienduser" action="/frienduser" method="post"
+            $if relationship['friend']:
+              data-confirm="Are you sure you wish to remove this friend?"
+          >
             <input type="hidden" name="userid" value="${profile['userid']}" />
             <input type="hidden" name="feature" value="user" />
             $if(relationship['friendreq']):

--- a/weasyl/templates/common/user_tools.html
+++ b/weasyl/templates/common/user_tools.html
@@ -76,7 +76,10 @@ $def with (profile, userinfo, relationship)
 
           <li><a href="/notes/compose?recipient=${LOGIN(profile['username'])}"><span class="icon icon-20 icon-pencil"></span> Message</a></li>
 
-          <li><form name="ignoreuser" action="/ignoreuser" method="post">
+          <li><form name="ignoreuser" action="/ignoreuser" method="post"
+            $if not relationship['ignore']:
+              data-confirm="Are you sure you wish to ignore this user?"
+          >
             <input type="hidden" name="userid" value="${profile['userid']}" />
             $if(relationship['ignore']):
               <input type="hidden" name="action" value="unignore" />

--- a/weasyl/templates/common/user_tools.html
+++ b/weasyl/templates/common/user_tools.html
@@ -44,7 +44,10 @@ $def with (profile, userinfo, relationship)
       <ul id="user-actions" class="toolset clear">
 
         $if not relationship['is_self']:
-          <li><form name="followuser" action="/followuser" method="post">
+          <li><form name="followuser" action="/followuser" method="post"
+            $if relationship['follow']:
+              data-confirm="Are you sure you wish to unfollow this user?"
+          >
             <input type="hidden" name="userid" value="${profile['userid']}" />
             $if(relationship['follow']):
               <input type="hidden" name="action" value="unfollow" />


### PR DESCRIPTION
- Add confirmations for the following actions:
  - unfollowing a user
  - unfavoriting a submission
  - ignoring a user
- Replace one-off confirmation logic for unfriending a user with `data-confirm`
- Replace `XMLHttpRequest` with `fetch` in client-side submission favoriting logic

I was not able to cleanly use `data-confirm` for unfavoriting a submission, since the next `submit` event handler, which does the web request to favorite or unfavorite the submission, will then immediately fire regardless of the user's choice for the confirmation dialog. Perhaps the `e.preventDefault();` in the `data-confirm` handler could be changed to ignore all following event handlers instead of just the default event handler, but I didn't pursue this since I don't know if this would break another part of Weasyl.

Closes #1462.