### PR TITLE
Completely disable OAuth

### DIFF
--- a/weasyl/middleware.py
+++ b/weasyl/middleware.py
@@ -11,6 +11,7 @@ from prometheus_client import Histogram
 from pyramid.decorator import reify
 from pyramid.httpexceptions import (
     HTTPBadRequest,
+    HTTPServiceUnavailable,
     HTTPUnauthorized,
 )
 from pyramid.request import Request as Request_
@@ -369,11 +370,7 @@ def userid_request_property(request):
         return userid
 
     elif authorization:
-        from weasyl.oauth2 import get_userid_from_authorization
-        userid = get_userid_from_authorization(request)
-        if not userid:
-            raise HTTPUnauthorized(www_authenticate=('Bearer', 'realm="Weasyl" error="invalid_token"'))
-        return userid
+        raise HTTPServiceUnavailable()
 
     else:
         sess = request.weasyl_session

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -1,5 +1,4 @@
-import json
-from pyramid.httpexceptions import HTTPBadRequest, HTTPFound
+from pyramid.httpexceptions import HTTPBadRequest, HTTPFound, HTTPServiceUnavailable
 from pyramid.response import Response
 from oauthlib.oauth2 import FatalClientError, OAuth2Error
 
@@ -56,21 +55,12 @@ def authorize_get_(request):
 @token_checked
 @login_required
 def authorize_post_(request):
-    try:
-        credentials = json.loads(request.POST['credentials'])
-    except ValueError:
-        raise HTTPBadRequest()
-    scopes = credentials.pop('scopes')
-    credentials['userid'] = request.userid
-    response_attrs = server.create_authorization_response(
-        *(extract_params(request) + (scopes, credentials)))
-    return OAuthResponse(*response_attrs)
+    return HTTPServiceUnavailable()
 
 
 @disallow_api
 def token_(request):
-    response_attrs = server.create_token_response(*extract_params(request))
-    return OAuthResponse(*response_attrs)
+    return HTTPServiceUnavailable()
 
 
 def get_userid_from_authorization(request, scopes=['wholesite']):


### PR DESCRIPTION
Endpoints under `/api/oauth2` already disabled for a while at the Cloudflare level, but I’m not completely sure that there’s no way to slip a request past that somehow. Hotfix in depth for a global impersonation vulnerability.

(This is the change that I’ve been merging main into before each deployment since finding the OAuth vulnerability. It’s time to stop doing that.)