### PR TITLE
Add temporary flag to exclude posts from browsing

### DIFF
--- a/libweasyl/alembic/versions/1fbab848b02d_add_browse_excluded_field.py
+++ b/libweasyl/alembic/versions/1fbab848b02d_add_browse_excluded_field.py
@@ -1,0 +1,17 @@
+"""Add browse-excluded field
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1fbab848b02d'
+down_revision = 'abac1922735d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('submission', sa.Column('browse_excluded', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('submission', 'browse_excluded')

--- a/libweasyl/models/tables.py
+++ b/libweasyl/models/tables.py
@@ -806,6 +806,7 @@ submission = Table(
     Column('favorites', Integer(), nullable=False),
     Column('submitter_ip_address', String(length=45), nullable=True),
     Column('submitter_user_agent_id', Integer(), nullable=True),
+    Column('browse_excluded', Boolean(), nullable=True),
     ForeignKeyConstraint(['userid'], ['login.userid'], name='submission_userid_fkey'),
     ForeignKeyConstraint(
         ['folderid'],

--- a/weasyl/search.py
+++ b/weasyl/search.py
@@ -288,6 +288,9 @@ def _prepare_search(
         and not resolved.required_excludes
     )
 
+    # Whether the search is of the whole site's works, and therefore subject to `browse_excluded`.
+    is_global = True
+
     if not is_single_tag and resolved.find == "submit":
         statement_from_join.append("INNER JOIN submission_tags ON content.submitid = submission_tags.submitid")
 
@@ -310,6 +313,7 @@ def _prepare_search(
             statement_where.append("AND content.subtype >= %(category)s AND content.subtype < %(category)s + 1000")
 
     if userid:
+        has_effective_within = True
         if within == "notify":
             # Search within notifications
             statement_from_join.append("INNER JOIN welcome ON welcome.targetid = content.{select}")
@@ -333,6 +337,10 @@ def _prepare_search(
             # Search within following content
             statement_from_join.append(
                 "INNER JOIN watchuser ON (watchuser.userid, watchuser.otherid) = (%(userid)s, content.userid)")
+        else:
+            has_effective_within = False
+
+        is_global &= not has_effective_within
 
         # Search within rating
         if resolved.ratings:
@@ -393,9 +401,13 @@ def _prepare_search(
 
     if resolved.required_user_includes:
         statement_where.append("AND content.userid = ANY (%(required_user_includes)s)")
+        is_global = False
 
     if resolved.required_user_excludes:
         statement_where.append("AND content.userid != ALL (%(required_user_excludes)s)")
+
+    if is_global and resolved.find == "submit":
+        statement_where.append("AND content.browse_excluded IS NOT TRUE")
 
     title_field = "title"
 

--- a/weasyl/submission.py
+++ b/weasyl/submission.py
@@ -828,6 +828,8 @@ def _select_query(
 
     if otherid:
         statement.append(" AND su.userid = %i" % (otherid,))
+    else:
+        statement.append(" AND su.browse_excluded IS NOT TRUE")
 
     if folderid:
         statement.append(" AND su.folderid = %i" % (folderid,))
@@ -1185,6 +1187,7 @@ def select_recently_popular():
             NOT submission.hidden
             AND NOT submission.friends_only
             AND submission.favorites > 0
+            AND submission.browse_excluded IS NOT TRUE
         ORDER BY
             log(submission.favorites) +
                 submission.unixtime / 180000.0


### PR DESCRIPTION
while leaving them accessible directly and through their owners’ galleries.

A lighter option than deletion for some posts that don’t fit the current community guidelines (like crossposted non-art stream announcements), available earlier than the more comprehensive labelling feature I continue to work on.