### PR TITLE
Speed up single-tag guest searches; improve search page metadata

### DIFF
--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -69,23 +69,27 @@ def search_(request):
         else:
             search_query.ratings.update(ratings.CHARACTER_MAP[rating_code].code for rating_code in meta["rated"])
 
-            if backid:
-                page = search.PrevFilter(meta["backid"])
-            elif nextid:
-                page = search.NextFilter(meta["nextid"])
+            resolved = search.resolve(search_query)
+            if resolved is None:
+                query, prev_page, next_page = [], None, None
             else:
-                page = search.FIRST_PAGE
+                if backid:
+                    page = search.PrevFilter(meta["backid"])
+                elif nextid:
+                    page = search.NextFilter(meta["nextid"])
+                else:
+                    page = search.FIRST_PAGE
 
-            query, prev_page, next_page = search.select(
-                userid=request.userid,
-                rating=rating,
-                limit=63,
-                search=search_query,
-                within=meta["within"],
-                cat=meta["cat"],
-                subcat=meta["subcat"],
-                page=page,
-            )
+                query, prev_page, next_page = search.select(
+                    userid=request.userid,
+                    rating=rating,
+                    limit=63,
+                    resolved=resolved,
+                    within=meta["within"],
+                    cat=meta["cat"],
+                    subcat=meta["subcat"],
+                    page=page,
+                )
 
         title = "Search results"
         template_args = (

--- a/weasyl/controllers/general.py
+++ b/weasyl/controllers/general.py
@@ -1,4 +1,5 @@
 import itertools
+from typing import Literal
 
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.response import Response
@@ -25,12 +26,59 @@ def index_(request):
     )
 
 
+_SEARCH_RESULTS = {
+    "submit": "Posts",
+    "char": "Characters",
+    "journal": "Journals",
+}
+
+
 _BROWSE = {
     'submit': ("Submissions", "Browse Submissions"),
     'char': ("Characters", "Browse Characters"),
     'journal': ("Journals", "Browse Journals"),
     'critique': ("Critique requests", "Browse Critique Requests"),
 }
+
+
+# NOTE: Most canonical paths are good candidates for a `history.replaceState`, but ones that include freeform user input (like this one) are exceptions: it would be annoying to the user to process and rearrange the input if they want to continue making changes to it, especially in cases where the original input was slightly wrong in a way that dramatically changed its interpretation. TODO: Consider a similar function for the purpose of `replaceState`-style use cases, leaving the form state intact while removing defaults. TODO: Display the interpretation of the query.
+def _get_search_canonical_path(
+    search_query: search.Query,
+    *,
+    within: Literal["", "notify", "fave", "friend", "follow"],
+    cat: int | None,
+    subcat: int | None,
+    backid: int | None,
+    nextid: int | None,
+) -> str:
+    params = {
+        "q": search_query.get_terms_string(),
+    }
+
+    find = search_query.find
+
+    if find != "submit":
+        params["find"] = find
+
+    if find != "user" and within:
+        params["within"] = within
+
+    if find != "user" and ratings:
+        params["rated"] = [ratings.CODE_MAP[r].character for r in sorted(search_query.ratings)]
+
+    if find == "submit":
+        if subcat:
+            params["subcat"] = str(subcat)
+        elif cat:
+            params["cat"] = str(cat)
+
+    if find != "user":
+        if backid:
+            params["backid"] = str(backid)
+        elif nextid:
+            params["nextid"] = str(nextid)
+
+    return f"/search?{define.query_string(params)}"
 
 
 def search_(request):
@@ -45,9 +93,21 @@ def search_(request):
     backid = request.params.get('backid')
     nextid = request.params.get('nextid')
 
+    canonical_path = None
+    robots = None
+
     if q:
         if find not in ("submit", "char", "journal", "user"):
             find = "submit"
+
+        if (
+            not request.userid
+            or within not in ["", "notify", "fave", "friend", "follow"]
+        ):
+            within = ""
+
+        if find != "submit":
+            cat = subcat = None
 
         q = q.strip()
         search_query = search.Query.parse(q, find)
@@ -68,6 +128,8 @@ def search_(request):
             prev_page = next_page = None
         else:
             search_query.ratings.update(ratings.CHARACTER_MAP[rating_code].code for rating_code in meta["rated"])
+            if len(search_query.ratings) == len(ratings.ALL_RATINGS):
+                search_query.ratings.clear()
 
             resolved = search.resolve(search_query)
             if resolved is None:
@@ -85,13 +147,37 @@ def search_(request):
                     rating=rating,
                     limit=63,
                     resolved=resolved,
-                    within=meta["within"],
+                    within=within,
                     cat=meta["cat"],
                     subcat=meta["subcat"],
                     page=page,
                 )
 
-        title = "Search results"
+        if (
+            search_query.find != "user"
+            and not within
+            and not cat
+            and not subcat
+            and (simple := search_query.as_simple())
+        ):
+            title = f'{_SEARCH_RESULTS[search_query.find]} tagged “{simple}”'
+
+            # Don’t index reverse pagination or empty result sets.
+            if backid or not query:
+                robots = "noindex"
+        else:
+            title = "Search results"
+            robots = "noindex"
+
+        canonical_path = _get_search_canonical_path(
+            search_query,
+            within=meta["within"],
+            cat=meta["cat"],
+            subcat=meta["subcat"],
+            backid=meta["backid"],
+            nextid=meta["nextid"],
+        )
+
         template_args = (
             # Search method
             "search",
@@ -185,7 +271,17 @@ def search_(request):
             },
         )
 
-    return Response(define.webpage(request.userid, "etc/search.html", template_args, options=('search',), title=title))
+    return Response(
+        define.webpage(
+            request.userid,
+            "etc/search.html",
+            template_args,
+            options=('search',),
+            title=title,
+            canonical_url=canonical_path,
+            robots=robots,
+        )
+    )
 
 
 def streaming_(request):

--- a/weasyl/controllers/search.py
+++ b/weasyl/controllers/search.py
@@ -21,11 +21,18 @@ def navigation_counts(request):
     backid = request.GET.get('backid')
     nextid = request.GET.get('nextid')
 
+    resolved = search.resolve(query)
+    if resolved is None:
+        return Response(json={
+            'nextCount': 0,
+            'backCount': 0,
+        })
+
     def _search(page: PrevFilter | NextFilter) -> int:
         return search.select_count(
             userid=request.userid,
             rating=define.get_rating(request.userid),
-            search=query,
+            resolved=resolved,
             within=request.GET.get('within', ''),
             cat=int(cat) if cat else None,
             subcat=int(subcat) if subcat else None,

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -42,10 +42,15 @@ $def with (query, options, extended_options={})
     $for k, v in extended_options['ogp'].items():
       <meta property="og:${k}" content="${v}" />
 
-  $if 'canonical_url' in extended_options:
-    <link rel="canonical" href="https://www.weasyl.com/${extended_options['canonical_url'].lstrip('/')}" />
-
   <script src="${resource_path('js/main.js')}" async blocking="render"></script>
+
+  $code:
+    canonical_url = extended_options.get('canonical_url')
+    robots = extended_options.get('robots')
+  $if canonical_url:
+    <link rel="canonical" href="https://www.weasyl.com/${canonical_url.lstrip('/')}">
+  $if robots:
+    <meta name="robots" content="${robots}">
 
   <link rel="search" title="Weasyl" type="application/opensearchdescription+xml" href="/opensearch.xml">
 


### PR DESCRIPTION
- adds the title ‘Posts tagged “foo”’ (or “Journals”, “Characters”) to single-tag searches
- adds canonical URLs to searches
- speeds up single-tag searches when not logged in (down to <10 ms from as high as >1 s)