### PR TITLE
Require every non-`GET` route to define an explicit CSRF check policy

### DIFF
--- a/weasyl/controllers/api.py
+++ b/weasyl/controllers/api.py
@@ -1,8 +1,9 @@
+from functools import wraps
+
 from pyramid.httpexceptions import HTTPForbidden
 from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.httpexceptions import HTTPUnprocessableEntity
 from pyramid.response import Response
-from pyramid.view import view_config
 
 from libweasyl.text import markdown, slug_for
 from libweasyl import ratings
@@ -47,6 +48,7 @@ _CONTENT_IDS = {
 
 
 def api_method(view_callable):
+    @wraps(view_callable)
     def wrapper(request):
         try:
             return view_callable(request)
@@ -73,6 +75,7 @@ def api_login_required(view_callable):
     Like decorators.login_required, but returning json on an error.
     """
     # TODO: If we replace the regular @login_required checks on POSTs with a tween, what do about this?
+    @wraps(view_callable)
     def inner(request):
         if request.userid == 0:
             raise HTTPUnauthorized(
@@ -83,7 +86,6 @@ def api_login_required(view_callable):
     return inner
 
 
-@view_config(route_name='useravatar', renderer='json')
 @api_method
 def api_useravatar_(request):
     form = request.web_input(username="")
@@ -98,7 +100,6 @@ def api_useravatar_(request):
     raise WeasylError('userRecordMissing')
 
 
-@view_config(route_name='whoami', renderer='json')
 @api_login_required
 def api_whoami_(request):
     return {
@@ -107,7 +108,6 @@ def api_whoami_(request):
     }
 
 
-@view_config(route_name='version', renderer='json')
 @api_method
 def api_version_(request):
     format = request.matchdict.get("format", ".json")
@@ -149,7 +149,6 @@ def tidy_submission(submission):
             "/%s/%d/%s" % (linktype, submitid, slug_for(submission['title'])))
 
 
-@view_config(route_name='api_frontpage', renderer='json')
 @api_method
 def api_frontpage_(request):
     form = request.web_input(since=None, count=0)
@@ -176,7 +175,6 @@ def api_frontpage_(request):
     return ret
 
 
-@view_config(route_name='api_submission_view', renderer='json')
 @api_method
 def api_submission_view_(request):
     form = request.web_input(anyway='', increment_views='')
@@ -185,7 +183,6 @@ def api_submission_view_(request):
         anyway=bool(form.anyway), increment_views=bool(form.increment_views))
 
 
-@view_config(route_name='api_journal_view', renderer='json')
 @api_method
 def api_journal_view_(request):
     form = request.web_input(anyway='', increment_views='')
@@ -194,7 +191,6 @@ def api_journal_view_(request):
         anyway=bool(form.anyway), increment_views=bool(form.increment_views))
 
 
-@view_config(route_name='api_character_view', renderer='json')
 @api_method
 def api_character_view_(request):
     form = request.web_input(anyway='', increment_views='')
@@ -203,7 +199,6 @@ def api_character_view_(request):
         anyway=bool(form.anyway), increment_views=bool(form.increment_views))
 
 
-@view_config(route_name='api_user_view', renderer='json')
 @api_method
 def api_user_view_(request):
     # Helper functions for this view.
@@ -337,7 +332,6 @@ def api_user_view_(request):
     return user
 
 
-@view_config(route_name='api_user_gallery', renderer='json')
 @api_method
 def api_user_gallery_(request):
     userid = profile.resolve_by_username(request.matchdict['login'])
@@ -376,7 +370,6 @@ def api_user_gallery_(request):
     }
 
 
-@view_config(route_name='api_messages_submissions', renderer='json')
 @api_login_required
 @api_method
 def api_messages_submissions_(request):
@@ -405,7 +398,6 @@ def api_messages_submissions_(request):
     }
 
 
-@view_config(route_name='api_messages_summary', renderer='json')
 @api_login_required
 @api_method
 def api_messages_summary_(request):
@@ -422,7 +414,6 @@ def api_messages_summary_(request):
 # TODO(hyena): It's probable that token_checked won't return json from these. Consider writing an api_token_checked.
 
 
-@view_config(route_name='api_favorite', request_method='POST', renderer='json')
 @api_login_required
 @api_method
 @token_checked
@@ -435,7 +426,6 @@ def api_favorite_(request):
     }
 
 
-@view_config(route_name='api_unfavorite', request_method='POST', renderer='json')
 @api_login_required
 @api_method
 @token_checked

--- a/weasyl/controllers/decorators.py
+++ b/weasyl/controllers/decorators.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from pyramid.response import Response
 
 from libweasyl import staff
@@ -11,7 +13,11 @@ Contains decorators for weasyl view callables to enforce permissions and the lik
 """
 
 
+csrf_defined: set[tuple[str, str]] = set()
+
+
 def login_required(view_callable):
+    @wraps(view_callable)
     def inner(request):
         if request.userid == 0:
             raise WeasylError('unsigned')
@@ -20,6 +26,7 @@ def login_required(view_callable):
 
 
 def guest_required(view_callable):
+    @wraps(view_callable)
     def inner(request):
         if request.userid != 0:
             raise WeasylError('signed')
@@ -29,6 +36,7 @@ def guest_required(view_callable):
 
 def moderator_only(view_callable):
     """Implies login_required."""
+    @wraps(view_callable)
     def inner(request):
         if weasyl.api.is_api_user(request):
             raise WeasylError('InsufficientPermissions')
@@ -40,6 +48,7 @@ def moderator_only(view_callable):
 
 def admin_only(view_callable):
     """Implies login_required."""
+    @wraps(view_callable)
     def inner(request):
         if weasyl.api.is_api_user(request):
             raise WeasylError('InsufficientPermissions')
@@ -51,6 +60,7 @@ def admin_only(view_callable):
 
 def director_only(view_callable):
     """Implies login_required."""
+    @wraps(view_callable)
     def inner(request):
         if weasyl.api.is_api_user(request):
             raise WeasylError('InsufficientPermissions')
@@ -61,6 +71,7 @@ def director_only(view_callable):
 
 
 def disallow_api(view_callable):
+    @wraps(view_callable)
     def inner(request):
         if weasyl.api.is_api_user(request):
             raise WeasylError('InsufficientPermissions')
@@ -73,6 +84,7 @@ def twofactorauth_enabled_required(view_callable):
     This decorator requires that 2FA be enabled for a given Weasyl account as identified
     by ``request.userid``.
     """
+    @wraps(view_callable)
     def inner(request):
         if not two_factor_auth.is_2fa_enabled(request.userid):
             raise WeasylError("TwoFactorAuthenticationRequireEnabled")
@@ -85,6 +97,7 @@ def twofactorauth_disabled_required(view_callable):
     This decorator requires that 2FA be disabled for a given Weasyl account as identified
     by ``request.userid``.
     """
+    @wraps(view_callable)
     def inner(request):
         if two_factor_auth.is_2fa_enabled(request.userid):
             raise WeasylError("TwoFactorAuthenticationRequireDisbled")
@@ -92,7 +105,21 @@ def twofactorauth_disabled_required(view_callable):
     return inner
 
 
+def csrf_skip(view_callable):
+    key = (view_callable.__module__, view_callable.__qualname__)
+
+    if key in csrf_defined:
+        raise RuntimeError(f"multiple CSRF policies for {key}")  # pragma: no cover
+
+    csrf_defined.add(key)
+
+    return view_callable
+
+
 def token_checked(view_callable):
+    csrf_skip(view_callable)
+
+    @wraps(view_callable)
     def inner(request):
         assert request.method in ("POST", "DELETE", "PUT", "PATCH")
         if not weasyl.api.is_api_user(request) and not define.is_csrf_valid(request):
@@ -102,6 +129,7 @@ def token_checked(view_callable):
 
 
 def supports_json(view_callable):
+    @wraps(view_callable)
     def inner(request):
         if request.params.get('format', "") == "json":
 

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -1,4 +1,11 @@
-from collections import namedtuple
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Mapping
+from typing import Any
+from typing import Literal
+
+from pyramid.request import Request
 
 from weasyl.controllers import (
     admin,
@@ -25,13 +32,29 @@ from weasyl.controllers.decorators import csrf_defined
 from weasyl import oauth2
 
 
-Route = namedtuple('Route', ['pattern', 'name', 'view'])
-"""
-A route to be added to the Weasyl application.
+HttpMethod = Literal["GET", "POST", "PUT", "DELETE", "PATCH"]
+Handler = Callable[[Request], Any]
 
-`view` may be either a view callable (in which case only GET/HEAD requests are routed to it) or a
-dict mapping http methods to view callables.
-"""
+
+class Route:
+    __slots__ = ("pattern", "name", "handlers", "renderer")
+
+    pattern: str
+    name: str
+    handlers: Mapping[HttpMethod, Handler]
+    renderer: Literal["json"] | None
+
+    def __init__(
+        self,
+        pattern: str,
+        name: str,
+        handlers: dict[HttpMethod, Handler] | Handler,
+        renderer: Literal["json"] | None = None,
+    ):
+        self.pattern = pattern
+        self.name = name
+        self.handlers = handlers if isinstance(handlers, dict) else {"GET": handlers}
+        self.renderer = renderer
 
 
 routes = (
@@ -352,6 +375,21 @@ routes = (
 
     # Routes for static event pages, such as holidays.
     Route("/events/halloweasyl2014", "events_halloweasyl2014", events.halloweasyl2014_),
+
+    # API routes.
+    Route("/api/useravatar", "useravatar", api.api_useravatar_, renderer="json"),
+    Route("/api/whoami", "whoami", api.api_whoami_, renderer="json"),
+    Route(r"/api/version{format:(\.[^.]+)?}", "version", api.api_version_, renderer="json"),
+    Route("/api/submissions/frontpage", "api_frontpage", api.api_frontpage_, renderer="json"),
+    Route("/api/submissions/{submitid:[0-9]+}/view", "api_submission_view", api.api_submission_view_, renderer="json"),
+    Route("/api/journals/{journalid:[0-9]+}/view", "api_journal_view", api.api_journal_view_, renderer="json"),
+    Route("/api/characters/{charid:[0-9]+}/view", "api_character_view", api.api_character_view_, renderer="json"),
+    Route("/api/users/{login:[^/]+}/view", "api_user_view", api.api_user_view_, renderer="json"),
+    Route("/api/users/{login:[^/]+}/gallery", "api_user_gallery", api.api_user_gallery_, renderer="json"),
+    Route("/api/messages/submissions", "api_messages_submissions", api.api_messages_submissions_, renderer="json"),
+    Route("/api/messages/summary", "api_messages_summary", api.api_messages_summary_, renderer="json"),
+    Route("/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/favorite", "api_favorite", {'POST': api.api_favorite_}, renderer="json"),
+    Route("/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/unfavorite", "api_unfavorite", {'POST': api.api_unfavorite_}, renderer="json"),
 )
 
 
@@ -364,30 +402,13 @@ def setup_routes_and_views(config):
     """
     for route in routes:
         config.add_route(name=route.name, pattern=route.pattern)
-        if isinstance(route.view, dict):
-            for method in route.view:
-                handler = route.view[method]
+        for method, handler in route.handlers.items():
+            if method != "GET" and (handler.__module__, handler.__qualname__) not in csrf_defined:
+                raise RuntimeError(f"{handler} has no explicit CSRF policy")
 
-                if method != "GET" and (handler.__module__, handler.__qualname__) not in csrf_defined:
-                    raise RuntimeError(f"{handler} has no explicit CSRF policy")
-
-                config.add_view(view=handler, route_name=route.name, request_method=method)
-        else:
-            config.add_view(view=route.view, route_name=route.name, request_method="GET")
-
-    # API routes.
-    config.add_route("useravatar", "/api/useravatar")
-    config.add_route("whoami", "/api/whoami")
-    config.add_route("version", r"/api/version{format:(\.[^.]+)?}")
-    config.add_route("api_frontpage", "/api/submissions/frontpage")
-    config.add_route("api_submission_view", "/api/submissions/{submitid:[0-9]+}/view")
-    config.add_route("api_journal_view", "/api/journals/{journalid:[0-9]+}/view")
-    config.add_route("api_character_view", "/api/characters/{charid:[0-9]+}/view")
-    config.add_route("api_user_view", "/api/users/{login:[^/]+}/view")
-    config.add_route("api_user_gallery", "/api/users/{login:[^/]+}/gallery")
-    config.add_route("api_messages_submissions", "/api/messages/submissions")
-    config.add_route("api_messages_summary", "/api/messages/summary")
-    config.add_route("api_favorite", "/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/favorite")
-    config.add_route("api_unfavorite", "/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/unfavorite")
-
-    config.scan(api)
+            config.add_view(
+                view=handler,
+                route_name=route.name,
+                request_method=method,
+                renderer=route.renderer,
+            )

--- a/weasyl/controllers/user.py
+++ b/weasyl/controllers/user.py
@@ -256,6 +256,7 @@ def resetpassword_get_(request):
 
 
 @guest_required
+@token_checked
 def resetpassword_post_(request):
     expect_userid = int(request.POST['userid'])
 

--- a/weasyl/oauth2.py
+++ b/weasyl/oauth2.py
@@ -3,7 +3,7 @@ from pyramid.response import Response
 from oauthlib.oauth2 import FatalClientError, OAuth2Error
 
 from libweasyl.oauth import get_consumers_for_user, revoke_consumers_for_user, server
-from weasyl.controllers.decorators import disallow_api, token_checked
+from weasyl.controllers.decorators import disallow_api, token_checked, csrf_skip
 from weasyl import define as d
 from weasyl import media, orm
 from weasyl.controllers.decorators import login_required
@@ -59,6 +59,7 @@ def authorize_post_(request):
 
 
 @disallow_api
+@csrf_skip
 def token_(request):
     return HTTPServiceUnavailable()
 


### PR DESCRIPTION
Making a critical security decorator that’s easy to overlook a little more robust.