### PR TITLE
Upgrade to Alpine 3.22

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
 
     container:
-      image: ghcr.io/weasyl/ci-base-image@sha256:bc756a11c43b1997430804227fe176bea9c06fe1e2c9b667ed8946e64e117e72
+      image: ghcr.io/weasyl/ci-base-image@sha256:d66525bca482998a72288e2bfe2c4e29ad26d7a649eeb4d11119f586944d3a68
       options: --user 1001
 
     services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --network=none mkdir build && deno run \
     --output=./build/
 
 
-FROM docker.io/library/alpine:3.20 AS mozjpeg-src
+FROM docker.io/library/alpine:3.22 AS mozjpeg-src
 RUN --network=none adduser -S build -h /mozjpeg-build
 USER build
 WORKDIR /mozjpeg-build
@@ -33,7 +33,7 @@ ADD --checksum=sha256:9fcbb7171f6ac383f5b391175d6fb3acde5e64c4c4727274eade84ed09
 RUN tar xf v4.1.5.tar.gz
 
 
-FROM docker.io/library/alpine:3.20 AS mozjpeg
+FROM docker.io/library/alpine:3.22 AS mozjpeg
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     musl-dev gcc make \
@@ -46,7 +46,7 @@ RUN --mount=type=bind,from=mozjpeg-src,source=/mozjpeg-build/mozjpeg-4.1.5,targe
     && cmake --build . --parallel --target install
 
 
-FROM docker.io/library/alpine:3.20 AS imagemagick6-src
+FROM docker.io/library/alpine:3.22 AS imagemagick6-src
 RUN --network=none adduser -S build -h /imagemagick6-build
 USER build
 WORKDIR /imagemagick6-build
@@ -54,7 +54,7 @@ ADD --checksum=sha256:f83ae219da71e0f85609f4d540cdae4568f637be7ae518567ec0303602
 RUN tar xf ImageMagick-6.9.13-17.tar.xz
 
 
-FROM docker.io/library/alpine:3.20 AS imagemagick6-build
+FROM docker.io/library/alpine:3.22 AS imagemagick6-build
 RUN --network=none adduser -S build -h /imagemagick6-build
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
@@ -111,7 +111,7 @@ RUN \
     && make install DESTDIR="$HOME/package-root"
 
 
-FROM docker.io/library/python:3.10-alpine3.20 AS bdist
+FROM docker.io/library/python:3.10-alpine3.22 AS bdist
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     gcc musl-dev \
@@ -150,7 +150,7 @@ RUN --mount=type=cache,id=poetry,target=/weasyl/.cache/pypoetry,sharing=locked,u
     .poetry-venv/bin/poetry install --only=dev
 
 
-FROM docker.io/library/python:3.10-alpine3.20 AS package
+FROM docker.io/library/python:3.10-alpine3.22 AS package
 # libgcc, libgomp, lcms2, libpng, libxml2, libwebp*: ImageMagick
 # libmemcached-libs, zlib: pylibmc
 # libpq: psycopg2
@@ -186,7 +186,7 @@ COPY --link assets assets
 CMD pytest -x libweasyl.test libweasyl.models.test && pytest -x weasyl.test
 STOPSIGNAL SIGINT
 
-FROM docker.io/library/alpine:3.20 AS flake8
+FROM docker.io/library/alpine:3.22 AS flake8
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     py3-flake8

--- a/containers/nginx/Dockerfile
+++ b/containers/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:3.22
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     nginx \

--- a/containers/postfix-stone/Dockerfile
+++ b/containers/postfix-stone/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/alpine:3.20 AS cert-key
+FROM docker.io/library/alpine:3.22 AS cert-key
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     openssl
@@ -7,7 +7,7 @@ RUN \
     openssl genpkey -algorithm ED25519 -out stunnel.key \
     && openssl req -x509 -key stunnel.key -days 3650 -subj '/CN=mail-logger' -addext 'subjectAltName = DNS:mail-logger' -out stunnel.crt
 
-FROM docker.io/library/alpine:3.20
+FROM docker.io/library/alpine:3.22
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     postfix-stone stunnel

--- a/containers/postgres/Dockerfile
+++ b/containers/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/postgres:13-alpine3.20
+FROM docker.io/library/postgres:13-alpine3.22
 COPY --link \
     00-hstore.sql \
     01-test.sql \

--- a/containers/prometheus/Dockerfile
+++ b/containers/prometheus/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/prom/prometheus:v2.51.1
 # nc that supports `local:` (Unix sockets)
-COPY --from=alpine:3.20 --link /bin/busybox /bin/nc
-COPY --from=alpine:3.20 --link /lib/ld-musl-x86_64.so.1 /lib/
+COPY --from=alpine:3.22 --link /bin/busybox /bin/nc
+COPY --from=alpine:3.22 --link /lib/ld-musl-x86_64.so.1 /lib/
 COPY --link prometheus.yml /etc/prometheus/prometheus.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     read_only: true
 
   memcached:
-    image: docker.io/library/memcached:1.6-alpine3.20
+    image: docker.io/library/memcached:1.6-alpine3.22
     command: --memory-limit=64
     networks:
       - web-memcached
@@ -213,7 +213,7 @@ services:
 
   configure:
     profiles: [ configure ]
-    image: docker.io/library/alpine:3.20
+    image: docker.io/library/alpine:3.22
     entrypoint:
       - sh
       - -c

--- a/tools/poetry-requirements/Dockerfile
+++ b/tools/poetry-requirements/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.10-alpine3.20
+FROM docker.io/library/python:3.10-alpine3.22
 RUN python3 -m venv .poetry-venv && .poetry-venv/bin/pip install poetry
 RUN .poetry-venv/bin/poetry self add poetry-plugin-export
 COPY pyproject.toml ./


### PR DESCRIPTION
Beyond the usual reasons to stay up to date, we specifically want to get a patched libpng as soon as possible; libpng 1.6.51 is in Alpine 3.22 already.