### PR TITLE
Asynchronous view counting

### DIFF
--- a/assets/js/view-count.js
+++ b/assets/js/view-count.js
@@ -1,0 +1,41 @@
+import ready from './util/ready.js';
+
+const visible = new Promise(resolve => {
+    const check = () => {
+        if (!document.hidden) {
+            document.removeEventListener('visibilitychange', check);
+            resolve();
+        }
+    };
+
+    document.addEventListener('visibilitychange', check);
+    check();
+});
+
+visible.then(async () => {
+    await ready;
+
+    const viewsContainer = document.getElementById('page-views');
+
+    if (!viewsContainer) {
+        return;
+    }
+
+    if (new URLSearchParams('?' + location.search).get('anyway') === 'true') {
+        return;
+    }
+
+    const response = await fetch(`/api-unstable/${viewsContainer.dataset.viewable}/views/`, {
+        method: 'POST',
+        priority: 'low',
+        keepalive: true,
+    });
+
+    const updatedViews = await response.text();
+
+    if (response.ok && updatedViews) {
+        viewsContainer.textContent = updatedViews;
+    }
+});
+
+export {}

--- a/build.ts
+++ b/build.ts
@@ -635,6 +635,7 @@ const tasks: readonly AnyTask[] = [
         'js/tags-edit.js',
         'js/signup.js',
         'js/submit.js',
+        'js/view-count.js',
     ], PRIVATE_FIELDS_ESM, {touch}),
     new EsbuildFiles(['js/flash.js'], {
         format: 'esm',

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -192,7 +192,7 @@ def _select_character_and_check(
     rating,
     ignore: bool,
     anyway: bool,
-    increment_views: bool = True,
+    increment_views: bool,
 ):
     """Selects a character, after checking if the user is authorized, etc.
 
@@ -231,8 +231,8 @@ def _select_character_and_check(
 
     query = dict(query)
 
-    if increment_views and define.common_view_content(userid, charid, 'char'):
-        query['page_views'] += 1
+    if increment_views and (new_views := define.common_view_content(userid, charid, 'characters')) is not None:
+        query['page_views'] = new_views
 
     return query
 
@@ -251,6 +251,7 @@ def select_view(
         rating=rating,
         ignore=ignore,
         anyway=anyway,
+        increment_views=False,
     )
 
     login = define.get_sysname(query['username'])

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -185,16 +185,24 @@ def reupload(userid, charid, submitdata):
     """, settings=settings, character=charid)
 
 
-def _select_character_and_check(userid, charid, *, rating, ignore, anyway, increment_views=True):
+def _select_character_and_check(
+    userid,
+    charid,
+    *,
+    rating,
+    ignore: bool,
+    anyway: bool,
+    increment_views: bool = True,
+):
     """Selects a character, after checking if the user is authorized, etc.
 
     Args:
         userid (int): Currently authenticating user ID.
         charid (int): Character ID to fetch.
         rating (int): Maximum rating to display.
-        ignore (bool): Whether to check for blocked tags and users.
-        anyway (bool): For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
-        increment_views (bool): Whether to increment the number of views on the submission. Defaults to True.
+        ignore: Whether to check for blocked tags and users.
+        anyway: For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
+        increment_views: Whether to increment the number of views on the submission.
 
     Returns:
         A character and all needed data as a dict.
@@ -229,9 +237,21 @@ def _select_character_and_check(userid, charid, *, rating, ignore, anyway, incre
     return query
 
 
-def select_view(userid, charid, rating, ignore=True, anyway=None):
+def select_view(
+    userid,
+    charid,
+    *,
+    rating,
+    ignore: bool = True,
+    anyway: bool = False,
+):
     query = _select_character_and_check(
-        userid, charid, rating=rating, ignore=ignore, anyway=anyway == "true")
+        userid,
+        charid,
+        rating=rating,
+        ignore=ignore,
+        anyway=anyway,
+    )
 
     login = define.get_sysname(query['username'])
 
@@ -263,12 +283,23 @@ def select_view(userid, charid, rating, ignore=True, anyway=None):
     }
 
 
-def select_view_api(userid, charid, anyway=False, increment_views=False):
+def select_view_api(
+    userid,
+    charid,
+    *,
+    anyway: bool,
+    increment_views: bool,
+):
     rating = define.get_rating(userid)
 
     query = _select_character_and_check(
-        userid, charid, rating=rating, ignore=not anyway,
-        anyway=False, increment_views=increment_views)
+        userid,
+        charid,
+        rating=rating,
+        ignore=not anyway,
+        anyway=False,
+        increment_views=increment_views,
+    )
 
     login = define.get_sysname(query['username'])
 

--- a/weasyl/character.py
+++ b/weasyl/character.py
@@ -192,8 +192,8 @@ def _select_character_and_check(userid, charid, *, rating, ignore, anyway, incre
         userid (int): Currently authenticating user ID.
         charid (int): Character ID to fetch.
         rating (int): Maximum rating to display.
-        ignore (bool): Whether to respect ignored or blocked tags
-        anyway (bool): Whether to ignore checks and display anyway.
+        ignore (bool): Whether to check for blocked tags and users.
+        anyway (bool): For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
         increment_views (bool): Whether to increment the number of views on the submission. Defaults to True.
 
     Returns:
@@ -267,8 +267,8 @@ def select_view_api(userid, charid, anyway=False, increment_views=False):
     rating = define.get_rating(userid)
 
     query = _select_character_and_check(
-        userid, charid, rating=rating, ignore=anyway,
-        anyway=anyway, increment_views=increment_views)
+        userid, charid, rating=rating, ignore=not anyway,
+        anyway=False, increment_views=increment_views)
 
     login = define.get_sysname(query['username'])
 

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -567,7 +567,13 @@ def edit_submission_get_(request):
     form = request.web_input(submitid="", anyway="")
     form.submitid = define.get_int(form.submitid)
 
-    detail = submission.select_view(request.userid, form.submitid, ratings.EXPLICIT.code, False, anyway=form.anyway)
+    detail = submission.select_view(
+        request.userid,
+        form.submitid,
+        rating=ratings.EXPLICIT.code,
+        ignore=False,
+        anyway=form.anyway == "true",
+    )
 
     if request.userid != detail['userid'] and request.userid not in staff.MODS:
         raise WeasylError('InsufficientPermissions')
@@ -618,7 +624,13 @@ def edit_character_get_(request):
     form = request.web_input(charid="", anyway="")
     form.charid = define.get_int(form.charid)
 
-    detail = character.select_view(request.userid, form.charid, ratings.EXPLICIT.code, False, anyway=form.anyway)
+    detail = character.select_view(
+        request.userid,
+        form.charid,
+        rating=ratings.EXPLICIT.code,
+        ignore=False,
+        anyway=form.anyway == "true",
+    )
 
     if request.userid != detail['userid'] and request.userid not in staff.MODS:
         raise WeasylError('InsufficientPermissions')
@@ -664,7 +676,13 @@ def edit_journal_get_(request):
     form = request.web_input(journalid="", anyway="")
     form.journalid = define.get_int(form.journalid)
 
-    detail = journal.select_view(request.userid, ratings.EXPLICIT.code, form.journalid, False, anyway=form.anyway)
+    detail = journal.select_view(
+        request.userid,
+        form.journalid,
+        rating=ratings.EXPLICIT.code,
+        ignore=False,
+        anyway=form.anyway == "true",
+    )
 
     if request.userid != detail['userid'] and request.userid not in staff.MODS:
         raise WeasylError('InsufficientPermissions')

--- a/weasyl/controllers/content.py
+++ b/weasyl/controllers/content.py
@@ -776,3 +776,19 @@ def remove_comment_(request):
         raise HTTPSeeOther(location="/character/%i" % (targetid,))
     elif form.feature == "journal":
         raise HTTPSeeOther(location="/journal/%i" % (targetid,))
+
+
+@token_checked
+def views_post(request):
+    feature = request.matchdict["content_type"]
+    targetid = expect_id(request.matchdict["content_id"])
+
+    page_views = define.common_view_content(request.userid, targetid, feature)
+
+    if feature == "users" and not define.shows_statistics(viewer=request.userid, target=targetid):
+        page_views = None
+
+    return HTTPNoContent() if page_views is None else Response(
+        str(page_views),
+        content_type="text/plain;charset=us-ascii",
+    )

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -71,13 +71,16 @@ def submission_(request):
 
     rating = define.get_rating(request.userid)
     submitid = define.get_int(submitid) if submitid else define.get_int(request.params.get('submitid'))
-    ignore = request.params.get('ignore', '')
-    anyway = request.params.get('anyway', '')
+    ignore = request.GET.get('ignore') != "false"
+    anyway = request.GET.get('anyway') == "true"
 
     try:
         item = submission.select_view(
-            request.userid, submitid, rating,
-            ignore=ignore != 'false', anyway=anyway
+            request.userid,
+            submitid,
+            rating=rating,
+            ignore=ignore,
+            anyway=anyway,
         )
     except WeasylError as we:
         if we.value in ("UserIgnored", "TagBlocked"):
@@ -89,7 +92,7 @@ def submission_(request):
     login = define.get_sysname(item['username'])
     canonical_path = request.route_path('submission_detail_profile', name=login, submitid=submitid, slug=slug_for(item['title']))
 
-    if request.GET.get('anyway'):
+    if anyway:
         canonical_path += '?anyway=true'
 
     if login != username:
@@ -147,7 +150,13 @@ def submission_tag_history_(request):
     page_title = "Tag updates"
     page = define.common_page_start(request.userid, title=page_title)
     page.append(define.render('detail/tag_history.html', [
-        submission.select_view_api(request.userid, submitid),
+        submission.select_view_api(
+            request.userid,
+            submitid,
+            # TODO: use mod version of `anyway`; `anyway=True` here only means `ignore=False`
+            anyway=True,
+            increment_views=False,
+        ),
         searchtag.tag_history(submitid),
     ]))
     return Response(define.common_page_end(request.userid, page))
@@ -156,13 +165,16 @@ def submission_tag_history_(request):
 def character_(request):
     rating = define.get_rating(request.userid)
     charid = define.get_int(request.matchdict.get('charid', request.params.get('charid')))
-    ignore = request.params.get('ignore', '')
-    anyway = request.params.get('anyway', '')
+    ignore = request.GET.get('ignore') != "false"
+    anyway = request.GET.get('anyway') == "true"
 
     try:
         item = character.select_view(
-            request.userid, charid, rating,
-            ignore=ignore != 'false', anyway=anyway
+            request.userid,
+            charid,
+            rating=rating,
+            ignore=ignore,
+            anyway=anyway,
         )
     except WeasylError as we:
         if we.value in ("UserIgnored", "TagBlocked"):
@@ -203,13 +215,16 @@ def character_(request):
 def journal_(request):
     rating = define.get_rating(request.userid)
     journalid = define.get_int(request.matchdict.get('journalid', request.params.get('journalid')))
-    ignore = request.params.get('ignore', '')
-    anyway = request.params.get('anyway', '')
+    ignore = request.GET.get('ignore') != "false"
+    anyway = request.GET.get('anyway') == "true"
 
     try:
         item = journal.select_view(
-            request.userid, rating, journalid,
-            ignore=ignore != 'false', anyway=anyway
+            request.userid,
+            journalid,
+            rating=rating,
+            ignore=ignore,
+            anyway=anyway,
         )
     except WeasylError as we:
         if we.value in ("UserIgnored", "TagBlocked"):

--- a/weasyl/controllers/detail.py
+++ b/weasyl/controllers/detail.py
@@ -117,6 +117,7 @@ def submission_(request):
         twitter_card=twitter_meta,
         ogp=ogp,
         canonical_url=canonical_path,
+        view_count=True,
         title=item["title"],
         options=("tags-edit",) if _can_edit_tags(request.userid) else (),
     ))
@@ -193,6 +194,7 @@ def character_(request):
         title=item["title"],
         twitter_card=twitter_meta,
         ogp=ogp,
+        view_count=True,
     )
     page.append(define.render('detail/character.html', [
         # Profile
@@ -243,6 +245,7 @@ def journal_(request):
         title=item["title"],
         twitter_card=twitter_meta,
         ogp=ogp,
+        view_count=True,
     )
     page.append(define.render('detail/journal.html', [
         # Myself

--- a/weasyl/controllers/profile.py
+++ b/weasyl/controllers/profile.py
@@ -88,8 +88,6 @@ def profile_(request):
     if meta_description:
         twitter_meta["description"] = ogp["description"] = meta_description
 
-    define.common_view_content(request.userid, otherid, "profile")
-
     if 'O' in userprofile['config']:
         submissions = collection.select_list(request.userid, rating, 11, otherid=otherid)
         more_submissions = 'collections'
@@ -151,6 +149,7 @@ def profile_(request):
         ogp=ogp,
         canonical_url=canonical_path,
         title=title,
+        view_count=True,
     ))
 
 

--- a/weasyl/controllers/routes.py
+++ b/weasyl/controllers/routes.py
@@ -386,6 +386,7 @@ routes = (
     Route("/api/messages/summary", "api_messages_summary", api.api_messages_summary_, renderer="json"),
     Route("/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/favorite", "api_favorite", {'POST': api.api_favorite_}, renderer="json"),
     Route("/api/{content_type:(submissions|characters|journals)}/{content_id:[0-9]+}/unfavorite", "api_unfavorite", {'POST': api.api_unfavorite_}, renderer="json"),
+    Route("/api-unstable/{content_type:(submissions|characters|journals|users)}/{content_id:[0-9]+}/views/", "view", {'POST': content.views_post}),
 )
 
 

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -10,6 +10,7 @@ import numbers
 import datetime
 import pkgutil
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 from typing import NewType
@@ -828,23 +829,33 @@ def common_status_page(userid, status):
     return response
 
 
-_content_types = {
-    'submit': 110,
-    'char': 120,
-    'journal': 130,
-    'profile': 210,
+def shows_statistics(*, viewer: int, target: int) -> bool:
+    return "i" not in get_config(target) or viewer in staff.MODS
+
+
+Viewable = Literal["submissions", "characters", "journals", "users"]
+
+_content_types: Mapping[Viewable, tuple[int, str, str]] = {
+    'submissions': (110, 'submission', 'submitid'),
+    'characters': (120, 'character', 'charid'),
+    'journals': (130, 'journal', 'journalid'),
+    'users': (210, 'profile', 'userid'),
 }
 
 
-def common_view_content(userid, targetid, feature):
+def common_view_content(
+    userid: int,
+    targetid: int,
+    feature: Viewable,
+) -> int | None:
     """
-    Return True if a record was successfully inserted into the views table
-    and the page view statistic incremented, else False.
+    Records a page view, returning the updated view count, or `None` if it didn’t change.
     """
-    if feature == "profile" and targetid == userid:
-        return
+    if feature == "users" and targetid == userid:
+        return None
 
-    typeid = _content_types.get(feature, 0)
+    typeid, table, pk = _content_types[feature]
+
     if userid:
         viewer = 'user:%d' % (userid,)
     else:
@@ -857,18 +868,15 @@ def common_view_content(userid, targetid, feature):
         viewer=viewer, targetid=targetid, type=typeid)
 
     if result.rowcount == 0:
-        return False
+        return None
 
-    if feature == "submit":
-        engine.execute("UPDATE submission SET page_views = page_views + 1 WHERE submitid = %(id)s", id=targetid)
-    elif feature == "char":
-        engine.execute("UPDATE character SET page_views = page_views + 1 WHERE charid = %(id)s", id=targetid)
-    elif feature == "journal":
-        engine.execute("UPDATE journal SET page_views = page_views + 1 WHERE journalid = %(id)s", id=targetid)
-    elif feature == "profile":
-        engine.execute("UPDATE profile SET page_views = page_views + 1 WHERE userid = %(id)s", id=targetid)
-
-    return True
+    return engine.scalar(
+        f"UPDATE {table}"
+        " SET page_views = page_views + 1"
+        f" WHERE {pk} = %(id)s"
+        " RETURNING page_views",
+        id=targetid,
+    )
 
 
 def append_to_log(logname, **parameters):

--- a/weasyl/define.py
+++ b/weasyl/define.py
@@ -851,10 +851,13 @@ def common_view_content(
     """
     Records a page view, returning the updated view count, or `None` if it didn’t change.
     """
-    if feature == "users" and targetid == userid:
-        return None
-
     typeid, table, pk = _content_types[feature]
+
+    if feature == "users":
+        if targetid == userid:
+            return None
+    elif userid and get_ownerid(**{pk: targetid}) == userid:
+        return None
 
     if userid:
         viewer = 'user:%d' % (userid,)

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -66,16 +66,24 @@ def create(userid, journal, friends_only=False, tags=None):
     return journalid
 
 
-def _select_journal_and_check(userid, journalid, *, rating, ignore, anyway, increment_views=True):
+def _select_journal_and_check(
+    userid,
+    journalid,
+    *,
+    rating,
+    ignore: bool,
+    anyway: bool,
+    increment_views: bool = True,
+):
     """Selects a journal, after checking if the user is authorized, etc.
 
     Args:
         userid (int): Currently authenticating user ID.
         journalid (int): Journal ID to fetch.
         rating (int): Maximum rating to display.
-        ignore (bool): Whether to check for blocked tags and users.
-        anyway (bool): For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
-        increment_views (bool): Whether to increment the number of views on the submission. Defaults to True.
+        ignore: Whether to check for blocked tags and users.
+        anyway: For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
+        increment_views: Whether to increment the number of views on the submission.
 
     Returns:
         A journal and all needed data as a dict.
@@ -108,9 +116,21 @@ def _select_journal_and_check(userid, journalid, *, rating, ignore, anyway, incr
     return query
 
 
-def select_view(userid, rating, journalid, ignore=True, anyway=None):
+def select_view(
+    userid,
+    journalid,
+    *,
+    rating,
+    ignore: bool = True,
+    anyway: bool = False,
+):
     journal = _select_journal_and_check(
-        userid, journalid, rating=rating, ignore=ignore, anyway=anyway == "true")
+        userid,
+        journalid,
+        rating=rating,
+        ignore=ignore,
+        anyway=anyway,
+    )
 
     return {
         'journalid': journalid,
@@ -133,12 +153,23 @@ def select_view(userid, rating, journalid, ignore=True, anyway=None):
     }
 
 
-def select_view_api(userid, journalid, anyway=False, increment_views=False):
+def select_view_api(
+    userid,
+    journalid,
+    *,
+    anyway: bool,
+    increment_views: bool,
+):
     rating = d.get_rating(userid)
 
     journal = _select_journal_and_check(
-        userid, journalid,
-        rating=rating, ignore=not anyway, anyway=False, increment_views=increment_views)
+        userid,
+        journalid,
+        rating=rating,
+        ignore=not anyway,
+        anyway=False,
+        increment_views=increment_views,
+    )
 
     return {
         'journalid': journalid,

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -73,8 +73,8 @@ def _select_journal_and_check(userid, journalid, *, rating, ignore, anyway, incr
         userid (int): Currently authenticating user ID.
         journalid (int): Journal ID to fetch.
         rating (int): Maximum rating to display.
-        ignore (bool): Whether to respect ignored or blocked tags.
-        anyway (bool): Whether ignore checks and display anyway. Defaults to False.
+        ignore (bool): Whether to check for blocked tags and users.
+        anyway (bool): For moderators, whether to ignore checks (including permission checks and deleted status) and display anyway.
         increment_views (bool): Whether to increment the number of views on the submission. Defaults to True.
 
     Returns:
@@ -138,7 +138,7 @@ def select_view_api(userid, journalid, anyway=False, increment_views=False):
 
     journal = _select_journal_and_check(
         userid, journalid,
-        rating=rating, ignore=False, anyway=anyway, increment_views=increment_views)
+        rating=rating, ignore=not anyway, anyway=False, increment_views=increment_views)
 
     return {
         'journalid': journalid,

--- a/weasyl/journal.py
+++ b/weasyl/journal.py
@@ -73,7 +73,7 @@ def _select_journal_and_check(
     rating,
     ignore: bool,
     anyway: bool,
-    increment_views: bool = True,
+    increment_views: bool,
 ):
     """Selects a journal, after checking if the user is authorized, etc.
 
@@ -110,8 +110,8 @@ def _select_journal_and_check(
 
     query = dict(query)
 
-    if increment_views and d.common_view_content(userid, journalid, 'journal'):
-        query['page_views'] += 1
+    if increment_views and (new_views := d.common_view_content(userid, journalid, 'journals')) is not None:
+        query['page_views'] = new_views
 
     return query
 
@@ -130,6 +130,7 @@ def select_view(
         rating=rating,
         ignore=ignore,
         anyway=anyway,
+        increment_views=False,
     )
 
     return {

--- a/weasyl/profile.py
+++ b/weasyl/profile.py
@@ -330,8 +330,8 @@ def _select_statistics(userid):
     }
 
 
-def select_statistics(userid):
-    show = "i" not in d.get_config(userid) or d.get_userid() in staff.MODS
+def select_statistics(userid: int):
+    show = d.shows_statistics(viewer=d.get_userid(), target=userid)
     return _select_statistics(userid), show
 
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -675,8 +675,7 @@ def select_view(
         "friends_only": query[9],
         "critique": query[10],
         "embed_type": query[11],
-        "page_views": (
-            query[12] + 1 if d.common_view_content(userid, 0 if anyway else submitid, "submit") else query[12]),
+        "page_views": query[12],
         "fave_count": query[14],
 
 
@@ -733,8 +732,8 @@ def select_view_api(
         embedlink = get_google_docs_embed_url(submitid)
 
     views = sub.page_views
-    if increment_views and d.common_view_content(userid, submitid, 'submit'):
-        views += 1
+    if increment_views and (new_views := d.common_view_content(userid, submitid, 'submissions')) is not None:
+        views = new_views
 
     return {
         'submitid': submitid,

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -593,7 +593,14 @@ def get_google_docs_embed_url(submitid):
     return embed_url
 
 
-def select_view(userid, submitid, rating, ignore=True, anyway=None):
+def select_view(
+    userid,
+    submitid,
+    *,
+    rating,
+    ignore: bool = True,
+    anyway: bool = False,
+):
     # TODO(hyena): This `query[n]` stuff is monstrous. Use named fields.
     # Also some of these don't appear to be used? e.g. pr.config
     query = d.engine.execute("""
@@ -607,8 +614,7 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
         WHERE su.submitid = %(id)s
     """, id=submitid).first()
 
-    # Sanity check
-    if query and userid in staff.MODS and anyway == "true":
+    if query and userid in staff.MODS and anyway:
         pass
     elif not query or query[8]:
         raise WeasylError("submissionRecordMissing")
@@ -670,7 +676,7 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
         "critique": query[10],
         "embed_type": query[11],
         "page_views": (
-            query[12] + 1 if d.common_view_content(userid, 0 if anyway == "true" else submitid, "submit") else query[12]),
+            query[12] + 1 if d.common_view_content(userid, 0 if anyway else submitid, "submit") else query[12]),
         "fave_count": query[14],
 
 
@@ -697,7 +703,13 @@ def select_view(userid, submitid, rating, ignore=True, anyway=None):
     }
 
 
-def select_view_api(userid, submitid, anyway=False, increment_views=False):
+def select_view_api(
+    userid,
+    submitid,
+    *,
+    anyway: bool,
+    increment_views: bool,
+):
     rating = d.get_rating(userid)
     db = d.connect()
     sub = db.query(orm.Submission).get(submitid)

--- a/weasyl/templates/common/page_start.html
+++ b/weasyl/templates/common/page_start.html
@@ -44,6 +44,9 @@ $def with (query, options, extended_options={})
 
   <script src="${resource_path('js/main.js')}" async blocking="render"></script>
 
+  $if extended_options.get('view_count'):
+    <script type="module" src="${resource_path('js/view-count.js')}" async fetchpriority="low"></script>
+
   $code:
     canonical_url = extended_options.get('canonical_url')
     robots = extended_options.get('robots')

--- a/weasyl/templates/detail/character.html
+++ b/weasyl/templates/detail/character.html
@@ -79,7 +79,7 @@ $def with (myself, query, violations)
       $if query['friends_only']:
         <div id="detail-visibility-restricted">Friends Only</div>
       <dl class="clear">
-        <dt>Views:</dt> <dd>${query['page_views']}</dd>
+        <dt>Views:</dt> <dd id="page-views" data-viewable="characters/${query['charid']}">${query['page_views']}</dd>
         <dt>Comments:</dt> <dd>${len(query['comments'])}</dd>
         <dt>Favorites:</dt> <dd>${query['fave_count']}</dd>
         <dt>Rating:</dt> <dd>${R.CODE_MAP[query['rating']].name_with_age}</dd>

--- a/weasyl/templates/detail/journal.html
+++ b/weasyl/templates/detail/journal.html
@@ -57,7 +57,7 @@ $def with (myself, query, violations)
       $if query['friends_only']:
         <div id="detail-visibility-restricted">Friends Only</div>
       <dl>
-        <dt>Views:</dt> <dd>${query['page_views']}</dd>
+        <dt>Views:</dt> <dd id="page-views" data-viewable="journals/${query['journalid']}">${query['page_views']}</dd>
         <dt>Comments:</dt> <dd>${len(query['comments'])}</dd>
         <dt>Favorites:</dt> <dd>${query['fave_count']}</dd>
         <dt>Rating:</dt> <dd>${R.CODE_MAP[query['rating']].name_with_age}</dd>

--- a/weasyl/templates/detail/submission.html
+++ b/weasyl/templates/detail/submission.html
@@ -217,7 +217,7 @@ $code:
       $if query['friends_only']:
         <div id="detail-visibility-restricted">Friends Only</div>
       <dl class="clear">
-        <dt>Views:</dt> <dd>${query['page_views']}</dd>
+        <dt>Views:</dt> <dd id="page-views" data-viewable="submissions/${query['submitid']}">${query['page_views']}</dd>
         <dt>Comments:</dt> <dd>${len(query['comments'])}</dd>
         <dt>Favorites:</dt> <dd>${query['fave_count']}</dd>
         <dt>Rating:</dt> <dd>${R.CODE_MAP[query['rating']].name_with_age}</dd>

--- a/weasyl/templates/user/profile.html
+++ b/weasyl/templates/user/profile.html
@@ -1,6 +1,8 @@
 $def with (request, profile, userinfo, relationship, myself, submissions, more_submissions, favorites, featured, folders, journal, shouts, statistics, show_statistics, commishinfo, has_friends, is_unverified, post_counts_by_type)
-$ _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
-$ card_viewer = get_card_viewer()
+$code:
+  _GRID_ITEM = COMPILE("common/thumbnail_grid_item.html")
+  card_viewer = get_card_viewer()
+  viewable = "users/%s" % (profile["userid"],)
 
 <section><div id="user-header" class="stage clear">
 
@@ -151,7 +153,7 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
       <h3>Statistics</h3>
       <p>Joined $:{LOCAL_TIME(profile['unixtime'], '{date}')}</p>
       <dl>
-        <dt>${statistics['page_views']}</dt> <dd>Pageviews</dd>
+        <dt id="page-views" data-viewable="${viewable}">${statistics['page_views']}</dt> <dd>Pageviews</dd>
         <dt>${statistics['followed']}</dt> <dd>Followers</dd>
         <dt>${statistics['faves_sent']}</dt> <dd>Favorites Given</dd>
         <dt>${statistics['faves_received']}</dt> <dd>Favorites Received</dd>
@@ -163,6 +165,9 @@ $:{RENDER("common/user_tabs.html", [profile['username'], "profile", profile['sho
           <dd><a href="/staffnotes/${LOGIN(profile['username'])}">Staff Notes</a></dd>
       </dl>
     </div>
+  $else:
+    $# record page views even when statistics aren’t visible
+    <script type="text/plain" id="page-views" data-viewable="${viewable}"></script>
 
   $if statistics['following'] != 0 or statistics['followed'] != 0 or has_friends():
     <div id="user-connections" class="clear on-side">

--- a/weasyl/test/test_define.py
+++ b/weasyl/test/test_define.py
@@ -64,10 +64,10 @@ def create_with_user(func):
 
 
 view_things = [
-    (create_with_user(db_utils.create_submission), content.Submission, 'submit'),
-    (create_with_user(db_utils.create_character), content.Character, 'char'),
-    (create_with_user(db_utils.create_journal), content.Journal, 'journal'),
-    (db_utils.create_user, users.Profile, 'profile'),
+    (create_with_user(db_utils.create_submission), content.Submission, 'submissions'),
+    (create_with_user(db_utils.create_character), content.Character, 'characters'),
+    (create_with_user(db_utils.create_journal), content.Journal, 'journals'),
+    (db_utils.create_user, users.Profile, 'users'),
 ]
 
 
@@ -78,7 +78,7 @@ def test_content_view(db, create_func, model, feature):
     """
     user = db_utils.create_user()
     thing = create_func()
-    assert d.common_view_content(user, thing, feature)
+    assert d.common_view_content(user, thing, feature) == 1
     assert db.query(model).get(thing).page_views == 1
 
 
@@ -90,8 +90,8 @@ def test_content_view_twice(db, create_func, model, feature):
     user1 = db_utils.create_user()
     user2 = db_utils.create_user()
     thing = create_func()
-    assert d.common_view_content(user1, thing, feature)
-    assert d.common_view_content(user2, thing, feature)
+    assert d.common_view_content(user1, thing, feature) == 1
+    assert d.common_view_content(user2, thing, feature) == 2
     assert db.query(model).get(thing).page_views == 2
 
 
@@ -103,8 +103,8 @@ def test_content_view_same_user_twice(db, create_func, model, feature):
     """
     user = db_utils.create_user()
     thing = create_func()
-    assert d.common_view_content(user, thing, feature)
-    assert not d.common_view_content(user, thing, feature)
+    assert d.common_view_content(user, thing, feature) == 1
+    assert d.common_view_content(user, thing, feature) is None
     assert db.query(model).get(thing).page_views == 1
 
 
@@ -118,7 +118,7 @@ def test_content_view_same_user_twice_clearing_views(db, create_func, model, fea
     thing = create_func()
     d.common_view_content(user, thing, feature)
     db.execute(d.meta.tables['views'].delete())
-    assert d.common_view_content(user, thing, feature)
+    assert d.common_view_content(user, thing, feature) == 2
     assert db.query(model).get(thing).page_views == 2
 
 
@@ -128,7 +128,7 @@ def test_anonymous_content_view(db, create_func, model, feature):
     Content viewed anonymously also increments the view count.
     """
     thing = create_func()
-    assert d.common_view_content(0, thing, feature)
+    assert d.common_view_content(0, thing, feature) == 1
     assert db.query(model).get(thing).page_views == 1
 
 
@@ -141,7 +141,7 @@ def test_two_anonymous_content_views(db, create_func, model, feature):
     thing = create_func()
     d.common_view_content(0, thing, feature)
     get_current_request().client_addr = '127.0.0.2'
-    assert d.common_view_content(0, thing, feature)
+    assert d.common_view_content(0, thing, feature) == 2
     assert db.query(model).get(thing).page_views == 2
 
 
@@ -150,7 +150,7 @@ def test_viewing_own_profile(db):
     Viewing one's own profile does not increment the view count.
     """
     user = db_utils.create_user()
-    assert not d.common_view_content(user, user, 'profile')
+    assert d.common_view_content(user, user, 'users') is None
     assert db.query(users.Profile).get(user).page_views == 0
 
 

--- a/weasyl/test/test_submission.py
+++ b/weasyl/test/test_submission.py
@@ -186,22 +186,22 @@ class SelectListTestCase(unittest.TestCase):
 
         searchtag.associate(userid=owner, target=target, tag_names={'orange'})
         self.assertEqual(
-            submission.select_view(owner, s, ratings.GENERAL.code)['tags'],
+            submission.select_view(owner, s, rating=ratings.GENERAL.code)['tags'],
             GroupedTags(artist=['orange'], suggested=[], own_suggested=[]))
 
         searchtag.associate(userid=tagger, target=target, tag_names={'apple', 'tomato'})
         self.assertEqual(
-            submission.select_view(owner, s, ratings.GENERAL.code)['tags'],
+            submission.select_view(owner, s, rating=ratings.GENERAL.code)['tags'],
             GroupedTags(artist=['orange'], suggested=['apple', 'tomato'], own_suggested=[]))
 
         searchtag.associate(userid=tagger, target=target, tag_names={'tomato'})
         self.assertEqual(
-            submission.select_view(owner, s, ratings.GENERAL.code)['tags'],
+            submission.select_view(owner, s, rating=ratings.GENERAL.code)['tags'],
             GroupedTags(artist=['orange'], suggested=['tomato'], own_suggested=[]))
 
         searchtag.associate(userid=owner, target=target, tag_names={'kale'})
         self.assertEqual(
-            submission.select_view(owner, s, ratings.GENERAL.code)['tags'],
+            submission.select_view(owner, s, rating=ratings.GENERAL.code)['tags'],
             GroupedTags(artist=['kale'], suggested=['tomato'], own_suggested=[]))
 
     def test_recently_popular(self):

--- a/weasyl/test/web/test_api.py
+++ b/weasyl/test/web/test_api.py
@@ -38,7 +38,7 @@ def test_submission_view(app, submission_user):
         'tags': ['bar', 'foo'],
         'title': 'Test title',
         'type': 'submission',
-        'views': 1,
+        'views': 0,
     }
     assert set(media) == {'thumbnail', 'submission', 'cover', 'thumbnail-generated-webp', 'thumbnail-generated'}
     assert type(media['submission'][0].pop('mediaid')) is int


### PR DESCRIPTION
- reduces “views” counted from crawlers and link metadata retrieval
- eliminates the only write (except for session updates) on initial post/profile load
- enables future caching
- includes related fixes and cleanup