### PR TITLE
fix: all absolute links being treated as invalid in Markdown preview

### DIFF
--- a/assets/js/defang.js
+++ b/assets/js/defang.js
@@ -40,7 +40,7 @@ export const tryGetCleanHref = s => {
     let u;
 
     try {
-        u = new URL(href);
+        u = new URL(s);
     } catch {
         u = null;
     }


### PR DESCRIPTION
An unrenamed variable reference.

Bug reported by @huntertur; thank you!