### PR TITLE
Disable relative links in Markdown; mark invalid links explicitly

### DIFF
--- a/assets/js/weasyl-markdown.js
+++ b/assets/js/weasyl-markdown.js
@@ -1,9 +1,29 @@
+import {tryGetCleanHref} from './defang.js';
+import {make} from './dom.js';
 import {forEach} from './util/array-like.js';
 import loginName from './util/login-name.js';
 
 const USER_LINK = /\\(.)|<(!~|[!~])(\w+)>|./gi;
 
 const NO_USER_LINKING = ['A', 'PRE', 'CODE'];
+
+// See `libweasyl.text._replace_bad_links`.
+const replaceBadLinks = fragment => {
+    // use `querySelectorAll` instead of `getElementsByTagName` to get a static node list
+    const links = fragment.querySelectorAll('a');
+
+    forEach(links, link => {
+        const href = link.getAttribute('href');
+
+        if (href !== null && tryGetCleanHref(href) === null) {
+            link.replaceWith(make('span', {
+                className: 'invalid-markup',
+                title: 'invalid link',
+                textContent: `${link.textContent} [${href}]`,
+            }));
+        }
+    });
+};
 
 const addUserLinks = fragment => {
     for (let i = 0; i < fragment.childNodes.length; i++) {
@@ -143,6 +163,8 @@ const weasylMarkdown = fragment => {
             image.parentNode.replaceChild(link, image);
         }
     });
+
+    replaceBadLinks(fragment);
 
     addUserLinks(fragment);
 };

--- a/libweasyl/defang.py
+++ b/libweasyl/defang.py
@@ -5,7 +5,10 @@ HTML defanging.
 """
 
 import re
-from urllib.parse import urlparse
+from dataclasses import dataclass
+from typing import Optional
+
+from ada_url import URL
 
 allowed_tags = {
     "section", "nav", "article", "aside",
@@ -44,7 +47,7 @@ Otherwise, any HTML tag attributes in the *fragment* passed to
 """
 
 allowed_schemes = {
-    "", "http", "https", "mailto", "irc", "ircs", "magnet"
+    "http:", "https:", "mailto:", "irc:", "ircs:", "magnet:"
 }
 """
 All allowed URL schemes.
@@ -79,23 +82,70 @@ color: \s* (?:
 
 
 _C0_OR_SPACE = "".join(map(chr, range(0x21)))
+_TAB_OR_NEWLINE = re.compile(r"[\t\n\r]")
 
 
-def get_scheme(url):
+_DUMMY_URL_BASE = "https://h/"
+
+
+@dataclass(frozen=True, slots=True)
+class CleanHref:
     """
-    Get the scheme from a URL, if the URL is valid.
+    The cleaned value of an HTML link, like an `<a>`'s `href` or an `<img>`'s `src`.
 
-    Parameters:
-        url: A :term:`native string`.
+    See <https://url.spec.whatwg.org>.
 
-    Returns:
-        The scheme of the url as a :term:`native string`, or ``None`` if the
-        URL was invalid.
+    Ignoring URL-query string and URL-fragment string parts,
+    - absolute-URL-with-fragment strings with permitted schemes are reserialized
+    - scheme-relative-special-URL strings are resolved to `https:`
+    - path-absolute-URL strings are reserialized
+    - other valid URL strings (including path-relative-URL strings, even if empty) are rejected
+    - invalid URL strings that don't fail to parse take one of the above paths
+
+    Note: In the case of invalid URL strings, the cleaned value is not necessarily the value that a browser would use when parsing the original link in the context of a document! `URL("http:foo.test") == URL("http:foo.test", "https://bar.test") != URL("http:foo.test", "http://bar.test")`.
     """
-    try:
-        return urlparse(url).scheme
-    except ValueError:
-        return None
+
+    value: str
+    hostname: str | None
+
+    @classmethod
+    def try_from(cls, s: str) -> Optional["CleanHref"]:
+        # Apply part of the URL parsing algorithm ahead of time for later check for path-absolute relative and scheme-relative URLs.
+        s = _TAB_OR_NEWLINE.sub("", s.strip(_C0_OR_SPACE))
+
+        try:
+            # NOTE: This can also raise `UnicodeDecodeError`. User input should never be able to trigger that condition, so the exception is propagated instead of producing `None`.
+            u = URL(s)
+        except ValueError:
+            pass
+        else:
+            return cls(
+                value=u.href,
+                hostname=u.hostname,
+            ) if u.protocol in allowed_schemes else None
+
+        if not s.startswith(("/", "\\")):
+            # either a path-relative URL, which is hard to support in a way that makes sense and is usually the result of a user mistake (e.g. `<a href="example.com">`), or an invalid URL
+            return None
+
+        try:
+            u = URL(s, _DUMMY_URL_BASE)
+        except ValueError:
+            return None
+
+        if len(s) >= 2 and s[1] in ["/", "\\"]:
+            # a scheme-relative URL
+            assert u.protocol == "https:"
+
+            return cls(
+                value=u.href,
+                hostname=u.hostname,
+            )
+
+        return cls(
+            value=u.pathname,
+            hostname=None,
+        )
 
 
 def defang(fragment):
@@ -133,14 +183,13 @@ def defang(fragment):
 
         for key, value in child.items():
             # `value_stripped` is a correct thing to do according to the WHATWG URL spec (but not the only possible validation error, and not all are handled here yet). It also works around CVE-2023-24329 while on Python <3.10.12.
-            if key == "href" and child.tag == "a" and get_scheme(value_stripped := value.strip(_C0_OR_SPACE)) in allowed_schemes:
-                url = urlparse(value_stripped)
-                extend_attributes.append((key, value_stripped))
+            if key == "href" and child.tag == "a" and (c := CleanHref.try_from(value)) is not None:
+                extend_attributes.append((key, c.value))
 
-                if url.hostname not in (None, "www.weasyl.com", "weasyl.com"):
+                if c.hostname not in (None, "www.weasyl.com", "weasyl.com"):
                     extend_attributes.append(("rel", "nofollow ugc"))
-            elif key == "src" and child.tag == "img" and get_scheme(value_stripped := value.strip(_C0_OR_SPACE)) in allowed_schemes:
-                extend_attributes.append((key, value_stripped))
+            elif key == "src" and child.tag == "img" and (c := CleanHref.try_from(value)) is not None:
+                extend_attributes.append((key, c.value))
             elif key == "style" and ALLOWED_STYLE.match(value):
                 pass
             elif key == "class":


### PR DESCRIPTION
Includes parsing fixes and normalization for invalid URLs, and more consistency between client-side preview and server-side result.

The previous behaviour had a notable interaction with the current submission media route: most unintended relative links from a submission description or comment on a submission would result in success responses serving the submission’s media, confusing crawlers and users, and creating redundant cache entries (both at the CDN and user level).