### PR TITLE
cleanup: Remove leftovers of configurable SFW mode rating limit

### DIFF
--- a/libweasyl/alembic/versions/bb2c42b6df18_remove_max_sfw_rating.py
+++ b/libweasyl/alembic/versions/bb2c42b6df18_remove_max_sfw_rating.py
@@ -1,0 +1,22 @@
+"""Remove max_sfw_rating
+
+Revision ID: bb2c42b6df18
+Revises: 63baa2713e72
+Create Date: 2025-06-09 03:43:50.460340
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bb2c42b6df18'
+down_revision = '63baa2713e72'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("UPDATE profile SET jsonb_settings = jsonb_settings - 'max_sfw_rating'")
+
+
+def downgrade():
+    # irreversible!
+    pass

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -904,8 +904,7 @@ def do_manage(my_userid, userid, username=None, full_name=None, catchphrase=None
             d.engine.execute(
                 """
                 UPDATE profile
-                SET config = REGEXP_REPLACE(config, '[ap]', '', 'g'),
-                    jsonb_settings = jsonb_settings - 'max_sfw_rating'
+                SET config = REGEXP_REPLACE(config, '[ap]', '', 'g')
                 WHERE userid = %(user)s
                 """,
                 user=userid,
@@ -967,16 +966,11 @@ class ProfileSettings:
             self.default = default
             self.typecast = typecast
 
-    def _valid_rating(rating):
-        rating = int(rating)
-        return rating if rating in ratings.CODE_MAP else ratings.GENERAL.code
-
     _raw_settings = {}
     _settings = {
         "allow_collection_requests": Setting(True, bool),
         "allow_collection_notifs": Setting(True, bool),
         "disable_custom_thumbs": Setting(False, bool),
-        "max_sfw_rating": Setting(ratings.GENERAL.code, _valid_rating),
     }
 
     def __init__(self, json):


### PR DESCRIPTION
The change has been deployed for a while and we’re probably not going to roll it back, so it’s fine to leave any unlikely recovery needs to database backups.

The migration can run before or after web server deployment.