### PR TITLE
Work around pip 23.0.1 dependency resolution bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          .poetry-venv/bin/pip install --require-hashes --only-binary :all: -r poetry-requirements.txt
+          .poetry-venv/bin/pip install --require-hashes --only-binary :all: --no-deps -r poetry-requirements.txt
 
       - name: Create virtualenv
         run: python3 -m venv --system-site-packages .venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ COPY --from=imagemagick6-build --chown=root:root /imagemagick6-build/package-roo
 COPY poetry-requirements.txt ./
 RUN --network=none python3 -m venv .poetry-venv
 RUN --mount=type=cache,id=pip,target=/weasyl/.cache/pip,sharing=locked,uid=1000 \
-    .poetry-venv/bin/pip install --require-hashes --only-binary :all: -r poetry-requirements.txt
+    .poetry-venv/bin/pip install --require-hashes --only-binary :all: --no-deps -r poetry-requirements.txt
 RUN --network=none python3 -m venv .venv
 COPY --chown=weasyl pyproject.toml poetry.lock setup.py ./
 RUN --network=none .poetry-venv/bin/poetry check --lock


### PR DESCRIPTION
pip is resolving a Poetry dependency to a version that isn’t the one we have pinned. Luckily, `--require-hashes` still catches it.

Both `-c requirements.txt` and `--no-deps` can work around the issue.

This was fixed at some point between pip 23.0.1 and the current pip 25.1.1, but I don’t want to add an additional Poetry-style lockfile for a pip upgrade and further bloat the image besides.

We should be able to upgrade to a fresher base image soon enough anyway.