### PR TITLE
Credit Museo font’s designer in minified CSS

### DIFF
--- a/assets/scss/fonts/_museo500.scss
+++ b/assets/scss/fonts/_museo500.scss
@@ -1,3 +1,4 @@
+/*! A font by Jos Buivenga (exljbris) -> www.exljbris.com */
 @font-face {
     font-family: Museo500;
     src:


### PR DESCRIPTION
The license Fontspring associates with the web font version of Museo doesn’t mention this, but it doesn’t hurt.