### PR TITLE
dev: Fix media with SHA-256 starting with `ad`

### DIFF
--- a/containers/nginx/nginx.conf
+++ b/containers/nginx/nginx.conf
@@ -77,6 +77,7 @@ http {
         }
 
         location /static/media/ {
+            rewrite ^/static/media/ax/(.*)$ /static/media/ad/$1 break;
             root /weasyl;
             try_files $uri @missing;
         }


### PR DESCRIPTION
See `libweasyl.models.media.MediaItem.display_url`.

This is a symlink in production.