### PR TITLE
Remove duplicate dl.leaders rules in site.scss

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -42,32 +42,6 @@ a:hover {
     display: none;
 }
 
-/* single, two-column dl list items with dashed borders between them */
-dl.leaders dt + dd {
-    border-top: 1px dashed #b4b4b4;
-    margin-top: 0.375em;
-    padding-top: 0.375em;
-}
-
-dl.leaders dt:first-child + dd {
-    border-top: none;
-}
-
-dl.leaders dt {
-    clear: left;
-    float: left;
-    font-weight: 700;
-    padding-top: 0.375em;
-}
-
-dl.leaders dd + dt, dl.leaders dt + dt {
-    padding-top: 0.75em;
-}
-
-dl.leaders dd {
-    text-align: right;
-}
-
 /* Typefaces
 --------------------------------*/
 #page-container, textarea, .typeface-default, button {


### PR DESCRIPTION
The removed section is a duplicate of the following section, minus one additional rule at the end:

https://github.com/Weasyl/weasyl/blob/6fd9b5969b67188e75baa09eeee0255bd36373b2/assets/scss/site.scss#L639-L669