### PR TITLE
Add more contact sites

### DIFF
--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -209,6 +209,10 @@ SOCIAL_SITES = {
         "name": "Itaku",
         "url": "https://itaku.ee/profile/%s",
     },
+    "patreon": {
+        "name": "Patreon",
+        "url": "https://www.patreon.com/%s",
+    },
     "reddit": {
         "name": "Reddit",
         "url": "https://www.reddit.com/user/%s",
@@ -232,10 +236,6 @@ SOCIAL_SITES = {
     "youtube": {
         "name": "YouTube",
         "url": "https://www.youtube.com/user/%s",
-    },
-    "patreon": {
-        "name": "Patreon",
-        "url": "https://www.patreon.com/%s",
     },
 }
 

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -237,6 +237,10 @@ SOCIAL_SITES = {
         "name": "Tumblr",
         "url": "https://%s.tumblr.com/",
     },
+    "twitch": {
+        "name": "Twitch",
+        "url": "https://twitch.tv/%s",
+    },
     "twitter": {
         "name": "Twitter",
         "url": "https://twitter.com/%s",

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -221,6 +221,10 @@ SOCIAL_SITES = {
         "name": "Picarto",
         "url": "https://picarto.tv/%s",
     },
+    "piczel": {
+        "name": "Piczel",
+        "url": "https://piczel.tv/watch/%s",
+    },
     "reddit": {
         "name": "Reddit",
         "url": "https://www.reddit.com/user/%s",

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -176,6 +176,10 @@ MACRO_SYS_STAFF_CONFIG_PATH = os.path.join(MACRO_SYS_CONFIG_PATH, "weasyl-staff.
 MACRO_CFG_SITE_CONFIG = MACRO_SYS_CONFIG_PATH + "site.config.txt"
 
 SOCIAL_SITES = {
+    "ao3": {
+        "name": "Archive of Our Own",
+        "url": "https://archiveofourown.org/users/%s",
+    },
     "bluesky": {
         "name": "Bluesky",
         "url": "https://bsky.app/profile/%s",

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -217,6 +217,10 @@ SOCIAL_SITES = {
         "name": "Patreon",
         "url": "https://www.patreon.com/%s",
     },
+    "picarto": {
+        "name": "Picarto",
+        "url": "https://picarto.tv/%s",
+    },
     "reddit": {
         "name": "Reddit",
         "url": "https://www.reddit.com/user/%s",

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -225,6 +225,10 @@ SOCIAL_SITES = {
         "name": "Steam",
         "url": "https://steamcommunity.com/id/%s",
     },
+    "telegram": {
+        "name": "Telegram",
+        "url": "https://t.me/%s",
+    },
     "tumblr": {
         "name": "Tumblr",
         "url": "https://%s.tumblr.com/",

--- a/weasyl/macro.py
+++ b/weasyl/macro.py
@@ -209,6 +209,10 @@ SOCIAL_SITES = {
         "name": "Itaku",
         "url": "https://itaku.ee/profile/%s",
     },
+    "kofi": {
+        "name": "Ko-fi",
+        "url": "https://ko-fi.com/%s",
+    },
     "patreon": {
         "name": "Patreon",
         "url": "https://www.patreon.com/%s",


### PR DESCRIPTION
Move Patreon back into the correct spot for the list to be in alphabetical order, then add:
* Archive of Our Own
* Ko-fi
* Picarto
* Piczel
* Telegram
* Twitch

I figured this can be proposed ahead of time while I work on the rest of the contact link redesign.