### PR TITLE
Remove Techs role

### DIFF
--- a/assets/scss/site.scss
+++ b/assets/scss/site.scss
@@ -4068,7 +4068,7 @@ a.user-icon:hover > span, a.user-icon:focus > span {
     color: #304bb2;
 }
 
-.user-type-tech, .user-type-dev {
+.user-type-dev {
     color: #c90;
 }
 

--- a/config/weasyl-staff.example.py
+++ b/config/weasyl-staff.example.py
@@ -11,10 +11,6 @@ directors = [
     2402,   # SkylerBunny
 ]
 
-technical_staff = [
-    5173,   # Keet
-]
-
 admins = [
     1014,   # Fiz
     20418,  # Novacaine

--- a/libweasyl/staff.py
+++ b/libweasyl/staff.py
@@ -5,9 +5,6 @@ Sets of Weasyl staff user ids.
 DIRECTORS = frozenset()
 """ Directors have the same powers as admins. """
 
-TECHNICAL = frozenset()
-""" Technical staff can moderate all content and manage all users. """
-
 ADMINS = frozenset()
 """ Site administrators can update site news and moderate user content. """
 
@@ -21,13 +18,12 @@ WESLEY = None
 """ The site mascot. Option for the owner of a site update. """
 
 
-def _init_staff(directors=(), technical_staff=(), admins=(), mods=(), developers=(), wesley=None):
+def _init_staff(directors=(), admins=(), mods=(), developers=(), wesley=None):
     """
     Populates staff members from passed kwargs.
 
     Parameters:
         directors: Array with directors
-        technical_staff: Array with technical staff
         admins: array with admins
         mods: Array with mods
         developers: Array with developers
@@ -35,11 +31,8 @@ def _init_staff(directors=(), technical_staff=(), admins=(), mods=(), developers
     global DIRECTORS
     DIRECTORS = frozenset(directors)
 
-    global TECHNICAL
-    TECHNICAL = DIRECTORS | frozenset(technical_staff)
-
     global ADMINS
-    ADMINS = TECHNICAL | frozenset(admins)
+    ADMINS = DIRECTORS | frozenset(admins)
 
     global MODS
     MODS = ADMINS | frozenset(mods)

--- a/libweasyl/test/data/weasyl-staff.yaml
+++ b/libweasyl/test/data/weasyl-staff.yaml
@@ -8,9 +8,6 @@ directors:
     - 5      # Taw
     - 2008   # Tiger
 
-technical_staff:
-    - 5173   # Keet
-
 admins:
     - 3      # Kihari
     - 2011   # MLR

--- a/weasyl/controllers/admin.py
+++ b/weasyl/controllers/admin.py
@@ -91,7 +91,7 @@ def admincontrol_manageuser_get_(request):
 
     if not otherid:
         raise WeasylError("userRecordMissing")
-    if request.userid != otherid and otherid in staff.ADMINS and request.userid not in staff.TECHNICAL:
+    if request.userid != otherid and otherid in staff.ADMINS and request.userid not in staff.DIRECTORS:
         raise WeasylError('InsufficientPermissions')
 
     return Response(d.webpage(request.userid, "admincontrol/manageuser.html", [
@@ -105,7 +105,7 @@ def admincontrol_manageuser_get_(request):
 def admincontrol_manageuser_post_(request):
     userid = d.get_int(request.params.get('userid', ''))
 
-    if request.userid != userid and userid in staff.ADMINS and request.userid not in staff.TECHNICAL:
+    if request.userid != userid and userid in staff.ADMINS and request.userid not in staff.DIRECTORS:
         raise WeasylError('InsufficientPermissions')
 
     profile.do_manage(request.userid, userid,

--- a/weasyl/controllers/info.py
+++ b/weasyl/controllers/info.py
@@ -17,16 +17,14 @@ def _help_page(template, *, title):
 
 def staff_(request):
     directors = staff.DIRECTORS
-    technical = staff.TECHNICAL - staff.DIRECTORS
-    admins = staff.ADMINS - staff.DIRECTORS - staff.TECHNICAL
+    admins = staff.ADMINS - staff.DIRECTORS
     mods = staff.MODS - staff.ADMINS
     devs = staff.DEVELOPERS
-    staff_info_map = profile.select_avatars(list(directors | technical | admins | mods | devs))
+    staff_info_map = profile.select_avatars(list(directors | admins | mods | devs))
     staff_list = []
     for name, userids in [('Directors', directors),
                           ('Administrators', admins),
                           ('Moderators', mods),
-                          ('Techs', technical),
                           ('Developers', devs)]:
         users = [staff_info_map[u] for u in userids]
         users.sort(key=lambda info: info['username'].lower())

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -576,8 +576,6 @@ def age_in_years(birthdate):
 def user_type(userid):
     if userid in staff.DIRECTORS:
         return "director"
-    if userid in staff.TECHNICAL:
-        return "tech"
     if userid in staff.ADMINS:
         return "admin"
     if userid in staff.MODS:

--- a/weasyl/staff_config.py
+++ b/weasyl/staff_config.py
@@ -31,9 +31,13 @@ def load():
         if len(statement.targets) != 1 or not isinstance(target, ast.Name):
             raise SyntaxError("Unexpected assignment target in staff configuration")
 
+        # Techs no longer exist as a role, but still allow technical_staff
+        # to prevent an outage when upgrading past its removal.
+
         if target.id not in {"directors", "technical_staff", "admins", "mods", "developers", "wesley"}:
             raise SyntaxError("Unexpected key in staff configuration: %r" % (target.id,))
 
-        staff[target.id] = ast.literal_eval(statement.value)
+        if target.id != "technical_staff":
+            staff[target.id] = ast.literal_eval(statement.value)
 
     return staff

--- a/weasyl/staff_config.py
+++ b/weasyl/staff_config.py
@@ -31,13 +31,9 @@ def load():
         if len(statement.targets) != 1 or not isinstance(target, ast.Name):
             raise SyntaxError("Unexpected assignment target in staff configuration")
 
-        # Techs no longer exist as a role, but still allow technical_staff
-        # to prevent an outage when upgrading past its removal.
-
-        if target.id not in {"directors", "technical_staff", "admins", "mods", "developers", "wesley"}:
+        if target.id not in {"directors", "admins", "mods", "developers", "wesley"}:
             raise SyntaxError("Unexpected key in staff configuration: %r" % (target.id,))
 
-        if target.id != "technical_staff":
-            staff[target.id] = ast.literal_eval(statement.value)
+        staff[target.id] = ast.literal_eval(statement.value)
 
     return staff

--- a/weasyl/test/searchtag/test_associate.py
+++ b/weasyl/test/searchtag/test_associate.py
@@ -203,7 +203,7 @@ def test_attempt_setting_tags_when_some_tags_have_been_restricted():
 @pytest.mark.usefixtures('db')
 def test_moderators_and_above_can_add_restricted_tags_successfully(monkeypatch):
     """
-    Moderators (and admins, technical, and directors) can add restricted tags to content.
+    Moderators (and admins and directors) can add restricted tags to content.
     Developers are not included in this test, as they are for all intents and purposes just
       normal user accounts.
     """

--- a/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_edit_global_tag_restrictions.py
@@ -29,12 +29,10 @@ def test_edit_global_tag_restrictions_when_user_is_not_a_director_fails(monkeypa
     developer_user_id = db_utils.create_user()
     mod_user_id = db_utils.create_user()
     admin_user_id = db_utils.create_user()
-    technical_user_id = db_utils.create_user()
 
     monkeypatch.setattr(staff, 'DEVELOPERS', frozenset([developer_user_id]))
     monkeypatch.setattr(staff, 'MODS', frozenset([mod_user_id]))
     monkeypatch.setattr(staff, 'ADMINS', frozenset([admin_user_id]))
-    monkeypatch.setattr(staff, 'TECHNICAL', frozenset([technical_user_id]))
 
     # Function under test; users and staff (except director) should error
     with pytest.raises(WeasylError) as err:
@@ -48,9 +46,6 @@ def test_edit_global_tag_restrictions_when_user_is_not_a_director_fails(monkeypa
     assert 'InsufficientPermissions' == err.value.value
     with pytest.raises(WeasylError) as err:
         searchtag.edit_global_tag_restrictions(admin_user_id, combined_tags)
-    assert 'InsufficientPermissions' == err.value.value
-    with pytest.raises(WeasylError) as err:
-        searchtag.edit_global_tag_restrictions(technical_user_id, combined_tags)
     assert 'InsufficientPermissions' == err.value.value
 
 

--- a/weasyl/test/searchtag/test_get_tag_restrictions.py
+++ b/weasyl/test/searchtag/test_get_tag_restrictions.py
@@ -35,13 +35,11 @@ def test_get_global_searchtag_restrictions_fails_for_non_directors(monkeypatch):
     developer_user_id = db_utils.create_user()
     mod_user_id = db_utils.create_user()
     admin_user_id = db_utils.create_user()
-    technical_user_id = db_utils.create_user()
 
     # Monkeypatch the staff global variables
     monkeypatch.setattr(staff, 'DEVELOPERS', frozenset([developer_user_id]))
     monkeypatch.setattr(staff, 'MODS', frozenset([mod_user_id]))
     monkeypatch.setattr(staff, 'ADMINS', frozenset([admin_user_id]))
-    monkeypatch.setattr(staff, 'TECHNICAL', frozenset([technical_user_id]))
 
     with pytest.raises(WeasylError) as err:
         searchtag.get_global_tag_restrictions(normal_user_id)
@@ -57,8 +55,4 @@ def test_get_global_searchtag_restrictions_fails_for_non_directors(monkeypatch):
 
     with pytest.raises(WeasylError) as err:
         searchtag.get_global_tag_restrictions(admin_user_id)
-    assert err.value.value == 'InsufficientPermissions'
-
-    with pytest.raises(WeasylError) as err:
-        searchtag.get_global_tag_restrictions(technical_user_id)
     assert err.value.value == 'InsufficientPermissions'

--- a/weasyl/test/test_staff_config.py
+++ b/weasyl/test/test_staff_config.py
@@ -20,15 +20,3 @@ def test_bad_configuration(monkeypatch, tmp_path, content, exception):
 
     with pytest.raises(exception):
         staff_config.load()
-
-
-def test_ignore_technical_staff(monkeypatch, tmp_path):
-    config = tmp_path / 'config.py'
-    config.write_text('directors = [1]; technical_staff = [2]; wesley = 3')
-    monkeypatch.setattr(macro, 'MACRO_SYS_STAFF_CONFIG_PATH', str(config))
-
-    staff = staff_config.load()
-
-    assert staff['directors'] == [1]
-    assert 'technical_staff' not in staff
-    assert staff['wesley'] == 3

--- a/weasyl/test/test_staff_config.py
+++ b/weasyl/test/test_staff_config.py
@@ -1,0 +1,34 @@
+import pytest
+
+from weasyl import macro
+from weasyl import staff_config
+
+
+@pytest.mark.parametrize(
+    'content,exception',
+    (
+        ('directors = [2000]; import sys', SyntaxError),
+        ('directors, wesley = [1, 2]', SyntaxError),
+        ('foo = True', SyntaxError),
+        ('wesley = eval("evil")', ValueError),
+    ),
+)
+def test_bad_configuration(monkeypatch, tmp_path, content, exception):
+    bad_config = tmp_path / 'bad-config.py'
+    bad_config.write_text(content)
+    monkeypatch.setattr(macro, 'MACRO_SYS_STAFF_CONFIG_PATH', str(bad_config))
+
+    with pytest.raises(exception):
+        staff_config.load()
+
+
+def test_ignore_technical_staff(monkeypatch, tmp_path):
+    config = tmp_path / 'config.py'
+    config.write_text('directors = [1]; technical_staff = [2]; wesley = 3')
+    monkeypatch.setattr(macro, 'MACRO_SYS_STAFF_CONFIG_PATH', str(config))
+
+    staff = staff_config.load()
+
+    assert staff['directors'] == [1]
+    assert 'technical_staff' not in staff
+    assert staff['wesley'] == 3

--- a/weasyl/test/web/test_site_updates.py
+++ b/weasyl/test/web/test_site_updates.py
@@ -128,7 +128,6 @@ def test_create_restricted(app, monkeypatch):
     resp = app.post('/admincontrol/siteupdate', _FORM, headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
 
-    monkeypatch.setattr(staff, 'TECHNICAL', frozenset([user]))
     monkeypatch.setattr(staff, 'MODS', frozenset([user]))
 
     resp = app.get('/admincontrol/siteupdate', headers={'Cookie': cookie}, status=403)
@@ -227,7 +226,6 @@ def test_edit_restricted(app, monkeypatch, site_updates):
     resp = app.post('/site-updates/%d' % (updates[-1]['updateid'],), _FORM, headers={'Cookie': cookie}, status=403)
     assert resp.html.find(id='error_content').p.text.strip() == errorcode.permission
 
-    monkeypatch.setattr(staff, 'TECHNICAL', frozenset([user]))
     monkeypatch.setattr(staff, 'MODS', frozenset([user]))
 
     resp = app.get('/site-updates/%d/edit' % (updates[-1]['updateid'],), headers={'Cookie': cookie}, status=403)


### PR DESCRIPTION
Closes #1519

`technical_staff` is still allowed in the configuration file to prevent an outage when upgrading past this commit.