### PR TITLE
Resolve `./wzl check` warnings

### DIFF
--- a/weasyl/report.py
+++ b/weasyl/report.py
@@ -148,7 +148,7 @@ def select_list(userid, form):
     # collected Login model aliases to compare against Login.login_name.
     if form.submitter:
         submitter = d.get_sysname(form.submitter)
-        q = q.filter(sa.or_(l.login_name == submitter for l in login_aliases))
+        q = q.filter(sa.or_(login.login_name == submitter for login in login_aliases))
 
     # If filtering by violation type, see if the violation is in the array
     # aggregate of unique violations for this report.
@@ -215,7 +215,8 @@ def close(userid, form):
         q = (
             q
             .filter_by(is_closed=False)
-            .filter(sa.or_(l.login_name == root_report.target.owner.login_name for l in login_aliases)))
+            .filter(sa.or_(login.login_name == root_report.target.owner.login_name
+                           for login in login_aliases)))
         reports = q.all()
 
     else:

--- a/weasyl/test/conftest.py
+++ b/weasyl/test/conftest.py
@@ -12,8 +12,9 @@ from sqlalchemy.dialects.postgresql import psycopg2
 from webtest import TestApp as TestApp_
 
 from weasyl import config
-config._in_test = True  # noqa
+config._in_test = True
 
+# flake8: noqa: E402
 from libweasyl import cache
 from libweasyl.cache import ThreadCacheProxy
 from libweasyl.configuration import configure_libweasyl

--- a/weasyl/test/test_define.py
+++ b/weasyl/test/test_define.py
@@ -7,9 +7,9 @@ from weasyl.test import db_utils
 from weasyl import define as d
 
 
-def l2dl(l, k='k'):
+def l2dl(input_list, k='k'):
     "For list2dictlist."
-    return [{k: x} for x in l]
+    return [{k: x} for x in input_list]
 
 
 pagination_tests = [


### PR DESCRIPTION
Resolve the following warnings that currently appear in `./wzl check`. This makes `./wzl check` more useful by removing the need to mentally filter out warnings that were already present.

```
./weasyl/report.py:151:59: E741 ambiguous variable name 'l'
./weasyl/report.py:218:84: E741 ambiguous variable name 'l'
./weasyl/test/conftest.py:17:1: E402 module level import not at top of file
./weasyl/test/conftest.py:18:1: E402 module level import not at top of file
./weasyl/test/conftest.py:19:1: E402 module level import not at top of file
./weasyl/test/conftest.py:20:1: E402 module level import not at top of file
./weasyl/test/conftest.py:21:1: E402 module level import not at top of file
./weasyl/test/conftest.py:22:1: E402 module level import not at top of file
./weasyl/test/conftest.py:31:1: E402 module level import not at top of file
./weasyl/test/conftest.py:32:1: E402 module level import not at top of file
./weasyl/test/test_define.py:10:10: E741 ambiguous variable name 'l'
```