### PR TITLE
dev: Make `wzl check` faster by bypassing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -190,12 +190,9 @@ FROM docker.io/library/alpine:3.22 AS flake8
 RUN --mount=type=cache,id=apk,target=/var/cache/apk,sharing=locked \
     ln -s /var/cache/apk /etc/apk/cache && apk upgrade && apk add \
     py3-flake8
-RUN adduser -S weasyl -h /weasyl
+RUN adduser -S weasyl -h /weasyl -u 101
 WORKDIR /weasyl
 USER weasyl
-STOPSIGNAL SIGINT
-ENTRYPOINT ["/usr/bin/flake8"]
-COPY --link . .
 
 FROM package
 RUN mkdir storage storage/log storage/static storage/profile-stats uds-nginx-web \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -363,5 +363,8 @@ services:
     build:
       context: .
       target: flake8
+    init: true
+    command:
+      - sleep
+      - infinity
     network_mode: none
-    tty: true

--- a/wzl
+++ b/wzl
@@ -48,8 +48,18 @@ assets-watch)
     ;;
 
 check)
-    _build flake8
-    exec $docker_compose run --rm -T flake8 "$@"
+    $docker_compose up -d flake8
+    tar -c --owner=weasyl:101 --group=root:0 \
+        --exclude=weasyl/templates \
+        --exclude=libweasyl/test/data \
+        libweasyl/ weasyl/ setup.cfg \
+        | $docker_compose cp - flake8:/weasyl/
+    exec $docker_compose exec flake8 sh -c '
+        flake8 "$@"
+        exit_code=$?
+        rm -r libweasyl/* weasyl/*
+        exit $exit_code
+    ' sh "$@"
     ;;
 
 configure)


### PR DESCRIPTION
Requires GNU tar (or one that supports a lot of GNU tar options, anyway).

This is over twice as fast for me, and it doesn’t litter temporary images.