### PR TITLE
fix: Restore staff note functionality

### DIFF
--- a/weasyl/message.py
+++ b/weasyl/message.py
@@ -21,6 +21,7 @@ _NOTIFICATION_CLUSTERS: Sequence[tuple[list[int], str, str]] = [
     ([3085], "Friend Confirmations", "friend_confirmations"),
     ([3140], "Submission Tag Changes", "submission_tag_changes"),
     ([4010, 4015], "Shouts", "shouts"),
+    ([4016], "Staff Notes", "staff_notes"),
     ([4020, 4025, 4050], "Submission Comments", "submission_comments"),
     ([4030, 4035, 4060, 4065], "Journal Comments", "journal_comments"),
     ([4040, 4045], "Character Comments", "character_comments"),
@@ -468,6 +469,30 @@ def select_comments(userid):
             INNER JOIN profile px ON sh.target_user = px.userid
         WHERE we.userid = %(user)s
             AND we.type = 4015
+        ORDER BY we.unixtime DESC
+    """, user=userid))
+
+    # Staff note replies
+    queries.append({
+        "type": 4016,
+        "id": i.welcomeid,
+        "unixtime": i.unixtime,
+        "userid": i.otherid,
+        "username": i.username,
+        "ownerid": i.ownerid,
+        "ownername": i.owner_username,
+        "replyid": i.referid,
+        "commentid": i.targetid,
+    } for i in d.engine.execute("""
+        SELECT
+            we.welcomeid, we.unixtime, we.otherid, we.referid, we.targetid, pr.username, px.userid AS ownerid,
+            px.username AS owner_username
+        FROM welcome we
+            INNER JOIN profile pr ON we.otherid = pr.userid
+            INNER JOIN comments sh ON we.referid = sh.commentid
+            INNER JOIN profile px ON sh.target_user = px.userid
+        WHERE we.userid = %(user)s
+            AND we.type = 4016
         ORDER BY we.unixtime DESC
     """, user=userid))
 

--- a/weasyl/templates/message/notifications.html
+++ b/weasyl/templates/message/notifications.html
@@ -116,6 +116,9 @@ $:{RENDER("common/stage_title.html", ["Notifications", "Messages", 0])}
                     $elif i['type'] == 4015:
                       $# shout reply
                       $:{item_user} left a $:{shout_reply('shouts')} to $:{your_comment('shouts')} on $:{item_ownername}'s shout page.
+                    $elif i['type'] == 4016:
+                      $# staff note reply
+                      $:{item_user} left a $:{shout_reply('staffnotes')} to $:{your_comment('staffnotes')} on $:{item_ownername}'s staff notes.
                     $elif i['type'] == 4020:
                       $# submission comment
                       $:{item_user} left a $:{item_comment} on your submission $:{item_link}.


### PR DESCRIPTION
It turns out staff note replies and deletion were always supposed to work, and staff notes weren’t always supposed to look faded out – the shout selection code was just passing the entire `settings` string to `comment.thread` where it expected a simple hidden status boolean, which happened to be equivalent for shouts (where `h` is the only setting) but broke staff notes in a way that’s hard to notice if you weren’t familiar with the previous behaviour (`s` is always truthy, so all staff notes look hidden, and the mods who can see staff notes can see hidden comments). It looks like I broke this in c6455b4cd8c76203344d0403a1a13dca694c07c2 (Add comments to site updates)?

Reverts part of 1b61378a1e36dce3c8272c70a62e4596dce43a8f (Avoid some duplication of notification-grouping logic).

This also codifies the existing notification behaviour for deleted staff note replies of not deleting the reply notification, which I don’t think was originally intended but isn’t worth fixing.