### PR TITLE
fix: Ensure `searchtag._get_or_create` returns results in correct order

### DIFF
--- a/weasyl/searchtag.py
+++ b/weasyl/searchtag.py
@@ -172,11 +172,9 @@ def _get_or_create(*names: str) -> list[int]:
         ON CONFLICT (title) DO NOTHING
     ''', names=names_list)
 
-    result = d.engine.execute(
-        'SELECT tagid FROM searchtag WHERE title = ANY (%(names)s)',
-        names=names_list)
+    tag_ids = get_ids(names)
 
-    return result.scalars().all()
+    return [tag_ids[name] for name in names]
 
 
 def get_or_create(name):


### PR DESCRIPTION
The order needs to match the input in order for Dogpile to create the right cache entry associations.

This probably caused the tag id confusion bug, though it’s hard to reproduce or test because it depends on PostgreSQL’s query plan. Anyway, it was definitely wrong.