### PR TITLE
Remove trailing “Posted using PostyBirb” from excerpts

### DIFF
--- a/libweasyl/text.py
+++ b/libweasyl/text.py
@@ -325,6 +325,9 @@ def markdown_excerpt(markdown_text, length=300):
     fragment = _markdown_fragment(markdown_text)
     text = _normalize_whitespace("".join(_itertext_spaced(fragment)))
 
+    # TODO: more generic footer removal
+    text = text.removesuffix("Posted using PostyBirb").rstrip()
+
     if len(text) <= length:
         return text
     else:


### PR DESCRIPTION
Footers are noise in excerpts. In the future, I’d like to do more generic footer removal and include dedicated reusable blocks (including footers) as a feature with the upcoming rich text editor, but for now, this is by far the most common footer.